### PR TITLE
Customized Error Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ In your MongoDB database, make sure there is a collection called `organizations`
   "id": "1",
   "canCreateEvents": true,
   "canCreateMissions": false,
+  "supportEmail": "support@cascaderescueteam.org",
   "partners": [
     {
       "id": "2",

--- a/src/app/LoginPanel.tsx
+++ b/src/app/LoginPanel.tsx
@@ -39,28 +39,30 @@ export default function LoginPanel() {
       dispatch(OrgActions.set({ mine: res.organization }));
     } else {
       const organization = res.organization;
-      let supportEmail: string | undefined = undefined;
+      let supportContact: string | undefined = undefined;
       let memberProviderName = undefined;
 
       if (organization) {
-        supportEmail = organization.supportEmail;
+        supportContact = organization.supportEmail;
         memberProviderName = MemberProviderName[organization.memberProvider];
       }
+
+      supportContact ??= "your unit's operations leader";
 
       switch (res.error) {
         case AuthError.USER_NOT_KNOWN:
           if (memberProviderName) {
             setError(`Could not find your email address in ${memberProviderName}`);
-            setErrorDetails(`Please log in with an email address in your ${memberProviderName} profile. If your email address is not in your profile, contact ${supportEmail ?? "your unit's operations leader"} for support.`);
+            setErrorDetails(`Please log in with an email address in your ${memberProviderName} profile. If your email address is not in your profile, contact ${supportContact} for support.`);
           } else {
             setError("Could not find your email address");
-            setErrorDetails(`Please log in with an authorized email address or contact ${supportEmail ?? "your unit's operations leader"} for support.`);
+            setErrorDetails(`Please log in with an authorized email address or contact ${supportContact} for support.`);
           }
           break;
         
         default:
           setError("Error logging in" + (res.error ? ` - ${res.error}` : ""));
-          setErrorDetails(`Please try again. If you continue encountering this error, contact ${supportEmail ?? "your unit's operations leader"}.`);
+          setErrorDetails(`Please try again. If you continue encountering this error, contact ${supportContact}.`);
           break;
       }
       

--- a/src/app/LoginPanel.tsx
+++ b/src/app/LoginPanel.tsx
@@ -10,6 +10,7 @@ import { AuthResponse } from '@respond/types/authResponse'
 import { useState } from 'react'
 import { AuthError } from '@respond/lib/apiErrors'
 import { Alert, AlertTitle } from '@mui/material'
+import { MemberProviderName } from '@respond/types/data/MemberProviderType'
 
 export default function LoginPanel() {
   const { noExternalNetwork } = useAppSelector(state => state.config.dev );
@@ -37,15 +38,29 @@ export default function LoginPanel() {
       dispatch(AuthActions.set({ userInfo: res.userInfo }));
       dispatch(OrgActions.set({ mine: res.organization }));
     } else {
+      const organization = res.organization;
+      let supportEmail: string | undefined = undefined;
+      let memberProviderName = undefined;
+
+      if (organization) {
+        supportEmail = organization.supportEmail;
+        memberProviderName = MemberProviderName[organization.memberProvider];
+      }
+
       switch (res.error) {
         case AuthError.USER_NOT_KNOWN:
-          setError("Could not find email address in D4H");
-          setErrorDetails("Please contact your unit's database manager to have your email address added to your D4H profile, or log in with an email address in your profile.");
+          if (memberProviderName) {
+            setError(`Could not find your email address in ${memberProviderName}`);
+            setErrorDetails(`Please log in with an email address in your ${memberProviderName} profile. If your email address is not in your profile, contact ${supportEmail ?? "your unit's operations leader"} for support.`);
+          } else {
+            setError("Could not find your email address");
+            setErrorDetails(`Please log in with an authorized email address or contact ${supportEmail ?? "your unit's operations leader"} for support.`);
+          }
           break;
         
         default:
           setError("Error logging in" + (res.error ? ` - ${res.error}` : ""));
-          setErrorDetails("Please try again. If you continue encountering this error, please contact support.");
+          setErrorDetails(`Please try again. If you continue encountering this error, contact ${supportEmail ?? "your unit's operations leader"}.`);
           break;
       }
       

--- a/src/app/LoginPanel.tsx
+++ b/src/app/LoginPanel.tsx
@@ -47,7 +47,7 @@ export default function LoginPanel() {
         memberProviderName = MemberProviderName[organization.memberProvider];
       }
 
-      supportContact ??= "your unit's operations leader";
+      supportContact ??= "your unit's system administrator";
 
       switch (res.error) {
         case AuthError.USER_NOT_KNOWN:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import ClientOnly from '@respond/components/ClientOnly';
 import { getCookieAuth, userFromAuth } from '@respond/lib/server/auth';
 import { getOrganizationForRequest } from '@respond/lib/server/request';
+import { MyOrganization } from '@respond/types/organization'
 import { headers } from 'next/headers';
 import ClientProviders, { SiteConfig } from './ClientProviders';
 import "./globals.css"
@@ -34,13 +35,14 @@ export default async function RootLayout({
   };
 
   const user = userFromAuth(await getCookieAuth());
-  const myOrg = (user && org) ? {
+  const myOrg: MyOrganization | undefined = (user && org) ? {
     id: org.id,
     rosterName: org.rosterName,
-    mouName: org.mouName,
     title: org.title,
     canCreateMissions: org.canCreateMissions,
     canCreateEvents: org.canCreateEvents,
+    memberProvider: org.memberProvider.provider,
+    supportEmail: org.supportEmail,
     partners: org.partners?.map(p => ({
       id: p.id,
       title: p.title,

--- a/src/lib/server/memberProviders/d4hMembersProvider.ts
+++ b/src/lib/server/memberProviders/d4hMembersProvider.ts
@@ -1,6 +1,6 @@
 import mongoPromise from '@respond/lib/server/mongodb';
 import { MemberAuthInfo, MemberInfo, MemberProvider } from "./memberProvider";
-import { D4HConfig, OrganizationDoc, ORGANIZATION_COLLECTION } from '@respond/types/data/organizationDoc';
+import { MemberProviderConfig, OrganizationDoc, ORGANIZATION_COLLECTION } from '@respond/types/data/organizationDoc';
 
 const D4H_MEMBER_REFRESH_SECS = 15 * 60;
 const D4H_FETCH_LIMIT = 250;
@@ -55,7 +55,7 @@ export default class D4HMembersProvider implements MemberProvider {
       throw new Error('Unknown Organization');
     }
 
-    const config = organization?.memberProvider as D4HConfig;
+    const config = organization?.memberProvider as MemberProviderConfig;
     if (!config || !config.token) {
       console.log("Could not find memberProvider config or D4H token for org " + organizationId);
       throw new Error("Invalid Configuration");

--- a/src/lib/server/memberProviders/memberProvider.ts
+++ b/src/lib/server/memberProviders/memberProvider.ts
@@ -1,3 +1,5 @@
+import { MemberProviderType } from '@respond/types/data/MemberProviderType'
+
 export interface MemberInfo {
   id: string;
   groups: string[];
@@ -18,7 +20,7 @@ export interface MemberProvider {
 export class MemberProviderRegistry {
   private lookup: {[key:string]: MemberProvider} = {};
 
-  register(key: string, provider: MemberProvider) {
+  register(key: MemberProviderType, provider: MemberProvider) {
     this.lookup[key] = provider;
   }
 

--- a/src/lib/server/services.ts
+++ b/src/lib/server/services.ts
@@ -3,6 +3,7 @@ import { MemberProviderRegistry } from './memberProviders/memberProvider';
 import D4HMembersProvider from './memberProviders/d4hMembersProvider';
 import SocketManager from './socketManager';
 import { StateManager } from './stateManager';
+import { MemberProviderType } from '@respond/types/data/MemberProviderType'
 
 export interface Services {
   authClient: OAuth2Client;
@@ -24,7 +25,7 @@ export async function getServices(): Promise<Services> {
     };
 
     //defaultMembersRepositoryRegistry.register('LocalDatabaseMembers', new LocalDatabaseMembersProvider(repo, this.log));
-    instance.memberProviders.register('D4HMembers', new D4HMembersProvider());
+    instance.memberProviders.register(MemberProviderType.D4H, new D4HMembersProvider());
 
     await instance.stateManager.start();
   }

--- a/src/types/data/MemberProviderType.ts
+++ b/src/types/data/MemberProviderType.ts
@@ -1,0 +1,7 @@
+export enum MemberProviderType {
+    D4H = "D4HMembers",
+}
+
+export const MemberProviderName: Record<MemberProviderType, string> = {
+    [MemberProviderType.D4H]: "D4H",
+}

--- a/src/types/data/organizationDoc.ts
+++ b/src/types/data/organizationDoc.ts
@@ -1,5 +1,7 @@
-export interface D4HConfig {
-  provider: 'd4hMembers',
+import { MemberProviderType } from './MemberProviderType'
+
+export interface MemberProviderConfig {
+  provider: MemberProviderType,
   token: string,
   moreEmailsField: 'Secondary Email',
 }
@@ -24,9 +26,10 @@ export interface OrganizationDoc {
     primary: string;
     primaryDark?: string;
   };
-  memberProvider: D4HConfig;
+  memberProvider: MemberProviderConfig;
   canCreateEvents: boolean;
   canCreateMissions: boolean;
+  supportEmail?: string;
   partners: OrganizationPartner[];
   tags?: {
     groupId: string;

--- a/src/types/organization.ts
+++ b/src/types/organization.ts
@@ -1,3 +1,5 @@
+import { MemberProviderType } from './data/MemberProviderType'
+
 export interface BaseOrganization {
   id: string;
   title: string;
@@ -8,4 +10,6 @@ export interface BaseOrganization {
 
 export interface MyOrganization extends BaseOrganization {
   partners: BaseOrganization[];
+  memberProvider: MemberProviderType;
+  supportEmail?: string;
 }


### PR DESCRIPTION
Adds support for error messages that are customized in two ways:

1. Adds support for a new, optional "supportEmail" field for organizations. This is used in error messaging to direct users how to get support.
2. Using the member provider's name in error messaging.

As a part of supporting the member provider's name, this PR enforces type safety for member provider types rather than using a bare string.

![image](https://github.com/KingCountySAR/respond-next/assets/126836598/5a8d7b29-4391-4ef7-99c2-b2708e96f377)
![image](https://github.com/KingCountySAR/respond-next/assets/126836598/034ee6a1-ea13-4053-a343-b830a6a66827)
![image](https://github.com/KingCountySAR/respond-next/assets/126836598/589050e5-d096-483a-87f1-d18560d5e48d)
