### PR TITLE
Add pages that list all missions/events

### DIFF
--- a/src/app/(main)/EventListPage.tsx
+++ b/src/app/(main)/EventListPage.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { Box, Button, Stack, Typography, Chip } from "@mui/material";
+
+import { Activity, ActivityType } from '@respond/types/activity';
+import { buildActivityTypeSelector, buildMyActivitySelector, getActiveParticipants, getActivityStatus, isActive, isComplete, isFuture } from '@respond/lib/client/store/activities';
+import { EventTile } from './EventTile';
+import { OutputForm, OutputText, OutputTime } from '@respond/components/OutputForm';
+import { apiFetch } from '@respond/lib/api';
+
+export const EventListPage = ({activityType }: { activityType: ActivityType }) => {
+  const [ loading, setLoading ] = React.useState<boolean>(true);
+  const [ activities, setActivities ] = React.useState<Activity[]>([]);
+
+  React.useEffect(() => {
+    apiFetch<{ data: Activity[] }>(`/api/v1/${activityType}`).then(api => {
+      setLoading(false);
+      setActivities(api.data);
+    });
+  }, [activityType]);
+
+  return (
+    <main>
+      <Box sx={{ pb: 4 }}>
+        <Box sx={{mb:1, display:'flex', justifyContent:'space-between', alignItems:'center'}}>
+          <Typography variant="h5">{ activityType === 'missions' ? 'Mission List' : 'Event List'}</Typography>
+        </Box>
+        {loading
+        ? (<main><Typography>Loading ...</Typography></main>)
+        : (
+          <Stack spacing={1}>
+            {activities.map(a => (
+              <EventTile key={a.id} activity={a}>
+                <OutputForm>
+                  <Box>
+                    <OutputText label="Location" value={a.location.title} />
+                    <OutputText label="State #" value={a.idNumber} />
+                  </Box>
+                  <Box>
+                    <OutputText label="Mission Status" value={getActivityStatus(a)} />
+                    {isFuture(a.startTime) && <OutputTime label="Start Time" time={a.startTime}></OutputTime>}
+                    <OutputText label="Active Participants" value={getActiveParticipants(a).length.toString()} />
+                  </Box>
+                </OutputForm>
+              </EventTile>
+            ))}
+          </Stack>
+        )}
+      </Box>
+    </main>
+  )
+}

--- a/src/app/(main)/event/page.tsx
+++ b/src/app/(main)/event/page.tsx
@@ -1,0 +1,6 @@
+'use client';
+import { EventListPage } from '../EventListPage';
+
+export default function MissionList() {
+  return (<EventListPage activityType='events' />);
+}

--- a/src/app/(main)/mission/page.tsx
+++ b/src/app/(main)/mission/page.tsx
@@ -1,0 +1,6 @@
+'use client';
+import { EventListPage } from '../EventListPage';
+
+export default function MissionList() {
+  return (<EventListPage activityType='missions' />);
+}

--- a/src/app/api/v1/(activities)/events/route.ts
+++ b/src/app/api/v1/(activities)/events/route.ts
@@ -1,0 +1,5 @@
+import { getActivitiesList } from '../listActivities';
+
+export function GET(request: Request) {
+  return getActivitiesList('events', request);
+}

--- a/src/app/api/v1/(activities)/listActivities.ts
+++ b/src/app/api/v1/(activities)/listActivities.ts
@@ -1,0 +1,21 @@
+import { getCookieAuth, userFromAuth } from '@respond/lib/server/auth';
+import { NextResponse } from 'next/server';
+
+import mongoPromise from '@respond/lib/server/mongodb';
+import { getServices } from '@respond/lib/server/services';
+import { ActivityType } from '@respond/types/activity';
+
+export async function getActivitiesList(activityType: ActivityType, request: Request) {
+  const user = userFromAuth(await getCookieAuth());
+  if (user == null) {
+    return NextResponse.json({ status: 'not authenticated' }, { status: 401 });
+  }
+
+  const mongo = await mongoPromise;
+
+  const list = (await (await getServices()).stateManager.getAllActivities())
+  .filter(a => a.isMission === (activityType === 'missions'))
+  .sort((a,b) => (a.startTime > b.startTime) ? 1 : (a.startTime < b.startTime) ? -1 : 0);
+
+  return NextResponse.json({ status: 'ok', data: list });
+}

--- a/src/app/api/v1/(activities)/missions/route.ts
+++ b/src/app/api/v1/(activities)/missions/route.ts
@@ -1,0 +1,5 @@
+import { getActivitiesList } from '../listActivities';
+
+export function GET(request: Request) {
+  return getActivitiesList('missions', request);
+}


### PR DESCRIPTION
Add a simple view that includes all activities (missions or events). Intended to be low-cost initial implementation. Does not add links from existing UI into these pages, the user needs to type the page address (https://respond.team.org/mission or https://respond.team.org/event) into their browser.