### PR TITLE
layout-components : Implement OutputForm and OutputField

### DIFF
--- a/src/app/(main)/EventTile.tsx
+++ b/src/app/(main)/EventTile.tsx
@@ -10,20 +10,19 @@ export const EventTile = ({ activity, status, children }: { activity: Activity, 
 
     return (
       <Card>
-        <Box sx={{ p: 1, display: "flex", flexDirection: "row" }}>
+        <Box paddingX={1} paddingTop={1} sx={{ display: "flex", flexDirection: "row" }} alignItems="center">
           <Box sx={{ flexGrow: 1 }}>
             <Link href={getActivityPath(activity)} color="textPrimary" underline="hover">
               <Typography sx={{ fontWeight: "bold" }} variant="h6">
                 {activity.title}
               </Typography>
             </Link>
-            <Box>Location: {activity.location.title}</Box>
-            <Box>{children}</Box>
           </Box>
-          <Box sx={{ alignSelf: "flex-start" }}>
+          <Box>
             {status && <StatusChip status={status} />}
           </Box>
         </Box>
+        <Box sx={{ px: 1 }}>{children}</Box>
         {isActive(activity) && (
           <CardActions sx={{ p: 1 }}>
             <Grid container justifyContent="space-between" alignItems="center">

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -12,6 +12,8 @@ import { Activity, ResponderStatus } from '@respond/types/activity';
 import addDays from 'date-fns/addDays'
 import { EventTile } from './EventTile';
 import { OrganizationChip } from './OrganizationChip';
+import { OutputForm } from '@respond/components/OutputForm';
+import { OutputField } from '@respond/components/OutputField';
 
 //const inter = Inter({ subsets: ['latin'] })
 
@@ -61,7 +63,12 @@ export default function Home() {
           </Box>
           <Stack spacing={1}>
             {myCurrentActivities.map(up => (
-              <EventTile key={up.activity.id} activity={up.activity} status={up.status.status} />
+              <EventTile key={up.activity.id} activity={up.activity} status={up.status.status}>
+                <OutputForm>
+                  <OutputField label="Location" value={up.activity.location.title} />
+                  <OutputField label="Active Responders" value={getActiveParticipants(up.activity).length.toString()} />
+                </OutputForm>
+              </EventTile>
             ))}
           </Stack>
         </Box>
@@ -74,9 +81,12 @@ export default function Home() {
         <Stack spacing={1}>
           {missions.map(a => (
             <EventTile key={a.id} activity={a} status={getMyStatus(a)}>
-              <Box>State #: {a.idNumber}</Box>
-              <Box>Active Responders: {getActiveParticipants(a).length}</Box>
-              <Box sx={{ pt: 1 }}>
+              <OutputForm>
+                <OutputField label="Location" value={a.location.title} />
+                <OutputField label="Active Responders" value={getActiveParticipants(a).length.toString()} />
+                <OutputField label="State #" value={a.idNumber} />
+              </OutputForm>
+              <Box sx={{ pt: 2 }}>
                   {Object.entries(a.organizations ?? {}).map(([id, org]) => <OrganizationChip key={id} org={org} />)}
               </Box>
             </EventTile>
@@ -92,8 +102,11 @@ export default function Home() {
         <Stack spacing={1}>
           {events.map(a => (
             <EventTile key={a.id} activity={a}>
-              <Box>State #: {a.idNumber}</Box>
-              <Box>Participants: {getActiveParticipants(a).length}</Box>
+              <OutputForm>
+                <OutputField label="Location" value={a.location.title} />
+                <OutputField label="Participants" value={getActiveParticipants(a).length.toString()} />
+                <OutputField label="State #" value={a.idNumber} />
+              </OutputForm>
             </EventTile>
           ))}
           {events.length === 0 && <Typography>No recent events</Typography>}

--- a/src/components/OutputField.tsx
+++ b/src/components/OutputField.tsx
@@ -1,0 +1,12 @@
+import { Box, Typography } from '@mui/material';
+
+export const OutputField = ({ label, value }: { label: string, value: string }) => {
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "row", alignItems: "center", justifyContent: "space-between", borderColor: 'grey.200' }} borderBottom={1} >
+      <Typography variant="body2" sx={{ color: 'text.secondary', lineHeight: "2em" }}>{label}:</Typography>
+      <Typography variant="body1">{value}</Typography>
+    </Box>
+  );
+
+}

--- a/src/components/OutputField.tsx
+++ b/src/components/OutputField.tsx
@@ -1,11 +1,13 @@
 import { Box, Typography } from '@mui/material';
+import Link from 'next/link';
 
-export const OutputField = ({ label, value }: { label: string, value: string }) => {
+export const OutputField = ({ label, value, href, target }: { label: string, value: string, href?: string, target?: string }) => {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "row", alignItems: "center", justifyContent: "space-between", borderColor: 'grey.200' }} borderBottom={1} >
       <Typography variant="body2" sx={{ color: 'text.secondary', lineHeight: "2em" }}>{label}:</Typography>
-      <Typography variant="body1">{value}</Typography>
+      {!href && <Typography variant="body1">{value}</Typography>}
+      {href && <Link href={href} target={target ?? '_blank'}>{value}</Link>}
     </Box>
   );
 

--- a/src/components/OutputForm.tsx
+++ b/src/components/OutputForm.tsx
@@ -1,0 +1,22 @@
+import { Grid } from '@mui/material';
+import React, { ReactNode } from 'react';
+
+export const OutputForm = ({ children }: { children: ReactNode }) => {
+
+  const childrenArray = React.Children.toArray(children);
+
+  const outputFields = childrenArray.map((child, index) => {
+    return (
+      <Grid key={index} item xs={12} sm={6}>
+        {child}
+      </Grid>
+    )
+  });
+
+  return (
+    <Grid container columnSpacing={{ xs: 0, sm: 2 }}>
+      {outputFields.length && outputFields}
+    </Grid>
+  );
+
+}


### PR DESCRIPTION
Implements a pair of generic components for rendering labelled values; object fields such as Mission attributes. These will help make better use of the available space and take the boilerplate out of rendering/formatting this type of data.

Example Markup:
~~~~
<OutputForm>
  <OutputField label="Location" value={a.location.title} />
  <OutputField label="State #" value={a.idNumber} />
  <OutputField label="Active Responders" value={getActiveParticipants(a).length.toString()} />
  <OutputField label="Status" value={a.status} />
</OutputForm>
~~~~

This commit does not include changes to EventTile or the Event page; screenshots are for demonstration only.

![image](https://github.com/KingCountySAR/respond-next/assets/11284884/385f8772-bc3c-4706-a008-1c09ee008528)
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/586df0f7-1b04-4d7a-8dd7-be33eb00018f)