### PR TITLE
Roster Filter

### DIFF
--- a/src/components/OrganizationChip.tsx
+++ b/src/components/OrganizationChip.tsx
@@ -5,14 +5,20 @@ import { Activity, isActive as isParticipantStatusActive, OrganizationStatus, Pa
 
 function getOrgParticipantCount(activity: Activity, org: ParticipatingOrg) {
   const count = Object.values(activity.participants).filter((p) => isParticipantStatusActive(p.timeline[0].status) && p.organizationId === org.id).length;
-  return count ? count : '';
+  return count ? count : 0;
 }
 
-export const OrganizationChip = ({ org, activity, selected = false, onClick = undefined }: { org: ParticipatingOrg; activity: Activity; selected?: boolean; onClick?: MouseEventHandler<HTMLDivElement> }) => {
+export const OrganizationChip = ({ org, activity, selected = false, isClickable = undefined, onClick = undefined }: { org: ParticipatingOrg; activity: Activity; selected?: boolean; isClickable?: (participantCount: number) => boolean; onClick?: MouseEventHandler<HTMLDivElement> }) => {
   const participantCount = getOrgParticipantCount(activity, org);
+  const participantCountText = participantCount == 0 ? '' : participantCount;
 
   const status = org.timeline[0]?.status;
   const color = status === OrganizationStatus.Responding ? 'success' : status === OrganizationStatus.Standby ? 'warning' : 'default';
 
-  return <Chip size="small" sx={{ mr: 1 }} label={`${org.rosterName ?? org.title} ${participantCount}`} color={color} variant={selected ? 'filled' : 'outlined'} onClick={onClick} />;
+  // If isClickable isn't provided, assume it is clickable.
+  if (isClickable && !isClickable(participantCount)) {
+    onClick = undefined;
+  }
+
+  return <Chip size="small" sx={{ mr: 1 }} label={`${org.rosterName ?? org.title} ${participantCountText}`} color={color} variant={selected ? 'filled' : 'outlined'} onClick={onClick} />;
 };

--- a/src/components/OrganizationChip.tsx
+++ b/src/components/OrganizationChip.tsx
@@ -1,4 +1,5 @@
 import { Chip } from '@mui/material';
+import { MouseEventHandler } from 'react';
 
 import { Activity, isActive as isParticipantStatusActive, OrganizationStatus, ParticipatingOrg } from '@respond/types/activity';
 
@@ -7,11 +8,11 @@ function getOrgParticipantCount(activity: Activity, org: ParticipatingOrg) {
   return count ? count : '';
 }
 
-export const OrganizationChip = ({ org, activity }: { org: ParticipatingOrg; activity: Activity }) => {
+export const OrganizationChip = ({ org, activity, selected = false, onClick = undefined }: { org: ParticipatingOrg; activity: Activity; selected?: boolean; onClick?: MouseEventHandler<HTMLDivElement> }) => {
   const participantCount = getOrgParticipantCount(activity, org);
 
   const status = org.timeline[0]?.status;
   const color = status === OrganizationStatus.Responding ? 'success' : status === OrganizationStatus.Standby ? 'warning' : 'default';
 
-  return <Chip size="small" sx={{ mr: 1 }} label={`${org.rosterName ?? org.title} ${participantCount}`} color={color} variant="outlined" />;
+  return <Chip size="small" sx={{ mr: 1 }} label={`${org.rosterName ?? org.title} ${participantCount}`} color={color} variant={selected ? 'filled' : 'outlined'} onClick={onClick} />;
 };

--- a/src/components/activities/ActivityPage.tsx
+++ b/src/components/activities/ActivityPage.tsx
@@ -17,7 +17,7 @@ import { isActive as isParticpantActive, isCheckedIn as isParticpantCheckedIn, P
 
 import styles from './ActivityPage.module.css';
 
-const Roster = ({ participants, orgs, startTime }: { participants: Record<string, Participant>; orgs: Record<string, ParticipatingOrg>; startTime: number }) => {
+const Roster = ({ participants, orgs, orgFilter, startTime }: { participants: Record<string, Participant>; orgs: Record<string, ParticipatingOrg>; orgFilter: string; startTime: number }) => {
   const _startTime = startTime;
   const handleRowClick: GridEventListener<'rowClick'> = (
     _params, // GridRowParams
@@ -29,6 +29,7 @@ const Roster = ({ participants, orgs, startTime }: { participants: Record<string
 
   const rows: GridRowsProp = Object.values(participants)
     .filter((f) => f.timeline[0].status !== ParticipantStatus.NotResponding)
+    .filter((f) => (orgFilter ? f.organizationId == orgFilter : true))
     .map((f) => ({
       ...f,
       orgName: orgs[f.organizationId]?.rosterName ?? orgs[f.organizationId]?.title,
@@ -90,6 +91,7 @@ export const ActivityPage = ({ activityId }: { activityId: string }) => {
 
   const [promptingRemove, setPromptingRemove] = useState<boolean>(false);
   const [promptingActivityState, setPromptingActivityState] = useState<boolean>(false);
+  const [rosterOrgFilter, setRosterOrgFilter] = useState<string>('');
 
   useEffect(() => {
     document.title = `${activity?.idNumber} ${activity?.title}`;
@@ -168,14 +170,14 @@ export const ActivityPage = ({ activityId }: { activityId: string }) => {
           <Typography>Participating Organizations:</Typography>
           <Box sx={{ my: 2 }}>
             {Object.entries(activity.organizations ?? {}).map(([id, org]) => (
-              <OrganizationChip key={id} org={org} activity={activity} />
+              <OrganizationChip key={id} org={org} activity={activity} selected={rosterOrgFilter == id} onClick={() => (rosterOrgFilter == id ? setRosterOrgFilter('') : setRosterOrgFilter(id))} />
             ))}
           </Box>
         </Box>
 
         <Box>
           <Typography>Roster:</Typography>
-          <Roster participants={activity.participants} orgs={activity.organizations} startTime={activity.startTime} />
+          <Roster participants={activity.participants} orgs={activity.organizations} orgFilter={rosterOrgFilter} startTime={activity.startTime} />
         </Box>
 
         <Dialog open={promptingRemove} onClose={() => setPromptingRemove(false)}>

--- a/src/components/activities/ActivityPage.tsx
+++ b/src/components/activities/ActivityPage.tsx
@@ -170,7 +170,7 @@ export const ActivityPage = ({ activityId }: { activityId: string }) => {
           <Typography>Participating Organizations:</Typography>
           <Box sx={{ my: 2 }}>
             {Object.entries(activity.organizations ?? {}).map(([id, org]) => (
-              <OrganizationChip key={id} org={org} activity={activity} selected={rosterOrgFilter == id} onClick={() => (rosterOrgFilter == id ? setRosterOrgFilter('') : setRosterOrgFilter(id))} />
+              <OrganizationChip key={id} org={org} activity={activity} selected={rosterOrgFilter == id} isClickable={(count) => count > 0} onClick={() => (rosterOrgFilter == id ? setRosterOrgFilter('') : setRosterOrgFilter(id))} />
             ))}
           </Box>
         </Box>


### PR DESCRIPTION
Makes it so that clicking an organization chip above the roster filters the roster to only those participants in that organization. Organizations with no responders (for us right now, KCSO) are not clickable.

Active discussion in Slack about whether this should go in. Please go there for a broader discussion and keep the PR focused on code considerations.

![image](https://github.com/KingCountySAR/respond-next/assets/126836598/d2db854f-0b35-49c6-9b2e-42b3c8115edf)

![image](https://github.com/KingCountySAR/respond-next/assets/126836598/688b2348-3cf4-4419-9428-f8ac3a334b17)
