### PR TITLE
events-padding : Add bottom padding to the last element

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -84,7 +84,7 @@ export default function Home() {
           {missions.length === 0 && <Typography>No recent missions</Typography>}
         </Stack>
       </Box>
-      <Box>
+      <Box sx={{ pb: 4 }}>
         <Box sx={{mb:1, display:'flex', justifyContent:'space-between', alignItems:'center'}}>
           <Typography variant="h5">Events</Typography>
           {canCreateE && <Button variant="outlined" component={Link} href="/event/new">New Event</Button>}


### PR DESCRIPTION
Adding padding on the bottom of the events page so that the last element isn't right on the bottom of the viewport.

![image](https://github.com/KingCountySAR/respond-next/assets/11284884/a52b24cc-da58-4e5a-b130-701746b51ae1)
