### PR TITLE
Move activity-level buttons away from responders status

### DIFF
--- a/src/app/(main)/EventPage.tsx
+++ b/src/app/(main)/EventPage.tsx
@@ -101,19 +101,25 @@ export const EventPage = ({ eventId }: { eventId: string }) => {
     const isActivityActive = isActive(activity)
     body = (
       <Box>
-        <Typography variant="h4">{activity.title}</Typography>
+        <Stack direction="row" spacing={1} sx={{mt:2, mb:2}}>
+          <Typography variant="h4" sx={{mr:"auto"}}>{activity.title}</Typography>
+          
+          <Stack direction="row" spacing={1} sx={{height:"2.125rem"}}>
+            <Button variant="outlined" size="small" component={Link} href={`/${activity.isMission ? 'mission' : 'event'}/${eventId}/edit`}>Edit</Button>
+            <Button variant="outlined" size="small" onClick={() => setPromptingActivityState(true)}>{isActivityActive ? 'Complete' : 'Reactivate'}</Button>
+            <IconButton color="danger" onClick={() => setPromptingRemove(true)}><DeleteIcon/></IconButton>
+          </Stack>
+        </Stack>
+
         <Box>Location: {activity.location.title}</Box>
         <Box>State #: {activity.idNumber}</Box>
         {activity.ownerOrgId !== org?.id && <Box>Agency: {activity.organizations[activity.ownerOrgId]?.title}</Box>}
         <Box>Start Time: <RelativeTimeText time={activity.startTime} baseTime={nowTime}/></Box>
         {!isActivityActive && <Box>End Time: <RelativeTimeText time={activity.endTime ?? 0} baseTime={nowTime}/></Box>}
 
-        <Stack direction="row" spacing={1} sx={{mt:2, mb:2}}>
+        <Box sx={{mt:2, mb:2}}>
           {isActivityActive && <StatusUpdater activity={activity} current={myParticipation?.timeline[0].status} />}
-          <Button variant="outlined" size="small" component={Link} href={`/${activity.isMission ? 'mission' : 'event'}/${eventId}/edit`}>Edit</Button>
-          <Button variant="outlined" size="small" onClick={() => setPromptingActivityState(true)}>{isActivityActive ? 'Complete' : 'Reactivate'}</Button>
-          <IconButton color="danger" onClick={() => setPromptingRemove(true)}><DeleteIcon/></IconButton>
-        </Stack>
+        </Box>
 
         <Box>
           <Typography>Participating Organizations:</Typography>

--- a/src/app/(main)/EventPage.tsx
+++ b/src/app/(main)/EventPage.tsx
@@ -101,10 +101,10 @@ export const EventPage = ({ eventId }: { eventId: string }) => {
     const isActivityActive = isActive(activity)
     body = (
       <Box>
-        <Stack direction="row" spacing={1} sx={{mt:2, mb:2}}>
-          <Typography variant="h4" sx={{mr:"auto"}}>{activity.title}</Typography>
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} alignItems="start" sx={{mt:2, mb:2}}>
+          <Typography variant="h4" flexGrow={1}>{activity.title}</Typography>
           
-          <Stack direction="row" spacing={1} sx={{height:"2.125rem"}}>
+          <Stack direction="row" spacing={1} alignItems="center">
             <Button variant="outlined" size="small" component={Link} href={`/${activity.isMission ? 'mission' : 'event'}/${eventId}/edit`}>Edit</Button>
             <Button variant="outlined" size="small" onClick={() => setPromptingActivityState(true)}>{isActivityActive ? 'Complete' : 'Reactivate'}</Button>
             <IconButton color="danger" onClick={() => setPromptingRemove(true)}><DeleteIcon/></IconButton>


### PR DESCRIPTION
To reduce confusion, move the buttons that control an activity (edit, complete/reactivate, delete) away from the responder status button. Specifically to the right of the title.

Validated visual behavior with long titles.

Note that the height needed to be set for the button stack, otherwise the buttons would expand in height as the title wrapped onto multiple lines. The fixed height matches the font size of the title so that the buttons are as tall as one line of title text.