### PR TITLE
Try different viewport setting to avoid zoomed-in view on navigation

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import "./globals.css"
 export const metadata = {
   title: 'Respond Site',
   description: 'Respond to search and rescue activities',
+  viewport: 'width=device-width, initial-scale=1, maximum-scale=1',
 }
 
 export default async function RootLayout({


### PR DESCRIPTION
The site will currently change viewport zoom while navigating the app. Try a more restrictive viewport setting to try to stop this from happening.