### PR TITLE
Display an error if the user's email address is not found in D4H

### DIFF
--- a/src/app/LoginPanel.tsx
+++ b/src/app/LoginPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Box, Button, Stack, Typography } from '@respond/components/Material';
+import { Box, Button, Stack } from '@respond/components/Material';
 import { CredentialResponse, GoogleLogin } from '@react-oauth/google';
 import Api from '@respond/lib/api';
 import { useAppDispatch, useAppSelector } from '@respond/lib/client/store';
@@ -29,8 +29,7 @@ export default function LoginPanel() {
   }
 
   async function finishLogin(token: string) {
-    const res1 = await Api.post<any>('/api/auth/google', { token });
-    const res = res1 as AuthResponse;
+    const res = await Api.post<any>('/api/auth/google', { token }) as AuthResponse;
     console.log('login response', res);
 
     if (res.userInfo) {

--- a/src/app/LoginPanel.tsx
+++ b/src/app/LoginPanel.tsx
@@ -58,8 +58,8 @@ export default function LoginPanel() {
     <Box sx={{flexGrow: 1, display: 'flex', justifyContent:'center'}}>
       {noExternalNetwork
       ? <Button onClick={doOfflineLogin}>offline login</Button>
-      : <Stack>
-          { error && <Alert severity="error" sx={{mb:2}}>
+      : <Stack spacing={2}>
+          { error && <Alert severity="error">
             <AlertTitle>{error}</AlertTitle>
             {errorDetails}
           </Alert> }

--- a/src/app/LoginPanel.tsx
+++ b/src/app/LoginPanel.tsx
@@ -8,7 +8,7 @@ import { AuthActions } from '@respond/lib/client/store/auth';
 import { OrgActions } from '@respond/lib/client/store/organization'
 import { AuthResponse } from '@respond/types/authResponse'
 import { useState } from 'react'
-import { ApiError } from '@respond/lib/apiErrors'
+import { AuthError } from '@respond/lib/apiErrors'
 import { Alert, AlertTitle } from '@mui/material'
 
 export default function LoginPanel() {
@@ -39,7 +39,7 @@ export default function LoginPanel() {
       dispatch(OrgActions.set({ mine: res.organization }));
     } else {
       switch (res.error) {
-        case ApiError.USER_NOT_KNOWN:
+        case AuthError.USER_NOT_KNOWN:
           setError("Could not find email address in D4H");
           setErrorDetails("Please contact your unit's database manager to have your email address added to your D4H profile, or log in with an email address in your profile.");
           break;

--- a/src/lib/apiErrors.ts
+++ b/src/lib/apiErrors.ts
@@ -1,0 +1,7 @@
+export enum AuthError {
+    INVALID_CONFIGURATION = "Invalid configuration",
+    INVALID_DOMAIN = "Invalid domain",
+    NO_EMAIL = "Could not get user email",
+    NO_TICKET = "Could not get ticket",
+    USER_NOT_KNOWN = "User not known",
+}

--- a/src/lib/server/memberProviders/d4hMembersProvider.ts
+++ b/src/lib/server/memberProviders/d4hMembersProvider.ts
@@ -65,11 +65,15 @@ export default class D4HMembersProvider implements MemberProvider {
       throw new Error("Server is out of sync with member database");
     }
 
-    const info = this.tokenFetchInfo[config.token]?.lookup[this.tokenFetchInfo[config.token]?.authEmailToD4HId?.[auth.email]].memberInfo;
-    return {
-      ...info,
-      id: `${organizationId}:${info.id}`,
-    };
+    const info = this.tokenFetchInfo[config.token]?.lookup[this.tokenFetchInfo[config.token]?.authEmailToD4HId?.[auth.email]]?.memberInfo;
+    if (info) {
+      return {
+        ...info,
+        id: `${organizationId}:${info.id}`,
+      };
+    } else {
+      return undefined;
+    }
   }
 
   private async initialize() {

--- a/src/types/authResponse.ts
+++ b/src/types/authResponse.ts
@@ -4,4 +4,5 @@ import { UserInfo } from './userInfo'
 export interface AuthResponse {
     userInfo: UserInfo | undefined
     organization: MyOrganization | undefined
+    error: string | undefined
 }


### PR DESCRIPTION
Added support for displaying error messages during login.

Primary error to handle is when the user's email cannot be found in D4H (yet they were able to authenticate with Google). It is clearly actionable and has been hit before. Handled other errors gracefully.

Validated that the error is gone when returning to the login page after a successful sign-in and signing back out.

![image](https://github.com/KingCountySAR/respond-next/assets/126836598/bb06fa51-294c-4f48-8e3e-03cad262f532)
