### PR TITLE
Fix : Padding on EventTile

### DIFF
--- a/src/app/(main)/EventTile.tsx
+++ b/src/app/(main)/EventTile.tsx
@@ -11,21 +11,24 @@ export const EventTile = ({ activity, status, children }: { activity: Activity, 
 
     return (
       <Card>
-        <Box paddingX={1} paddingTop={1} sx={{ display: "flex", flexDirection: "row" }} alignItems="center">
-          <Box sx={{ flexGrow: 1 }}>
-            <Link href={getActivityPath(activity)} color="textPrimary" underline="hover">
-              <Typography sx={{ fontWeight: "bold" }} variant="h6">
-                {activity.title}
-              </Typography>
-            </Link>
+        <Box padding={1}>
+          <Box sx={{ pb: 2, display: "flex", flexDirection: "row" }} alignItems="center">
+            <Box sx={{ flexGrow: 1 }}>
+              <Link href={getActivityPath(activity)} color="textPrimary" underline="hover">
+                <Typography sx={{ fontWeight: "bold" }} variant="h6">
+                  {activity.title}
+                </Typography>
+              </Link>
+            </Box>
+            <Box>
+              {status && <StatusChip status={status} />}
+            </Box>
           </Box>
-          <Box>
-            {status && <StatusChip status={status} />}
-          </Box>
+          <Box>{children}</Box>
         </Box>
-        <Box sx={{ px: 1 }}>{children}</Box>
+        
         {isActive(activity) && (
-          <CardActions sx={{ p: 1 }}>
+          <CardActions>
             <Grid container justifyContent="space-between" alignItems="center">
               <Grid item>
                 {activity.mapId && 


### PR DESCRIPTION
When events are closed the card actions are hidden but the card body doesn't have any padding.

Also added a bit of padding below the header.

Before
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/a73c7eab-960c-4a92-9583-2f220a4f92a0)

After
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/24cf7e6f-5617-4be7-898f-5fa97bdab761)
