### PR TITLE
When status change is not sign-in, participant should not be signed o…

### DIFF
--- a/src/lib/state/activityReducers.ts
+++ b/src/lib/state/activityReducers.ts
@@ -92,7 +92,10 @@ export const BasicReducers: ActivityReducers = {
       Object.assign(person, payload.participant);
       person.timeline.unshift({ ... payload.update, organizationId: payload.participant.organizationId });
 
-      // If the user is signed into another mission or event, sign them out.
+      // If this is not a sign-in, then we are done.
+      if (payload.update.status !== ResponderStatus.SignedIn) { return; }
+
+      // If this is a sign-in and the user is already signed into another activity, sign them out of the other activity.
       state.list
         .filter(f => f.id !== payload.activityId && f.participants[payload.participant.id])
         .forEach(otherActivity => {


### PR DESCRIPTION
…ut of other activities

The user is signed out of any mission they are currently signed into if they change their status on any other mission to a state that is not signed in.

Repro:

Sign in to Mission A, Standby to Mission B => Mission A is signed out.
Standby to Mission B, Sign in to Mission A, Sign out to Mission B => Mission A is signed out.
Sign in to Mission A, Unavailable to Mission B => Mission A is signed out.
Expected Behavior:

Changing status on Mission B should not affect Signed In Status on Mission A except when the User Signs In to Mission B.