### PR TITLE
Responders should be able to add their unit to participating orgs.

### DIFF
--- a/src/components/Material.tsx
+++ b/src/components/Material.tsx
@@ -1,5 +1,6 @@
 // Importing from the inner files is supposed to help compile time / tree shaking.
 
+export { default as Alert } from '@mui/material/Alert';
 export { default as Box } from '@mui/material/Box';
 export { default as Button } from '@mui/material/Button';
 export { default as Dialog } from '@mui/material/Dialog';

--- a/src/components/StatusUpdater/index.tsx
+++ b/src/components/StatusUpdater/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle  } from '../Material';
+import { Alert, Button, Dialog, DialogActions, DialogContent, DialogTitle  } from '../Material';
 import { useAppSelector } from '@respond/lib/client/store';
 import { Activity, ResponderStatus } from '@respond/types/activity';
 import { MyOrganization } from '@respond/types/organization';
@@ -77,7 +77,7 @@ const StatusUpdaterProtected = ({activity, current, user, thisOrg}: {activity: A
   const formLogic = useFormLogic(
     activity,
     user,
-    thisOrg.id,
+    thisOrg,
     activity.participants[user.participantId],
     current,
     confirmStatus,
@@ -110,7 +110,10 @@ const StatusUpdaterProtected = ({activity, current, user, thisOrg}: {activity: A
         <form onSubmit={formLogic.doSubmit}>
           <DialogTitle id="status-update-dialog-title">{confirmTitle}</DialogTitle>
           <DialogContent>
-            <UpdateStatusForm form={formLogic} />
+            <>
+              {!activity.organizations[thisOrg.id] && (<Alert sx={{mb: 1}} severity="warning">You are the first responder for {thisOrg.rosterName}. Make sure you are authorized to commit {thisOrg.rosterName} to this {activity.isMission ? 'mission' : 'event'}.</Alert>)}
+              <UpdateStatusForm form={formLogic} />
+            </>
           </DialogContent>
           <DialogActions>
             <Button onClick={() => setConfirming(false)}>Cancel</Button>


### PR DESCRIPTION
If a user is signing in with an organization that's not in the list of responding units, add the organization to the list.