### PR TITLE
Complete/Reactivate Activities

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -12,14 +12,32 @@ import { Activity, ResponderStatus } from '@respond/types/activity';
 import { ActivityActions } from '@respond/lib/state';
 import { MyActivity } from './MyActivity';
 import { StatusUpdater } from '@respond/components/StatusUpdater';
+import addDays from 'date-fns/addDays'
 
 //const inter = Inter({ subsets: ['latin'] })
 
+function filterActivitiesForDisplay(activities: Activity[], maxCompletedVisible: number, oldestVisible: number) {
+  // Most recent first
+  const sort = (a: Activity, b: Activity) => a.startTime > b.startTime ? -1 : 1;
+
+  const active = activities.filter(a => !a.endTime).sort(sort);
+  const complete = activities.filter(a => a.endTime && a.startTime > oldestVisible).sort(sort).slice(0, maxCompletedVisible);
+
+  return active.concat(complete)
+}
+
 export default function Home() {
+  const maxCompletedActivitiesVisible = 3;
+  const oldestCompletedActivityVisible = addDays(new Date(), -3).getTime();
+
   const canCreateM = useAppSelector(state => canCreateMissions(state));
   const canCreateE = useAppSelector(state => canCreateEvents(state));
-  const missions = useAppSelector(buildActivityTypeSelector(true));
-  const events = useAppSelector(buildActivityTypeSelector(false));
+
+  let missions = useAppSelector(buildActivityTypeSelector(true));
+  missions = filterActivitiesForDisplay(missions, maxCompletedActivitiesVisible, oldestCompletedActivityVisible);
+  
+  let events = useAppSelector(buildActivityTypeSelector(false));
+  events = filterActivitiesForDisplay(events, maxCompletedActivitiesVisible, oldestCompletedActivityVisible);
 
   useEffect(() => {
     document.title = "Event list";
@@ -43,10 +61,12 @@ export default function Home() {
                 </Typography>
               </CardContent>
               </CardActionArea>
-              <CardActions>
-                <StatusUpdater activity={a} />
-                {/* <Button size="small" color="primary" variant="contained" onClick={() => confirmPrompt('Respond to Mission', 'Respond', a)}>Respond</Button> */}
-              </CardActions>
+              {(!a.endTime) && (
+                <CardActions>
+                  <StatusUpdater activity={a} />
+                  {/* <Button size="small" color="primary" variant="contained" onClick={() => confirmPrompt('Respond to Mission', 'Respond', a)}>Respond</Button> */}
+                </CardActions>
+                )}
             </Card>
           ))}
           {missions.length === 0 && <Typography>No recent missions</Typography>}
@@ -72,10 +92,12 @@ export default function Home() {
                 </Typography>
               </CardContent>
               </CardActionArea>
-              <CardActions>
-                <StatusUpdater activity={a} />
-                {/* <Button size="small" color="primary" onClick={() => confirmPrompt('Attend Event', 'Attend', a)}>Attend</Button> */}
-              </CardActions>
+              {(!a.endTime) && (
+                <CardActions>
+                  <StatusUpdater activity={a} />
+                  {/* <Button size="small" color="primary" onClick={() => confirmPrompt('Attend Event', 'Attend', a)}>Attend</Button> */}
+                </CardActions>
+              )}
             </Card>
           ))}
           {events.length === 0 && <Typography>No recent events</Typography>}

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -6,7 +6,7 @@ import { Box, Button, Card, CardActionArea, CardActions, CardContent, Dialog, Di
 //import styles from './page.module.css';
 import { useAppDispatch, useAppSelector } from '@respond/lib/client/store';
 import { canCreateEvents, canCreateMissions } from '@respond/lib/client/store/organization';
-import { buildActivityTypeSelector, getActiveParticipants } from '@respond/lib/client/store/activities';
+import { buildActivityTypeSelector, getActiveParticipants, isActive, isComplete } from '@respond/lib/client/store/activities';
 import { useEffect, useState } from 'react';
 import { Activity, ResponderStatus } from '@respond/types/activity';
 import { ActivityActions } from '@respond/lib/state';
@@ -20,8 +20,11 @@ function filterActivitiesForDisplay(activities: Activity[], maxCompletedVisible:
   // Most recent first
   const sort = (a: Activity, b: Activity) => a.startTime > b.startTime ? -1 : 1;
 
-  const active = activities.filter(a => !a.endTime).sort(sort);
-  const complete = activities.filter(a => a.endTime && a.startTime > oldestVisible).sort(sort).slice(0, maxCompletedVisible);
+  const active = activities.filter(isActive).sort(sort);
+  const complete = activities
+    .filter(a => isComplete(a) && a.startTime > oldestVisible)
+    .sort(sort)
+    .slice(0, maxCompletedVisible);
 
   return active.concat(complete)
 }
@@ -61,7 +64,7 @@ export default function Home() {
                 </Typography>
               </CardContent>
               </CardActionArea>
-              {(!a.endTime) && (
+              {(isActive(a)) && (
                 <CardActions>
                   <StatusUpdater activity={a} />
                   {/* <Button size="small" color="primary" variant="contained" onClick={() => confirmPrompt('Respond to Mission', 'Respond', a)}>Respond</Button> */}
@@ -92,7 +95,7 @@ export default function Home() {
                 </Typography>
               </CardContent>
               </CardActionArea>
-              {(!a.endTime) && (
+              {(isActive(a)) && (
                 <CardActions>
                   <StatusUpdater activity={a} />
                   {/* <Button size="small" color="primary" onClick={() => confirmPrompt('Attend Event', 'Attend', a)}>Attend</Button> */}

--- a/src/lib/client/store/activities.ts
+++ b/src/lib/client/store/activities.ts
@@ -20,6 +20,8 @@ const activitiesSlice = createSlice({
       .addCase(ActivityActions.reload, BasicReducers[ActivityActions.reload.type])
       .addCase(ActivityActions.update, BasicReducers[ActivityActions.update.type])
       .addCase(ActivityActions.remove, BasicReducers[ActivityActions.remove.type])
+      .addCase(ActivityActions.reactivate, BasicReducers[ActivityActions.reactivate.type])
+      .addCase(ActivityActions.complete, BasicReducers[ActivityActions.complete.type])
       .addCase(ActivityActions.appendOrganizationTimeline, BasicReducers[ActivityActions.appendOrganizationTimeline.type])
       .addCase(ActivityActions.participantUpdate, BasicReducers[ActivityActions.participantUpdate.type])
   },
@@ -59,4 +61,12 @@ export function buildMyActivitySelector() {
       return a.activity.isMission ? 1 : -1;
     });
   }
+}
+
+export function isActive(a: Activity) {
+  return !isComplete(a);
+}
+
+export function isComplete(a: Activity) {
+  return !!a.endTime;
 }

--- a/src/lib/state/activityActions.ts
+++ b/src/lib/state/activityActions.ts
@@ -15,7 +15,17 @@ const update = createAction('activity/update', (updates: Partial<Activity> & { i
 const remove = createAction('activity/remove', (activityId: string) => ({
   payload: { id: activityId },
   meta: { sync: true },
-}))
+}));
+
+const reactivate = createAction('activity/reactivate', (activityId: string) => ({
+  payload: { id: activityId },
+  meta: { sync: true },
+}));
+
+const complete = createAction('activity/complete', (activityId: string, endTime: number) => ({
+  payload: { id: activityId, endTime },
+  meta: { sync: true },
+}));
 
 const appendOrganizationTimeline = createAction('participatingOrg/append', (
   activityId: string,
@@ -43,6 +53,13 @@ const participantUpdate = createAction('participant/update', (activityId: string
   meta: { sync: true },
 }))
 
+const participantClear = createAction('participant/clear', (activityId: string, participantId: string) => ({
+  payload: {
+    activityId,
+    participantId,
+  }
+}));
+
 const tagParticipant = createAction('participant/tag', (activityId: string, participantId: string, tags: string[]) => ({
   payload: {
     activityId,
@@ -56,6 +73,8 @@ export const ActivityActions = {
   reload,
   update,
   remove,
+  reactivate,
+  complete,
   appendOrganizationTimeline,
   participantUpdate,
   tagParticipant,

--- a/src/lib/state/activityReducers.ts
+++ b/src/lib/state/activityReducers.ts
@@ -35,6 +35,7 @@ export const BasicReducers: ActivityReducers = {
   [ActivityActions.complete.type]: (state, { payload }) => {
     const activity = state.list.find(f => f.id === payload.id);
     if (activity) {
+      // First set the end time
       activity.endTime = payload.endTime;
 
       // Then clear every participant

--- a/src/lib/state/activityReducers.ts
+++ b/src/lib/state/activityReducers.ts
@@ -25,6 +25,34 @@ export const BasicReducers: ActivityReducers = {
     state.list = state.list.filter(f => f.id !== payload.id)
   },
 
+  [ActivityActions.reactivate.type]: (state, { payload }) => {
+    const activity = state.list.find(f => f.id === payload.id);
+    if (activity) {
+      activity.endTime = null;
+    }
+  },
+
+  [ActivityActions.complete.type]: (state, { payload }) => {
+    const activity = state.list.find(f => f.id === payload.id);
+    if (activity) {
+      activity.endTime = payload.endTime;
+
+      // Then clear every participant
+      for (const pId in activity.participants) {
+        const participant = activity.participants[pId]
+        BasicReducers['participant/update'](state, {
+          payload: {
+            activityId: activity.id,
+            participant: { ...participant },
+            update: {
+              time: payload.endTime,
+              status: ResponderStatus.Cleared,
+            }
+          }});
+      }
+    }
+  },
+
   [ActivityActions.appendOrganizationTimeline.type]: (state, { payload }) => {
     const activity = state.list.find(f => f.id === payload.activityId);
     if (activity) {

--- a/src/lib/state/activityReducers.ts
+++ b/src/lib/state/activityReducers.ts
@@ -28,7 +28,7 @@ export const BasicReducers: ActivityReducers = {
   [ActivityActions.reactivate.type]: (state, { payload }) => {
     const activity = state.list.find(f => f.id === payload.id);
     if (activity) {
-      activity.endTime = null;
+      activity.endTime = undefined;
     }
   },
 

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -58,7 +58,7 @@ export interface Activity {
   isMission: boolean;
   asMission: boolean;
   startTime: number;
-  endTime: number | null;
+  endTime?: number;
 
   participants: Record<string, Participant>;
   organizations: Record<string, ParticipatingOrg>;
@@ -79,7 +79,6 @@ export function createNewActivity(): Activity {
     title: '',
     location: { title: '' },
     startTime: new Date().getTime(),
-    endTime: null,
     isMission: false,
     asMission: false,
     ownerOrgId: '',

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -58,12 +58,13 @@ export interface Activity {
   isMission: boolean;
   asMission: boolean;
   startTime: number;
+  endTime: number | null;
 
   participants: Record<string, Participant>;
   organizations: Record<string, ParticipatingOrg>;
 }
 
-export const pickActivityProperties = pickSafely<Partial<Activity>>(['id', 'idNumber', 'title', 'location', 'ownerOrgId', 'isMission', 'asMission', 'startTime']);
+export const pickActivityProperties = pickSafely<Partial<Activity>>(['id', 'idNumber', 'title', 'location', 'ownerOrgId', 'isMission', 'asMission', 'startTime', 'endTime']);
 
 export type ActivityType = 'missions'|'events';
 
@@ -78,6 +79,7 @@ export function createNewActivity(): Activity {
     title: '',
     location: { title: '' },
     startTime: new Date().getTime(),
+    endTime: null,
     isMission: false,
     asMission: false,
     ownerOrgId: '',


### PR DESCRIPTION
Adds support for marking an activity complete and reactivating it. An activity is complete when it has an end time.

Notes and potential discussion points:
- I used the terminology "Active/Complete" (and variants) as I felt it fits better with SAR's vernacular. Not married to it and can switch to "Open/Closed" in code, the UI, or both if preferred.
- I am _always_ marking all participants as clear when completing an activity. It feels like an invalid state to have a completed activity with non-clear participants, so this prevents getting into that state.
- In the activities list, there will always be completed activities shown, regardless of how many active there are. This was deliberate as, if all complete activities were pushed off the end due to the number of active, it would be impossible to reactivate one that was accidentally completed until one or more other activities completed. Once the overflow page exists this becomes a non-issue.
- To update all of the participants on completion, I'm calling the 'participant/update' reducer from the 'activity/complete' reducer. This feels a bit weird, and I'm open to other approaches. It does seem to follow the [Collection / Item Reducer Pattern](https://redux.js.org/usage/structuring-reducers/reusing-reducer-logic#collection--item-reducer-pattern), though.

Adds the following:
- Button on the activity page to complete/reopoen
- Adds end time to activity page for completed activities
- Confirmation dialog before completing/reopening
- When completing clears all participants
- Hides participant status update button on main page and activity page for completed activities
- Updates the activity lists on the main page:
  - Sorts activities by active then start time (most recent first)
  - Limits the number of completed activities visible to 3 (happy to change this if that's too low)