### PR TITLE
Change In Town status color for better contrast, add min-height on rows.

### DIFF
--- a/src/app/(main)/EventPage.module.css
+++ b/src/app/(main)/EventPage.module.css
@@ -1,5 +1,6 @@
 .rosterNameCell {
   font-weight: bold;
+  min-height: 2.5lh !important;
 }
 
 div.roster :global(div.MuiDataGrid-cell):focus {
@@ -21,5 +22,5 @@ div.roster :global(div.MuiDataGrid-cell):focus {
 }
 
 .roster :global(.roster-status-Remote) {
-  background-color: blue;
+  background-color: turquoise;
 }


### PR DESCRIPTION
- Increased row height
- Changed In Town Status Indicator Color
  - During the mission yesterday, I noticed the blue did not have very good contrast next to green. trying a lighter hue.

![image](https://github.com/KingCountySAR/respond-next/assets/11284884/24d3817e-b5f0-41c9-8bd2-fe71ee1098e0)
