### PR TITLE
Change : UI Declutter, Show Relevant Data Based on Mission Status

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -6,7 +6,7 @@ import { Box, Button, Stack, Typography, Chip } from "@mui/material";
 //import styles from './page.module.css';
 import { useAppSelector } from '@respond/lib/client/store';
 import { canCreateEvents, canCreateMissions } from '@respond/lib/client/store/organization';
-import { buildActivityTypeSelector, buildMyActivitySelector, getActiveParticipants, getActivityStatus, isActive, isComplete } from '@respond/lib/client/store/activities';
+import { buildActivityTypeSelector, buildMyActivitySelector, getActiveParticipants, getActivityStatus, isActive, isClosed } from '@respond/lib/client/store/activities';
 import { useEffect } from 'react';
 import { Activity, isActive as isResponderStatusActive, ParticipatingOrg } from '@respond/types/activity';
 import addDays from 'date-fns/addDays'
@@ -22,7 +22,7 @@ function filterActivitiesForDisplay(activities: Activity[], maxCompletedVisible:
 
   const active = activities.filter(isActive).sort(sort);
   const complete = activities
-    .filter(a => isComplete(a) && a.startTime > oldestVisible)
+    .filter(a => isClosed(a) && a.startTime > oldestVisible)
     .sort(sort)
     .slice(0, maxCompletedVisible);
 

--- a/src/components/ActivityTabs.tsx
+++ b/src/components/ActivityTabs.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+
+import { Tab, Tabs, Box, Typography } from "@mui/material";
+
+import { Roster } from '@respond/app/(main)/EventPage';
+import { Activity, Participant, ResponderStatus } from '@respond/types/activity';
+import { OutputForm, OutputLink, OutputText, OutputTime } from './OutputForm';
+import { getActivityStatus } from '@respond/lib/client/store/activities';
+import { isActive, reduceDemobilized, reduceSignedOut } from '@respond/types/participant';
+
+interface TabPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+}
+
+function CustomTabPanel(props: TabPanelProps) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`simple-tabpanel-${index}`}
+      aria-labelledby={`simple-tab-${index}`}
+      {...other}
+    >
+      {value === index && (
+        <Box sx={{ pt: 2 }}>
+          {children}
+        </Box>
+      )}
+    </div>
+  );
+}
+
+function a11yProps(index: number) {
+  return {
+    id: `simple-tab-${index}`,
+    'aria-controls': `simple-tabpanel-${index}`,
+  };
+}
+
+const reduceActive = (count: number, participant: Participant) => {
+  return count + (isActive(participant?.timeline[0].status) ? 1 : 0);
+}
+
+const reduceStandby = (count: number, participant: Participant) => {
+  return count + (participant?.timeline[0].status === ResponderStatus.Standby ? 1 : 0);
+}
+
+const reduceSignedIn = (count: number, participant: Participant) => {
+  return count + (participant?.timeline[0].status === ResponderStatus.SignedIn ? 1 : 0);
+}
+
+const reduceCheckedIn = (count: number, participant: Participant) => {
+  return count + (isActive(participant?.timeline[0].status) ? 1 : 0);
+}
+
+export default function ActivityTabs({activity}:{activity: Activity}) {
+  const [value, setValue] = React.useState(0);
+
+  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+    setValue(newValue);
+  };
+
+  return (
+    <Box sx={{ width: '100%' }}>
+      
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <Tabs value={value} onChange={handleChange} aria-label="basic tabs example">
+          <Tab label="Roster" {...a11yProps(0)} />
+          <Tab label="Detail" {...a11yProps(1)} />
+        </Tabs>
+      </Box>
+
+      <CustomTabPanel value={value} index={0}>
+        <Roster participants={activity.participants} orgs={activity.organizations} startTime={activity.startTime} />
+      </CustomTabPanel>
+
+      <CustomTabPanel value={value} index={1}>
+
+        <Box sx={{ mb: 2, pt: 2 }}>
+          <OutputForm>
+            <Box>
+              <Typography variant='h6' sx={{ color: 'text.secondary'}}>Overview</Typography>
+            </Box>
+            <Box>
+              <OutputText label="Mission Status" value={getActivityStatus(activity)} />
+              <OutputTime label="Start Time" time={activity.startTime}></OutputTime>
+              <OutputTime label="Complete Time" time={activity.completeTime}></OutputTime>
+              <OutputTime label="End Time" time={activity.endTime}></OutputTime>
+            </Box>
+          </OutputForm>
+        </Box>
+        
+        <Box sx={{ mb: 2, pt: 2 }}>
+          <OutputForm>
+            <Box>
+              <Typography variant='h6' sx={{ color: 'text.secondary'}}>Responders</Typography>
+            </Box>
+            <Box>
+              <OutputText label="Active Responders" value={Object.values(activity.participants).reduce(reduceActive, 0).toString()}></OutputText>
+              <OutputText label="Standby" value={Object.values(activity.participants).reduce(reduceStandby, 0).toString()}></OutputText>
+              <OutputText label="Responding" value={Object.values(activity.participants).reduce(reduceSignedIn, 0).toString()}></OutputText>
+              <OutputText label="Checked-In" value={Object.values(activity.participants).reduce(reduceCheckedIn, 0).toString()}></OutputText>
+              <OutputText label="Demobilized" value={Object.values(activity.participants).reduce(reduceDemobilized, 0).toString()}></OutputText>
+              <OutputText label="Signed Out" value={Object.values(activity.participants).reduce(reduceSignedOut, 0).toString()}></OutputText>
+            </Box>
+          </OutputForm>
+        </Box>
+
+        <Box sx={{ pt: 2 }}>
+          <OutputForm>
+            <Box>
+              <Typography variant='h6' sx={{ color: 'text.secondary'}}>Responsible Agency</Typography>
+            </Box>
+            <Box>
+              <OutputText label="Agency" value={activity.organizations[activity.ownerOrgId]?.title} />
+            </Box>
+          </OutputForm>
+        </Box>
+
+      </CustomTabPanel>
+
+    </Box>
+  );
+}

