### PR TITLE
Repair dark mode (with brighter primary color)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ In your MongoDB database, make sure there is a collection called `organizations`
   "rosterName": "CRT",
   "mouName": "CRT",
   "brand": {
-    "primary": "#154515"
+    "primary": "#154515",
+    "primaryDark": "#31A031"
   },
   "domain": "<YOUR-PREFERRED-HOSTNAME-EX-localhost>",
   "memberProvider": {

--- a/src/app/ClientProviders.tsx
+++ b/src/app/ClientProviders.tsx
@@ -13,9 +13,10 @@ import { OrgActions } from '@respond/lib/client/store/organization';
 import { AppStore, buildClientStore } from '@respond/lib/client/store';
 import { ClientSync } from '@respond/lib/client/sync';
 import merge from 'lodash.merge';
+import { PaletteMode } from '@mui/material';
 
 export interface SiteConfig {
-  theme: ThemeOptions;
+  theme: { primary: string; primaryDark?: string };
   dev: { noExternalNetwork: boolean, buildId: string };
   organization: { title: string, shortTitle: string };
 }
@@ -32,21 +33,21 @@ export default function ClientProviders(
     sync.start();
   }, [sync]);
 
-  // We need to figure out how to keep brand colors to display with high enough contrast when in dark mode.
-  //const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
+  const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
   const hydratedTheme = useMemo(() => {
     console.log('rendering theme');
-    const theme = merge({}, config.theme, {
+    const theme: ThemeOptions = {
       palette: {
-        //mode: prefersDarkMode ? 'dark' : 'light'},
-        mode: 'light',
+        mode: prefersDarkMode ? 'dark' : 'light',
+        background: {
+          default: '#f00',
+        },
+        primary: { main: (prefersDarkMode ? config.theme.primaryDark : config.theme.primary) ?? config.theme.primary },
+        danger: { main: 'rgb(192,0,0)', contrastText: 'white' },
       },
-      background: {
-        default: '#f00',
-      }
-    });
+    }
     return createTheme(theme);
-  }, [ /*prefersDarkMode*/, config.theme ]);
+  }, [ prefersDarkMode, config.theme ]);
 
 
   if (!store) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,10 +28,8 @@ export default async function RootLayout({
       shortTitle: org?.rosterName ?? org?.title ?? 'Team',
     },
     theme: {
-      palette: {
-        primary: { main: org?.brand.primary ?? 'rgb(200, 100, 100)' },
-        danger: { main: 'rgb(192,0,0)', contrastText: 'white' },
-      },
+      primary: org?.brand.primary ?? 'rgb(200, 100, 100)',
+      primaryDark: org?.brand.primaryDark,
     }
   };
 

--- a/src/types/data/organizationDoc.ts
+++ b/src/types/data/organizationDoc.ts
@@ -22,6 +22,7 @@ export interface OrganizationDoc {
   mouName?: string;
   brand: {
     primary: string;
+    primaryDark?: string;
   };
   memberProvider: D4HConfig;
   canCreateEvents: boolean;


### PR DESCRIPTION
- Undo earlier change that tried to disable dark mode
- Add organization brand property for "dark mode primary color"
- Defer creating the MUI theme options object until we know if we're in dark mode or not.
![image](https://github.com/KingCountySAR/respond-next/assets/1082784/c2905a4a-8abb-4076-9c16-377f19a05da5)
