### PR TITLE
Ensure "Create Mission" and "Create Event" buttons appear immediately after login

### DIFF
--- a/src/app/LoginPanel.tsx
+++ b/src/app/LoginPanel.tsx
@@ -5,6 +5,8 @@ import { CredentialResponse, GoogleLogin, GoogleOAuthProvider } from '@react-oau
 import Api from '@respond/lib/api';
 import { useAppDispatch, useAppSelector } from '@respond/lib/client/store';
 import { AuthActions } from '@respond/lib/client/store/auth';
+import { OrgActions } from '@respond/lib/client/store/organization'
+import { AuthResponse } from '@respond/types/authResponse'
 
 export default function LoginPanel() {
   const { noExternalNetwork } = useAppSelector(state => state.config.dev );
@@ -22,11 +24,12 @@ export default function LoginPanel() {
   }
   
   async function finishLogin(token: string) {
-    const res = await Api.post<any>('/api/auth/google', { token });
-    localStorage.userAuth = JSON.stringify(res);
+    const res = await Api.post<any>('/api/auth/google', { token }) as AuthResponse;
+    localStorage.userAuth = JSON.stringify(res.userInfo);
   
     console.log('login response', res);
-    dispatch(AuthActions.set({ userInfo: res }));
+    dispatch(AuthActions.set({ userInfo: res.userInfo }));
+    dispatch(OrgActions.set({ mine: res.organization }))
     return res;
   }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,7 +36,7 @@ export default async function RootLayout({
   };
 
   const user = userFromAuth(await getCookieAuth());
-  const myOrg = org ? {
+  const myOrg = (user && org) ? {
     id: org.id,
     rosterName: org.rosterName,
     mouName: org.mouName,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,7 +36,7 @@ export default async function RootLayout({
   };
 
   const user = userFromAuth(await getCookieAuth());
-  const myOrg = (user && org) ? {
+  const myOrg = org ? {
     id: org.id,
     rosterName: org.rosterName,
     mouName: org.mouName,

--- a/src/lib/client/store/organization.ts
+++ b/src/lib/client/store/organization.ts
@@ -2,6 +2,7 @@ import { createSelector, createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { MyOrganization } from '@respond/types/organization';
 import merge from 'lodash.merge';
 import { RootState } from '.';
+import { logoutUser } from './auth'
 
 export interface OrganizationState {
   mine?: MyOrganization;
@@ -20,6 +21,12 @@ const slice = createSlice({
       Object.assign(state, action.payload);
     }
   },
+  extraReducers: (builder) => {
+    builder
+  .addCase(logoutUser.fulfilled, state => {
+    state.mine = undefined
+  });
+}
 });
 
 export default slice.reducer;

--- a/src/pages/api/auth/google.ts
+++ b/src/pages/api/auth/google.ts
@@ -6,6 +6,7 @@ import * as Mongo from '@respond/lib/server/mongodb';
 import * as Auth from '@respond/lib/server/auth';
 import { MemberProvider } from '@respond/lib/server/memberProviders/memberProvider';
 import { TokenPayload } from 'google-auth-library';
+import { AuthResponse } from '@respond/types/authResponse'
 
 async function apiLogin(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
@@ -78,7 +79,14 @@ async function apiLogin(req: NextApiRequest, res: NextApiResponse) {
 
     console.log(`Logging in user ${payload.email}`);
     await req.session.save();
-    res.json(Auth.userFromAuth(req.session.auth));
+
+    const userInfo = Auth.userFromAuth(req.session.auth)
+    const responseBody: AuthResponse = {
+      userInfo,
+      organization: userInfo ? organization : undefined
+    }
+
+    res.json(responseBody);
   } catch (error) {
     res.status(500).json({message: (error as Error).message });
   }

--- a/src/types/authResponse.ts
+++ b/src/types/authResponse.ts
@@ -1,0 +1,7 @@
+import { MyOrganization } from './organization'
+import { UserInfo } from './userInfo'
+
+export interface AuthResponse {
+    userInfo: UserInfo | undefined
+    organization: MyOrganization | undefined
+}


### PR DESCRIPTION
The "Create Mission" and "Create Event" buttons were not showing up immediately after logging in. Refreshing the page via the browser resulted in them showing up.

Root caused this to the fact the organization data, which dictates whether those buttons are allowed to show, is exclusively calculated server-side (never recalculated client-side) _and_ is only sent to the client if there's already a valid user.

Looking through the code and database structure I saw no dependency between org and user data. Thus, I opted to fix this bug by always sending the org data to client rather than just when there's a user.

If that gating needs to remain for reasons I didn't see, I'm happy to explore other options. Most likely will mean making an API call to the server to get the org data after the user is logged in, and clearing that data on logout.