### PR TITLE
Support per-org favicon

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -50,14 +50,14 @@ export default async function RootLayout({
     })) ?? [],
   } : undefined;
 
-  const favicon = org?.brand.favicon;
-  const homeScreenIcon = org?.brand.homeScreenIcon;
+  const faviconUrl = org?.brand.faviconUrl;
+  const homeScreenIconUrl = org?.brand.homeScreenIconUrl;
 
   return (
     <html lang="en">
       <head>
-        { favicon && <link rel="icon" href={ favicon } /> }
-        { homeScreenIcon && <link rel="apple-touch-icon" href={ homeScreenIcon } /> }
+        { faviconUrl && <link rel="icon" href={ faviconUrl } /> }
+        { homeScreenIconUrl && <link rel="apple-touch-icon" href={ homeScreenIconUrl } /> }
       </head>
       <body id="root">
         <ClientOnly>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -50,9 +50,15 @@ export default async function RootLayout({
     })) ?? [],
   } : undefined;
 
+  const favicon = org?.brand.favicon;
+  const homeScreenIcon = org?.brand.homeScreenIcon;
+
   return (
     <html lang="en">
-      <head />
+      <head>
+        { favicon && <link rel="icon" href={ favicon } /> }
+        { homeScreenIcon && <link rel="apple-touch-icon" href={ homeScreenIcon } /> }
+      </head>
       <body id="root">
         <ClientOnly>
           <ClientProviders googleClient={process.env.GOOGLE_ID ?? ''} config={siteConfig} user={user} myOrg={myOrg}>

--- a/src/types/data/organizationDoc.ts
+++ b/src/types/data/organizationDoc.ts
@@ -23,6 +23,8 @@ export interface OrganizationDoc {
   brand: {
     primary: string;
     primaryDark?: string;
+    favicon?: string;
+    homeScreenIcon?: string;
   };
   memberProvider: D4HConfig;
   canCreateEvents: boolean;

--- a/src/types/data/organizationDoc.ts
+++ b/src/types/data/organizationDoc.ts
@@ -23,8 +23,8 @@ export interface OrganizationDoc {
   brand: {
     primary: string;
     primaryDark?: string;
-    favicon?: string;
-    homeScreenIcon?: string;
+    faviconUrl?: string;
+    homeScreenIconUrl?: string;
   };
   memberProvider: D4HConfig;
   canCreateEvents: boolean;


### PR DESCRIPTION
Adding support for an organization to define a favicon and home screen icon (for when the site is pinned to a home screen on mobile). There are no filesystem changes (e.g. adding images) as the intent is organizations will set the icon to match their publicly facing website (or an image file hosted there).

While the optimal home screen icon solution would require responding with a custom site manifest for Android, by my research it will happily fall back to apple-touch-icon if the site manifest isn't present. I'll come back and add support for the site manifest if this doesn't work well.