### PR TITLE
Fix Active Responder Count on EventTile

### DIFF
--- a/src/lib/client/store/activities.ts
+++ b/src/lib/client/store/activities.ts
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { Activity, ResponderStatus, ResponderUpdate } from '@respond/types/activity';
+import { Activity, Participant, ResponderStatus, ResponderUpdate } from '@respond/types/activity';
 import { RootState } from '.';
 import { ActivityState, ActivityActions, BasicReducers } from '@respond/lib/state';
 
@@ -33,8 +33,24 @@ export function buildActivityTypeSelector(missions: boolean) {
   return (state: RootState) => state.activities.list.filter(f => f.isMission === missions);
 }
 
-export function getActiveParticipants(a: Activity) {
-  return Object.values(a.participants).filter(p => (p.timeline.slice(-1)?.[0].status ?? ResponderStatus.Unavailable) & 0x01);
+export function getActiveParticipants(activity: Activity) {
+  return fiterParticipantsByStatus(Object.values(activity.participants), [ResponderStatus.SignedIn])
+}
+
+export function getSignedInCount(activity: Activity) {
+  return fiterParticipantsByStatus(Object.values(activity.participants), [ResponderStatus.SignedIn]).length;
+}
+
+export function getStandbyCount(activity: Activity) {
+  return fiterParticipantsByStatus(Object.values(activity.participants), [ResponderStatus.Standby]).length;
+}
+
+export function getSignedOutCount(activity: Activity) {
+  return fiterParticipantsByStatus(Object.values(activity.participants), [ResponderStatus.SignedOut]).length;
+}
+
+function fiterParticipantsByStatus(participants: Participant[], statuses: ResponderStatus[]) {
+  return participants.filter(participant => statuses.includes(participant.timeline[0].status));
 }
 
 export function buildActivitySelector(id?: string) {


### PR DESCRIPTION
The Active responder calculation used on `EventTile` is not calculating correctly. It looks like it always reflects the first status that was reported by each participant.

Looking further in the code, this is confirmed, the current `getActiveParticipants()` call is looking at the last element in the timeline array instead of the first; however the first is the most recent status.

I have updated the `getActiveParticipants()` calculation to evaluate the first status in the timeline array.

I have also added some `get<Status>Count()` methods for future use.