### PR TITLE
responder-status : Refactor ResponderStatus to Bit Flags

### DIFF
--- a/src/app/(main)/EventPage.tsx
+++ b/src/app/(main)/EventPage.tsx
@@ -26,7 +26,7 @@ const Roster = ({participants, orgs, startTime}: {participants: Record<string, P
   };
   
 
-  const rows: GridRowsProp = Object.values(participants).filter(f => f.timeline[0].status !== ResponderStatus.Unavailable).map(f => ({
+  const rows: GridRowsProp = Object.values(participants).filter(f => f.timeline[0].status !== ResponderStatus.NotResponding).map(f => ({
     ...f,
     orgName: orgs[f.organizationId]?.rosterName ?? orgs[f.organizationId]?.title,
     status: f.timeline[0].status,

--- a/src/app/(main)/StatusChip.tsx
+++ b/src/app/(main)/StatusChip.tsx
@@ -3,17 +3,25 @@ import { Circle } from '@mui/icons-material';
 import { ResponderStatus } from '@respond/types/activity';
 
 const STATUS_COLORS: Record<ResponderStatus, 'success'|'error'|'warning'|'disabled'> = {
-  [ResponderStatus.SignedIn]: 'success',
-  [ResponderStatus.SignedOut]: 'error',
+  [ResponderStatus.NotResponding]: 'disabled',
   [ResponderStatus.Standby]: 'warning',
-  [ResponderStatus.Unavailable]: 'disabled'
+  [ResponderStatus.InTown]: 'success',
+  [ResponderStatus.SignedIn]: 'success',
+  [ResponderStatus.Available]: 'success',
+  [ResponderStatus.Assigned]: 'success',
+  [ResponderStatus.Demobilized]: 'warning',
+  [ResponderStatus.SignedOut]: 'error'
 };
 
 const STATUS_TEXT: Record<ResponderStatus, string> = {
-  [ResponderStatus.SignedIn]: 'Signed In',
-  [ResponderStatus.SignedOut]: 'Signed Out',
+  [ResponderStatus.NotResponding]: 'Not Responding',
   [ResponderStatus.Standby]: 'Standby',
-  [ResponderStatus.Unavailable]: 'Unavailable'
+  [ResponderStatus.InTown]: 'In Town',
+  [ResponderStatus.SignedIn]: 'Signed In',
+  [ResponderStatus.Available]: 'Available',
+  [ResponderStatus.Assigned]: 'Assigned',
+  [ResponderStatus.Demobilized]: 'Demobilized',
+  [ResponderStatus.SignedOut]: 'Signed Out'
 };
 
 export const StatusChip = ({ status }: { status: ResponderStatus }) => {

--- a/src/components/StatusUpdater/index.tsx
+++ b/src/components/StatusUpdater/index.tsx
@@ -8,7 +8,7 @@ import { SplitButton } from '../SplitButton';
 import { useFormLogic, UpdateStatusForm } from './UpdateStatusForm';
 
 const options = [
-  { id: ResponderStatus.Unavailable, text: 'Not Available' },
+  { id: ResponderStatus.NotResponding, text: 'Not Responding' },
   { id: ResponderStatus.Standby, text: 'Stand By' },
   { id: ResponderStatus.SignedIn, text: 'Sign In' },
   { id: ResponderStatus.SignedOut, text: 'Sign Out' },

--- a/src/lib/state/activityReducers.ts
+++ b/src/lib/state/activityReducers.ts
@@ -74,7 +74,7 @@ export const BasicReducers: ActivityReducers = {
       if (person) {
         const lastUpdate = person.timeline[0];
         if (lastUpdate.organizationId !== payload.participant.organizationId) {
-          if (lastUpdate.status !== ResponderStatus.SignedOut && lastUpdate.status !== ResponderStatus.Unavailable) {
+          if (lastUpdate.status !== ResponderStatus.SignedOut && lastUpdate.status !== ResponderStatus.NotResponding) {
             person.timeline.unshift({ organizationId: lastUpdate.organizationId, time: payload.update.time, status: ResponderStatus.SignedOut });
           }
           person.tags = undefined;

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -13,10 +13,14 @@ const pickSafely = <ObjectType>(keys: readonly `${string & keyof ObjectType}`[])
 }
 
 export enum ResponderStatus {
-  Unavailable = 0,
-  Standby = 2,
-  SignedIn = 3,
-  SignedOut = 4,
+  NotResponding = 0x00,
+  Standby = 0x01,
+  InTown = 0x03,
+  SignedIn = 0x07,
+  Available = 0x0B,
+  Assigned = 0x1B,
+  Demobilized = 0x27,
+  SignedOut = 0x21,
 }
 export enum OrganizationStatus {
   Unknown = 0,


### PR DESCRIPTION
This commit refactors ResponderStatus as a Bit Flag Enum.

Subject to change, I expect there will be continued discussion around this. Just getting a branch started that we can iterate on.

I'm also not sure what the best way to document the bitwise flagging is. I would think there is probably a best practice around this, like some sort of pattern to make the code self documenting, or a commenting strategy, but I haven't found it yet.

https://docs.google.com/spreadsheets/d/1QBt3RkDtGucOKESqMf_QjtJSwyThdayMig1qjIQYURQ/edit#gid=0