### PR TITLE
Force line endings to LF, even on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
-* text=auto eol=lf
+# Windows users: please set autocrlf to *false* for this repository for correct behavior. Do not set it here.
+#
+# From the command line inside this repo run: git config core.autocrlf false

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 - [Node.js] (https://nodejs.org/en) 16.x or higher
 - [Yarn](https://yarnpkg.com)
 
+**Windows users**:
+- Ensure git's `autocrlf` setting is set to `false` for this repository. If it's not, Git will checkout the files with CRLF line endings and the linter will throw errors.
+- If your global setting is already `false` you have nothing to do.
+- To view your current setting in the terminal, run the following command from within this repository: `git config core.autocrlf`
+- To set `autocrlf` for this repository only (global unchanged) run the following command from within this repository: `git config core.autocrlf false`
+
 ### Create dev database
 Development is supported on either a local or remote MongoDB server.
 - For a local installation, it's recommended to install the [Community Server](https://www.mongodb.com/try/download/community) and [Compass UI](https://www.mongodb.com/try/download/compass).


### PR DESCRIPTION
Git on Windows defaults check out files with CRLF line endings and push them with LF line endings for consistency with other platforms. This generally works, but our linter is exclusively looking for LF endings. This means it's impossible to run the linter locally on Windows with the default Git behavior.

This changes the Git setting for this repository to, for all files, force Git to check out with LF line endings, guaranteeing compatibility with our linter for those on Windows. It requires no intervention from the user, meaning their global setting can stay untouched.