### PR TITLE
Change : Make OutputTextArea collapsible

### DIFF
--- a/src/app/(main)/EventPage.tsx
+++ b/src/app/(main)/EventPage.tsx
@@ -115,7 +115,7 @@ export const EventPage = ({ eventId }: { eventId: string }) => {
             <OutputTime label="End Time" time={activity.endTime}></OutputTime>
           </Box>
         </OutputForm>
-        <OutputTextArea label="Description" value={activity.description} maxHeight={3}></OutputTextArea>
+        <OutputTextArea label="Description" value={activity.description} rows={3}></OutputTextArea>
 
         <Box sx={{ my:2 }}>
           {isActivityActive && <StatusUpdater activity={activity} current={myParticipation?.timeline[0].status} />}

--- a/src/app/(main)/EventPage.tsx
+++ b/src/app/(main)/EventPage.tsx
@@ -115,7 +115,7 @@ export const EventPage = ({ eventId }: { eventId: string }) => {
             <OutputTime label="End Time" time={activity.endTime}></OutputTime>
           </Box>
         </OutputForm>
-        <OutputTextArea label="Description" value={activity.description}></OutputTextArea>
+        <OutputTextArea label="Description" value={activity.description} maxHeight={3}></OutputTextArea>
 
         <Box sx={{ my:2 }}>
           {isActivityActive && <StatusUpdater activity={activity} current={myParticipation?.timeline[0].status} />}

--- a/src/components/OutputForm.tsx
+++ b/src/components/OutputForm.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography, Grid, Button } from '@mui/material';
+import { Box, Typography, Grid } from '@mui/material';
 import React, { ReactNode } from 'react';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';

--- a/src/components/OutputForm.tsx
+++ b/src/components/OutputForm.tsx
@@ -1,9 +1,10 @@
-import { Grid } from '@mui/material';
+import { Box, Typography, Grid, Button } from '@mui/material';
 import React, { ReactNode } from 'react';
-import { Box, Typography } from '@mui/material';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { RelativeTimeText } from './RelativeTimeText';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 
 export const OutputForm = ({ children }: { children: ReactNode }) => {
 
@@ -25,7 +26,7 @@ export const OutputForm = ({ children }: { children: ReactNode }) => {
 
 }
 
-const OutputField = ({ label, multiline, children, }: { label: string, multiline?: boolean, children: React.ReactNode }) => {
+const OutputField = ({ label, multiline, children }: { label: string, multiline?: boolean, children: React.ReactNode }) => {
 
   const flexDirection = multiline ? 'column' : 'Row';
   const alignItems = multiline ? 'start' : 'center';
@@ -47,17 +48,43 @@ export const OutputText = ({ label, value }: { label: string, value?: string }) 
   );
 }
 
-export const OutputTextArea = ({ label, value }: { label: string, value?: string }) => {
+export const OutputTextArea = ({ label, value, maxHeight }: { label: string, value?: string, maxHeight?: number }) => {
+
+  let content = (value !== undefined) &&  (
+    value.split('\n').map((v,i) => {
+      if (v === '') {
+        return (<Typography key={i}><br /></Typography>)
+      }
+      return <Typography key={i} variant="body1">{v}</Typography>
+    })
+  )
+
+  const [collapse, setCollapse] = useState<boolean>(!!maxHeight);
+  const handleClick = () => {
+    if (!maxHeight) { return; }
+    setCollapse(!collapse);
+  }
+
+  let linesToShow = collapse && (Math.max(maxHeight ?? 0, 0) > 0) ? maxHeight : undefined;
+  let cursorStyle = maxHeight ? 'pointer' : 'default';
+
   return (
-    <OutputField label={label} multiline>
-      {(value !== undefined) &&  (value.split('\n').map((v,i) => {
-        if (v === '') {
-          return (<Typography key={i} sx={{ lineHeight: .5 }} ><br /></Typography>)
+      <OutputField label={label} multiline>
+        <div style={{ overflow: "hidden", maxHeight: linesToShow && `${linesToShow}lh`, cursor: cursorStyle }} onClick={handleClick} >
+          {content}
+        </div>
+        {maxHeight &&
+            <div onClick={handleClick} style={{ cursor: 'pointer' }}>
+              <Box sx={{ display: "flex", flexDirection: 'row', alignItems: 'center' }}>
+                <Typography variant='caption'>{collapse ? 'show more' : 'show less'}</Typography>
+                {collapse && <ExpandMoreIcon fontSize='small' />}
+                {!collapse && <ExpandLessIcon fontSize='small' />}
+              </Box>
+            </div>
         }
-        return <Typography key={i} variant="body1">{v}</Typography>
-      }))}
-    </OutputField>
+      </OutputField>
   );
+
 }
 
 export const OutputLink = ({ label, value, href, target }: { label: string, value?: string, href?: string, target?: '_blank' | '_parent' | '_self' | '_top' }) => {

--- a/src/components/OutputForm.tsx
+++ b/src/components/OutputForm.tsx
@@ -54,15 +54,15 @@ export const OutputText = ({ label, value }: { label: string, value?: string }) 
 export const OutputTextArea = ({ label, value, rows }: { label: string, value?: string, rows?: number }) => {
 
   const rowLimit = Math.max(rows ?? 0, 0);
-  const maxHeightPixels = DEFAULT_LINE_HEIGHT_PIXELS * rowLimit;
+  const collapsedHeightPixels = DEFAULT_LINE_HEIGHT_PIXELS * rowLimit;
 
   const contentElement = useRef<any>(null);
   const isCollapsible = useRef<boolean>(false);
 
   useEffect(() => {
-    isCollapsible.current = !!maxHeightPixels && maxHeightPixels < contentElement.current?.offsetHeight;
+    isCollapsible.current = !!collapsedHeightPixels && collapsedHeightPixels < contentElement.current?.offsetHeight;
     setCollapse(isCollapsible.current);
-  }, [maxHeightPixels]);
+  }, [collapsedHeightPixels]);
 
   const [collapse, setCollapse] = useState<boolean>(false);
   const handleClick = () => {

--- a/src/components/OutputForm.tsx
+++ b/src/components/OutputForm.tsx
@@ -42,15 +42,7 @@ const OutputField = ({ label, multiline, children }: { label: string, multiline?
 
 }
 
-export const OutputText = ({ label, value }: { label: string, value?: string }) => {
-  return (
-    <OutputField label={label}>
-      {(value !== undefined) && <Typography variant="body1">{value}</Typography>}
-    </OutputField>
-  );
-}
-
-export const OutputTextArea = ({ label, value, rows }: { label: string, value?: string, rows?: number }) => {
+const OutputShowMore = ({children, rows}: {children: ReactNode, rows?: number}) => {
 
   const rowLimit = Math.max(rows ?? 0, 0);
   const collapsedHeightPixels = DEFAULT_LINE_HEIGHT_PIXELS * rowLimit;
@@ -72,34 +64,48 @@ export const OutputTextArea = ({ label, value, rows }: { label: string, value?: 
   let linesToShow = collapse && rowLimit ? rowLimit : undefined;
   let cursorStyle = isCollapsible.current ? 'pointer' : 'default';
 
-  const content = (value !== undefined) &&  (
-    value.split('\n').map((v,i) => {
-      if (v === '') {
-        return (<Typography key={i}><br /></Typography>)
-      }
-      return <Typography key={i} variant="body1">{v}</Typography>
-    })
-  )
-
-  const showMoreButton = isCollapsible.current && (
-    <div onClick={handleClick} style={{ cursor: 'pointer' }}>
-      <Box sx={{ display: "flex", flexDirection: 'row', alignItems: 'center' }}>
-        <Typography variant='caption'>{collapse ? 'show more' : 'show less'}</Typography>
-        {collapse && <ExpandMoreIcon fontSize='small' />}
-        {!collapse && <ExpandLessIcon fontSize='small' />}
-      </Box>
-    </div>
-  )
-
   return (
-      <OutputField label={label} multiline>
-        <div style={{ overflow: "hidden", maxHeight: linesToShow && `${linesToShow}lh`, cursor: cursorStyle }} onClick={handleClick} ref={contentElement}>
-          {content}
+    <>
+      <div style={{ overflow: "hidden", maxHeight: linesToShow && `${linesToShow}lh`, cursor: cursorStyle }} onClick={handleClick} ref={contentElement}>
+        {children}
+      </div>
+      {isCollapsible.current && (
+        <div onClick={handleClick} style={{ cursor: 'pointer' }}>
+          <Box sx={{ display: "flex", flexDirection: 'row', alignItems: 'center' }}>
+            <Typography variant='caption'>{collapse ? 'show more' : 'show less'}</Typography>
+            {collapse && <ExpandMoreIcon fontSize='small' />}
+            {!collapse && <ExpandLessIcon fontSize='small' />}
+          </Box>
         </div>
-        {showMoreButton}
-      </OutputField>
+      )}
+    </>
   );
 
+}
+
+export const OutputText = ({ label, value }: { label: string, value?: string }) => {
+  return (
+    <OutputField label={label}>
+      {(value !== undefined) && <Typography variant="body1">{value}</Typography>}
+    </OutputField>
+  );
+}
+
+export const OutputTextArea = ({ label, value, rows }: { label: string, value?: string, rows?: number }) => {
+  return (
+    <OutputField label={label} multiline>
+      <OutputShowMore rows={rows}>
+        {(value !== undefined) && (
+          value.split('\n').map((v,i) => {
+            if (v === '') {
+              return (<Typography key={i}><br /></Typography>)
+            }
+            return <Typography key={i} variant="body1">{v}</Typography>
+          })
+        )}
+      </OutputShowMore>
+    </OutputField>
+  );
 }
 
 export const OutputLink = ({ label, value, href, target }: { label: string, value?: string, href?: string, target?: '_blank' | '_parent' | '_self' | '_top' }) => {

--- a/src/components/OutputForm.tsx
+++ b/src/components/OutputForm.tsx
@@ -48,9 +48,9 @@ export const OutputText = ({ label, value }: { label: string, value?: string }) 
   );
 }
 
-export const OutputTextArea = ({ label, value, maxHeight }: { label: string, value?: string, maxHeight?: number }) => {
+export const OutputTextArea = ({ label, value, rows }: { label: string, value?: string, rows?: number }) => {
 
-  let content = (value !== undefined) &&  (
+  const content = (value !== undefined) &&  (
     value.split('\n').map((v,i) => {
       if (v === '') {
         return (<Typography key={i}><br /></Typography>)
@@ -59,21 +59,21 @@ export const OutputTextArea = ({ label, value, maxHeight }: { label: string, val
     })
   )
 
-  const [collapse, setCollapse] = useState<boolean>(!!maxHeight);
+  const [collapse, setCollapse] = useState<boolean>(!!rows);
   const handleClick = () => {
-    if (!maxHeight) { return; }
+    if (!rows) { return; }
     setCollapse(!collapse);
   }
 
-  let linesToShow = collapse && (Math.max(maxHeight ?? 0, 0) > 0) ? maxHeight : undefined;
-  let cursorStyle = maxHeight ? 'pointer' : 'default';
+  let linesToShow = collapse && (Math.max(rows ?? 0, 0) > 0) ? rows : undefined;
+  let cursorStyle = rows ? 'pointer' : 'default';
 
   return (
       <OutputField label={label} multiline>
         <div style={{ overflow: "hidden", maxHeight: linesToShow && `${linesToShow}lh`, cursor: cursorStyle }} onClick={handleClick} >
           {content}
         </div>
-        {maxHeight &&
+        {rows &&
             <div onClick={handleClick} style={{ cursor: 'pointer' }}>
               <Box sx={{ display: "flex", flexDirection: 'row', alignItems: 'center' }}>
                 <Typography variant='caption'>{collapse ? 'show more' : 'show less'}</Typography>

--- a/src/components/OutputForm.tsx
+++ b/src/components/OutputForm.tsx
@@ -5,7 +5,6 @@ import { useEffect, useState, useRef } from 'react';
 import { RelativeTimeText } from './RelativeTimeText';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
-import { ContactEmergency } from '@mui/icons-material';
 
 const DEFAULT_LINE_HEIGHT_PIXELS = 24;
 


### PR DESCRIPTION
Added a `maxHeight` prop on OutputTextArea
- When `maxHeight` is `undefined`, renders the full text.
- When `maxHeight` is set, the max height of the field is limited
  - A show more/show less button appears. Clicking toggles the full text.
  - Clicking anywhere on the body of the field also toggles the full text.
- I had to revert the line height of empty lines to 1 to avoid rendering half-lines.

Collapsed
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/7e53ca33-459f-44d0-a7c6-df6d79ccc4d3)

Expanded:
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/8df6ea92-fcb9-45cb-aab5-155282beb9a8)
