### PR TITLE
Change : Hide the Not Available status from the status updater

### DIFF
--- a/src/components/StatusUpdater/index.tsx
+++ b/src/components/StatusUpdater/index.tsx
@@ -8,7 +8,7 @@ import { SplitButton } from '../SplitButton';
 import { useFormLogic, UpdateStatusForm } from './UpdateStatusForm';
 
 const options = [
-  { id: ResponderStatus.Unavailable, text: 'Not Available' },
+  //{ id: ResponderStatus.Unavailable, text: 'Not Available' },
   { id: ResponderStatus.Standby, text: 'Stand By' },
   { id: ResponderStatus.SignedIn, text: 'Sign In' },
   { id: ResponderStatus.SignedOut, text: 'Sign Out' },


### PR DESCRIPTION
Once a user has signed into a mission, or some other "active" state like standby, they should not be able to go back to the null state. If there is any use case for this the better answer is probably to delete the participant from the activity.