--- a/src/lib/client/store/activities.ts
+++ b/src/lib/client/store/activities.ts
@@ -22,6 +22,7 @@ const activitiesSlice = createSlice({
       .addCase(ActivityActions.update, BasicReducers[ActivityActions.update.type])
       .addCase(ActivityActions.remove, BasicReducers[ActivityActions.remove.type])
       .addCase(ActivityActions.reactivate, BasicReducers[ActivityActions.reactivate.type])
+      .addCase(ActivityActions.closed, BasicReducers[ActivityActions.closed.type])
       .addCase(ActivityActions.complete, BasicReducers[ActivityActions.complete.type])
       .addCase(ActivityActions.appendOrganizationTimeline, BasicReducers[ActivityActions.appendOrganizationTimeline.type])
       .addCase(ActivityActions.participantUpdate, BasicReducers[ActivityActions.participantUpdate.type])
@@ -81,27 +82,32 @@ export function isFuture(time: number) {
 };
 
 export function isPending(a: Activity) {
-  return isActive(a) && !isOpen(a);
+  return isActive(a) && isFuture(a.startTime - earlySigninWindow);
 }
 
 export function isOpen(a: Activity) {
-  return isActive(a) && !isFuture(a.startTime - earlySigninWindow);
+  return isActive(a) && !isFuture(a.startTime - earlySigninWindow) && isFuture(a.startTime);
 }
 
 export function isStarted(a: Activity) {
-  return isActive(a) && !isFuture(a.startTime);
-}
-
-export function isActive(a: Activity) {
-  return !isComplete(a);
+  return isActive(a) && !isFuture(a.startTime) && !isComplete(a);
 }
 
 export function isComplete(a: Activity) {
+  return isActive(a) && !!a.completeTime;
+}
+
+export function isActive(a: Activity) {
+  return !isClosed(a);
+}
+
+export function isClosed(a: Activity) {
   return !!a.endTime;
 }
 
 export function getActivityStatus(a: Activity) {
-  if (isComplete(a)) { return 'Closed' }
+  if (isClosed(a)) { return 'Closed' }
+  if (isComplete(a)) { return 'Complete' }
   if (isStarted(a)) { return 'In Progress' }
   if (isOpen(a)) { return 'Open For Sign In' }
   if (isPending(a)) { return 'Not Started' }

--- a/src/lib/state/activityActions.ts
+++ b/src/lib/state/activityActions.ts
@@ -22,7 +22,12 @@ const reactivate = createAction('activity/reactivate', (activityId: string) => (
   meta: { sync: true },
 }));
 
-const complete = createAction('activity/complete', (activityId: string, endTime: number) => ({
+const complete = createAction('activity/complete', (activityId: string, completeTime: number) => ({
+  payload: { id: activityId, completeTime },
+  meta: { sync: true },
+}));
+
+const closed = createAction('activity/closed', (activityId: string, endTime: number) => ({
   payload: { id: activityId, endTime },
   meta: { sync: true },
 }));
@@ -76,6 +81,7 @@ export const ActivityActions = {
   remove,
   reactivate,
   complete,
+  closed,
   appendOrganizationTimeline,
   participantUpdate,
   tagParticipant,

--- a/src/lib/state/activityReducers.ts
+++ b/src/lib/state/activityReducers.ts
@@ -28,11 +28,19 @@ export const BasicReducers: ActivityReducers = {
   [ActivityActions.reactivate.type]: (state, { payload }) => {
     const activity = state.list.find(f => f.id === payload.id);
     if (activity) {
+      activity.completeTime = undefined;
       activity.endTime = undefined;
     }
   },
 
   [ActivityActions.complete.type]: (state, { payload }) => {
+    const activity = state.list.find(f => f.id === payload.id);
+    if (activity) {
+      activity.completeTime = payload.completeTime;
+    }
+  },
+
+  [ActivityActions.closed.type]: (state, { payload }) => {
     const activity = state.list.find(f => f.id === payload.id);
     if (activity) {
       // First set the end time

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -91,6 +91,7 @@ export interface Activity {
   isMission: boolean;
   asMission: boolean;
   startTime: number;
+  completeTime?: number;
   endTime?: number;
 
   participants: Record<string, Participant>;

--- a/src/types/participant.ts
+++ b/src/types/participant.ts
@@ -1,0 +1,43 @@
+import { Participant, ResponderStatus } from './activity';
+
+export function isActive(status: ResponderStatus) {
+  return [
+    ResponderStatus.Standby,
+    ResponderStatus.Remote,
+    ResponderStatus.SignedIn,
+    ResponderStatus.Available,
+    ResponderStatus.Assigned,
+    ResponderStatus.Demobilized
+  ].includes(status);
+}
+
+export function isCheckedIn(status: ResponderStatus) {
+  return [
+    ResponderStatus.Available,
+    ResponderStatus.Assigned
+  ].includes(status);
+}
+
+export const reduceActive = (count: number, participant: Participant) => {
+  return count + (isActive(participant?.timeline[0].status) ? 1 : 0);
+}
+
+export const reduceStandby = (count: number, participant: Participant) => {
+  return count + (participant?.timeline[0].status === ResponderStatus.Standby ? 1 : 0);
+}
+
+export const reduceSignedIn = (count: number, participant: Participant) => {
+  return count + (participant?.timeline[0].status === ResponderStatus.SignedIn ? 1 : 0);
+}
+
+export const reduceCheckedIn = (count: number, participant: Participant) => {
+  return count + (isCheckedIn(participant?.timeline[0].status) ? 1 : 0);
+}
+
+export const reduceDemobilized = (count: number, participant: Participant) => {
+  return count + (participant?.timeline[0].status === ResponderStatus.Demobilized ? 1 : 0);
+}
+
+export const reduceSignedOut = (count: number, participant: Participant) => {
+  return count + (participant?.timeline[0].status === ResponderStatus.SignedOut ? 1 : 0);
+}


### PR DESCRIPTION
**We can merge this if we like it, but for now I just put it together to help drive the UI discussion.**

### Added "Complete" to Mission Status Progression

- Added: `activity.completeTime`

I have re-defined "Complete" from a functional standpoint; there is no change to the underlying data structure. "Complete" now means `completeTime` is set; `endTime` is set now indicates "Closed". 

Differentiating between Complete and Closed provides granularity needed for contextual UI rendering based on Mission Status.

Pending -> Open (for sign in) -> Started -> **Complete** -> Closed

The Mission Status Button on EventPage has been updated to implement revised render sequencing.

- Clicking "Complete" sets the `completeTime`, the button updates to "Close".
- Clicking "Close" sets the `endTime`, the button updates to "Reactivate".
- Clicking "Reactivated" clears `completeTime` and `endTime`, the button updates to "Complete"

### Added Contextual Fields Based on Mission Status Progression

The Mission Details in the top section of the page are dependent on the Mission Status:

- **Pending ("Not Started")**: The Mission Start Time and Standby Responder Count are Shown.
- **Open(for sign in) and In Progress**: The Signed In (enroute) responder Count and Checked In (arrived at base) Responder Count are shown.
- **Complete**: The Demobilized (departed base, turned around) Responder Count and Active (Not Signed Out) Responder Count are Shown.
- **Closed**: No Responder Counts are shown

### Implemented Tabs and Moved Extra Data Fields to the "Detail" tab.

- The "Roster Tab is visible by default.
- The "Data Tab" has full Responder Count Data and other, less important mission details.

### Other UI Tweaks

- Changed the Description to only show the first line, clicking on it expands to toggle the full text.
- Changed the Positioning of the StatusUpdater on larger screens ( moved off to the right, inline with org chips.)
- Removed unnecessary labelling like "Roster:" and "Participating Organizations;"

### Pending Mission
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/fe0f686f-c928-4c90-a280-219476ea4479)

### Open (for sign in) Mission
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/58510d18-6b07-44fa-97c2-fea97a33c38a)

### In Progress Mission
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/31f51cc8-3d5b-4524-973a-77f13218ec61)

### Completed Mission
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/8e7ad81d-3dc9-4548-bb71-c0702e08434f)

### Closed Mission
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/66f5a73a-9ac4-4f6b-9ef9-4b8c410139d8)

### Mobile
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/a8974970-8d9c-4a3e-8a85-c0ba17ee3d3d)

### Detail Tab
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/81564227-ca88-4203-82ae-afe397365807)




