### PR TITLE
Change : Responder Statuses and Options Overhauled

### DIFF
--- a/src/app/(main)/EventPage.module.css
+++ b/src/app/(main)/EventPage.module.css
@@ -6,6 +6,20 @@ div.roster :global(div.MuiDataGrid-cell):focus {
   outline: none;
 }
 
-.roster :global(.roster-status-SignedIn) {
+.roster :global(.roster-status-Standby) {
+  background-color: orange;
+}
+
+.roster :global(.roster-status-SignedIn),
+.roster :global(.roster-status-Available),
+.roster :global(.roster-status-Assigned) {
   background-color: green;
+}
+
+.roster :global(.roster-status-Demobilized) {
+  background-color: darkred;
+}
+
+.roster :global(.roster-status-Remote) {
+  background-color: blue;
 }

--- a/src/app/(main)/EventPage.tsx
+++ b/src/app/(main)/EventPage.tsx
@@ -26,7 +26,7 @@ const Roster = ({participants, orgs, startTime}: {participants: Record<string, P
   };
   
 
-  const rows: GridRowsProp = Object.values(participants).filter(f => f.timeline[0].status !== ResponderStatus.Unavailable).map(f => ({
+  const rows: GridRowsProp = Object.values(participants).filter(f => f.timeline[0].status !== ResponderStatus.NotResponding).map(f => ({
     ...f,
     orgName: orgs[f.organizationId]?.rosterName ?? orgs[f.organizationId]?.title,
     status: f.timeline[0].status,

--- a/src/app/(main)/StatusChip.tsx
+++ b/src/app/(main)/StatusChip.tsx
@@ -3,17 +3,25 @@ import { Circle } from '@mui/icons-material';
 import { ResponderStatus } from '@respond/types/activity';
 
 const STATUS_COLORS: Record<ResponderStatus, 'success'|'error'|'warning'|'disabled'> = {
-  [ResponderStatus.SignedIn]: 'success',
-  [ResponderStatus.SignedOut]: 'error',
+  [ResponderStatus.NotResponding]: 'disabled',
   [ResponderStatus.Standby]: 'warning',
-  [ResponderStatus.Unavailable]: 'disabled'
+  [ResponderStatus.Remote]: 'success',
+  [ResponderStatus.SignedIn]: 'success',
+  [ResponderStatus.Available]: 'success',
+  [ResponderStatus.Assigned]: 'success',
+  [ResponderStatus.Demobilized]: 'warning',
+  [ResponderStatus.SignedOut]: 'error',
 };
 
 const STATUS_TEXT: Record<ResponderStatus, string> = {
-  [ResponderStatus.SignedIn]: 'Signed In',
-  [ResponderStatus.SignedOut]: 'Signed Out',
+  [ResponderStatus.NotResponding]: 'Not Responding',
   [ResponderStatus.Standby]: 'Standby',
-  [ResponderStatus.Unavailable]: 'Unavailable'
+  [ResponderStatus.Remote]: 'In Town',
+  [ResponderStatus.SignedIn]: 'Responding',
+  [ResponderStatus.Available]: 'Available',
+  [ResponderStatus.Assigned]: 'Assigned',
+  [ResponderStatus.Demobilized]: 'Demobilized',
+  [ResponderStatus.SignedOut]: 'Signed Out'
 };
 
 export const StatusChip = ({ status }: { status: ResponderStatus }) => {

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -8,7 +8,7 @@ import { useAppSelector } from '@respond/lib/client/store';
 import { canCreateEvents, canCreateMissions } from '@respond/lib/client/store/organization';
 import { buildActivityTypeSelector, buildMyActivitySelector, getActiveParticipants, isActive, isComplete } from '@respond/lib/client/store/activities';
 import { useEffect } from 'react';
-import { Activity, ResponderStatus } from '@respond/types/activity';
+import { Activity, isActive as isResponderStatusActive } from '@respond/types/activity';
 import addDays from 'date-fns/addDays'
 import { EventTile } from './EventTile';
 import { OrganizationChip } from './OrganizationChip';
@@ -32,7 +32,7 @@ function filterActivitiesForDisplay(activities: Activity[], maxCompletedVisible:
 
 export default function Home() {
   let myActivities = useAppSelector(buildMyActivitySelector());
-  let myCurrentActivities = myActivities.filter(activity => [ResponderStatus.SignedIn,ResponderStatus.Standby].includes(activity.status.status));
+  let myCurrentActivities = myActivities.filter(activity => isResponderStatusActive(activity.status.status) === true);
 
   function getMyStatus(activity: Activity) {
     return myActivities.find(f => f.activity.id === activity.id)?.status.status;

--- a/src/components/SplitButton.tsx
+++ b/src/components/SplitButton.tsx
@@ -91,7 +91,6 @@ export function SplitButton<K extends string|number|EnumMember, T extends IdOpti
                 {menuOptions.map((option, index) => (
                   <MenuItem
                     key={option.id + ''}
-                    selected={index === selectedIndex}
                     onClick={(event) => handleMenuItemClick(event, index)}
                   >
                     {option.text}

--- a/src/components/StatusUpdater/index.tsx
+++ b/src/components/StatusUpdater/index.tsx
@@ -32,7 +32,7 @@ const statusOptions: Record<ResponderStatus, { id: number, newStatus: ResponderS
   [ResponderStatus.SignedOut]: [statusTransitions.signIn, statusTransitions.standBy, statusTransitions.inTown],
 }
 
-const futureOptions: Record<ResponderStatus, { id: number, newStatus: ResponderStatus, text: string }[]> = {
+const futureStatusOptions: Record<ResponderStatus, { id: number, newStatus: ResponderStatus, text: string }[]> = {
   [ResponderStatus.NotResponding]: [statusTransitions.standBy],
   [ResponderStatus.Standby]: [statusTransitions.standDown],
   [ResponderStatus.Remote]: [statusTransitions.resetStatus],
@@ -43,16 +43,20 @@ const futureOptions: Record<ResponderStatus, { id: number, newStatus: ResponderS
   [ResponderStatus.SignedOut]: [statusTransitions.standBy],
 }
 
-const fourHourEarlySigninWindow = 4 * 60 * 60 * 1000;
+/**
+ * @description Members can sign in prior to the start time of a future mission.
+ * @return 4 Hours in milliseconds.
+ */
+const earlySigninWindow = 4 * 60 * 60 * 1000;
 
 function isFuture(time: number) {
-  return (time - fourHourEarlySigninWindow) > new Date().getTime();
+  return (time - earlySigninWindow) > new Date().getTime();
 };
 
 function getStatusOptions(current: ResponderStatus|undefined, startTime: number) {
   let status = current ?? ResponderStatus.NotResponding;
   if (isFuture(startTime)) {
-    return futureOptions[status];
+    return futureStatusOptions[status];
   }
   return statusOptions[status];
 }

--- a/src/components/StatusUpdater/index.tsx
+++ b/src/components/StatusUpdater/index.tsx
@@ -16,7 +16,9 @@ const statusTransitions = {
   arriveBase: { id: 5, newStatus: ResponderStatus.Available, text: 'Arrive Base' },
   departBase: { id: 6, newStatus: ResponderStatus.Demobilized, text: 'Depart Base' },
   signOut: { id: 7, newStatus: ResponderStatus.SignedOut, text: 'Sign Out' },
-  resetStatus: { id: 8, newStatus: ResponderStatus.NotResponding, text: 'Reset Status' } // clear status in edge cases that shouldn't generally be possible.
+  resetStatus: { id: 8, newStatus: ResponderStatus.NotResponding, text: 'Reset Status' }, // clear status in edge cases that shouldn't generally be possible.
+  assigned: { id: 9, newStatus: ResponderStatus.Assigned, text: 'Assigned' },
+  available: { id: 10, newStatus: ResponderStatus.Available, text: 'Available' }
 }
 
 const statusOptions: Record<ResponderStatus, { id: number, newStatus: ResponderStatus, text: string }[]> = {
@@ -24,8 +26,8 @@ const statusOptions: Record<ResponderStatus, { id: number, newStatus: ResponderS
   [ResponderStatus.Standby]: [statusTransitions.signIn, statusTransitions.standDown],
   [ResponderStatus.Remote]: [statusTransitions.signOut],
   [ResponderStatus.SignedIn]: [statusTransitions.arriveBase, statusTransitions.turnAround, statusTransitions.signOut],
-  [ResponderStatus.Available]: [statusTransitions.departBase],
-  [ResponderStatus.Assigned]: [statusTransitions.resetStatus],
+  [ResponderStatus.Available]: [statusTransitions.departBase, statusTransitions.assigned],
+  [ResponderStatus.Assigned]: [statusTransitions.available],
   [ResponderStatus.Demobilized]: [statusTransitions.signOut, statusTransitions.signIn, statusTransitions.arriveBase],
   [ResponderStatus.SignedOut]: [statusTransitions.signIn, statusTransitions.standBy, statusTransitions.inTown],
 }

--- a/src/lib/client/store/activities.ts
+++ b/src/lib/client/store/activities.ts
@@ -55,7 +55,7 @@ export function buildMyActivitySelector() {
     const myParticipation: { activity: Activity, status: ResponderUpdate }[] = [];
     for (const activity of state.activities.list) {
       const myUpdate = activity.participants[participantId]?.timeline[0];
-      if ([ResponderStatus.Standby, ResponderStatus.SignedIn, ResponderStatus.SignedOut].includes(myUpdate?.status)) {
+      if (myUpdate && myUpdate.status !== ResponderStatus.NotResponding) {
         myParticipation.push({ activity, status: myUpdate });
       }
     }

--- a/src/lib/client/store/activities.ts
+++ b/src/lib/client/store/activities.ts
@@ -2,6 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 import { Activity, Participant, ResponderStatus, ResponderUpdate } from '@respond/types/activity';
 import { RootState } from '.';
 import { ActivityState, ActivityActions, BasicReducers } from '@respond/lib/state';
+import { isActive as isResponderStatusActive } from '@respond/types/activity';
 
 let initialState: ActivityState = {
   list: [],
@@ -34,7 +35,7 @@ export function buildActivityTypeSelector(missions: boolean) {
 }
 
 export function getActiveParticipants(activity: Activity) {
-  return filterParticipantsByStatus(Object.values(activity.participants), [ResponderStatus.SignedIn])
+  return Object.values(activity.participants).filter(p => isResponderStatusActive(p.timeline[0].status) == true);
 }
 
 function filterParticipantsByStatus(participants: Participant[], statuses: ResponderStatus[]) {

--- a/src/lib/state/activityReducers.ts
+++ b/src/lib/state/activityReducers.ts
@@ -74,7 +74,7 @@ export const BasicReducers: ActivityReducers = {
       if (person) {
         const lastUpdate = person.timeline[0];
         if (lastUpdate.organizationId !== payload.participant.organizationId) {
-          if (lastUpdate.status !== ResponderStatus.SignedOut && lastUpdate.status !== ResponderStatus.Unavailable) {
+          if (lastUpdate.status !== ResponderStatus.SignedOut && lastUpdate.status !== ResponderStatus.NotResponding) {
             person.timeline.unshift({ organizationId: lastUpdate.organizationId, time: payload.update.time, status: ResponderStatus.SignedOut });
           }
           person.tags = undefined;

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -13,11 +13,41 @@ const pickSafely = <ObjectType>(keys: readonly `${string & keyof ObjectType}`[])
 }
 
 export enum ResponderStatus {
-  Unavailable = 0,
+  NotResponding = 0,
+  Remote = 1,
   Standby = 2,
   SignedIn = 3,
   SignedOut = 4,
+  Available = 5,
+  Assigned = 6,
+  Demobilized = 7,
 }
+
+export function isActive(status: ResponderStatus) {
+  return [
+    ResponderStatus.Standby,
+    ResponderStatus.Remote,
+    ResponderStatus.SignedIn,
+    ResponderStatus.Available,
+    ResponderStatus.Assigned,
+    ResponderStatus.Demobilized
+  ].includes(status);
+}
+
+export function isInTransit(status: ResponderStatus) {
+  return [
+    ResponderStatus.SignedIn,
+    ResponderStatus.Demobilized
+  ].includes(status);
+}
+
+export function isCheckedIn(status: ResponderStatus) {
+  return [
+    ResponderStatus.Available,
+    ResponderStatus.Assigned
+  ].includes(status);
+}
+
 export enum OrganizationStatus {
   Unknown = 0,
   Invited = 1,


### PR DESCRIPTION
- Add several new ResponderStatus options.
  - Remote (In Town): status for remote responders so we can account for them separate from field responders.
  - Available: Indicates responders who are at the mission, but not yet tasked.
  - Assigned: Indicates responders who are at the mission and currently assigned to a team or task.
  - Demobilized: Indicates responders who have turned around, or have departed the mission.
- Implements Status Transition Mapping for StatusUpdater so that only logical transitions are shown.
- Increase the Sign-In window from 1 hour to 4 hours, prior to  a future mission.
- No change to existing Enum status ids, changes are backwards compatible.

## Future Missions should only show Stand By or Stand Down:
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/41767697-edf4-4360-9efc-bf0bcf4bb226)
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/db29dcfe-7eb4-4f6a-96fe-d80ba50da3ec)

## Active Missions should allow logical transitions.  
### The happy path would be Sign In -> Arrive Base -> Depart Base -> Sign out
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/bc53aed1-a856-47ef-b796-13f9212633af)
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/96969417-85c0-4a9a-9f16-ff11958e13d7)
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/3c237d26-c4b6-4cfe-879e-82505d96fde6)
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/6d988078-10c8-4e1a-9433-753d822a2d28)
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/3b0433b7-a40b-422d-aafc-46099d9c1058)
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/040386f3-f5d7-46ae-b428-ef680382f946)

## In Towns can sign into a separate status
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/66d2f435-8c54-4a7e-8258-362c2d8ffd6d)
