### PR TITLE
No Explicit Any Warnings

### DIFF
--- a/src/components/LoginPanel.tsx
+++ b/src/components/LoginPanel.tsx
@@ -31,9 +31,7 @@ export default function LoginPanel() {
   }
 
   async function finishLogin(token: string) {
-    const res = (await Api.post<any>('/api/auth/google', {
-      token,
-    })) as AuthResponse;
+    const res = await Api.postBody<{ token: string }, AuthResponse>('/api/auth/google', { token });
     console.log('login response', res);
 
     if (res.userInfo) {

--- a/src/components/OutputForm.tsx
+++ b/src/components/OutputForm.tsx
@@ -49,11 +49,11 @@ const OutputShowMore = ({ children, rows }: { children: ReactNode; rows?: number
   const rowLimit = Math.max(rows ?? 0, 0);
   const collapsedHeightPixels = DEFAULT_LINE_HEIGHT_PIXELS * rowLimit;
 
-  const contentElement = useRef<any>(null);
+  const contentElement = useRef<HTMLDivElement>(null);
   const isCollapsible = useRef<boolean>(false);
 
   useEffect(() => {
-    isCollapsible.current = !!collapsedHeightPixels && collapsedHeightPixels < contentElement.current?.offsetHeight;
+    isCollapsible.current = !!collapsedHeightPixels && !!contentElement.current && collapsedHeightPixels < contentElement.current.offsetHeight;
     setCollapse(isCollapsible.current);
   }, [collapsedHeightPixels]);
 

--- a/src/components/StatusUpdater/UpdateStatusForm.tsx
+++ b/src/components/StatusUpdater/UpdateStatusForm.tsx
@@ -88,7 +88,7 @@ export function useFormLogic(activity: Activity, user: UserInfo, respondingOrg: 
 }
 type FormLogic = ReturnType<typeof useFormLogic>;
 
-export const TotalMilesInput = ({ control, errors }: { control: Control<FormValues, any>; errors: FieldErrors<FormValues> }) => {
+export const TotalMilesInput = ({ control, errors }: { control: Control<FormValues>; errors: FieldErrors<FormValues> }) => {
   return (
     <Controller
       name="miles"

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -10,7 +10,11 @@ export async function apiFetch<T>(url: string, config?: RequestInit): Promise<T>
   return await response.json();
 }
 
-export async function apiPost<T>(url: string, data: any): Promise<T> {
+export async function apiPost<TResponse>(url: string): Promise<TResponse> {
+  return apiPostBody(url, undefined);
+}
+
+export async function apiPostBody<TBody, TResponse>(url: string, data: TBody): Promise<TResponse> {
   // Default options are marked with *
   const response = await fetch(url, {
     method: 'POST', // *GET, POST, PUT, DELETE, etc.
@@ -29,6 +33,7 @@ export async function apiPost<T>(url: string, data: any): Promise<T> {
 const group = {
   get: apiFetch,
   post: apiPost,
+  postBody: apiPostBody,
 };
 
 export default group;

--- a/src/lib/client/store/index.ts
+++ b/src/lib/client/store/index.ts
@@ -1,4 +1,4 @@
-import type { Action, Middleware, ThunkAction } from '@reduxjs/toolkit';
+import type { Action, Middleware, PayloadAction, ThunkAction } from '@reduxjs/toolkit';
 import { addListener, combineReducers, configureStore, createListenerMiddleware, TypedAddListener, TypedStartListening } from '@reduxjs/toolkit';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 
@@ -8,7 +8,7 @@ import configReducer from './config';
 import organizationReducer from './organization';
 import syncReducer from './sync';
 
-export const logMiddleware: Middleware<unknown, RootState> = (_storeApi) => (next) => (action: { type: string; payload: any; meta?: { sync?: boolean } }) => {
+export const logMiddleware: Middleware<unknown, RootState> = (_storeApi) => (next) => (action: PayloadAction) => {
   if (typeof window !== 'undefined') console.log('action ' + action.type, action.payload);
   const result = next(action);
   return result;

--- a/src/lib/client/sync.ts
+++ b/src/lib/client/sync.ts
@@ -13,6 +13,7 @@ import { Actions as SyncActions } from './store/sync';
 export class ClientSync {
   // This property is set during the build method below, so it's effectively set in the constructor
   // and doesn't need a valid value here.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private dispatch: AppDispatch = undefined as any;
   private socket: Socket<ServerToClientEvents, ClientToServerEvents>;
   private key: string = '';

--- a/src/lib/formUtils.ts
+++ b/src/lib/formUtils.ts
@@ -8,9 +8,9 @@ function replacePropertiesType<T extends object, FROM, TO, K extends [...(keyof 
   let key: keyof typeof obj;
   for (key in obj) {
     if (!keys.includes(key)) {
-      ret[key] = obj[key] as any;
+      ret[key] = obj[key] as any; // eslint-disable-line @typescript-eslint/no-explicit-any
     } else {
-      ret[key] = transform(obj[key] as FROM) as any;
+      ret[key] = transform(obj[key] as FROM) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
     }
   }
 
@@ -32,5 +32,7 @@ export function fromExpandedDates<T extends object, K extends [...(keyof T)[]]>(
     const parsed = parseDate(`${date} ${time}`, 'yyyy-MM-dd HHmm', new Date());
     return parsed.getTime();
   };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return replacePropertiesType<T, { date: string; time: string }, number, K>(obj as any, transform, ...keys) as T;
 }

--- a/src/lib/server/memberProviders/d4hMembersProvider.ts
+++ b/src/lib/server/memberProviders/d4hMembersProvider.ts
@@ -7,6 +7,16 @@ const D4H_MEMBER_REFRESH_SECS = 15 * 60;
 const D4H_FETCH_LIMIT = 250;
 const D4H_CACHE_COLLECTION = 'd4hCache';
 
+interface CustomField {
+  label: string;
+  value: string;
+}
+
+interface Group {
+  id: number;
+  title: string;
+}
+
 interface D4HMemberResponse {
   id: number;
   ref?: string;
@@ -14,7 +24,7 @@ interface D4HMemberResponse {
   email?: string;
   mobilephone?: string;
   group_ids?: number[];
-  custom_fields: any[];
+  custom_fields: CustomField[];
   urls: {
     image?: string;
   };
@@ -166,7 +176,7 @@ export default class D4HMembersProvider implements MemberProvider {
   private async refreshMembersForToken(token: string, moreEmailsLabel?: string) {
     let offset: number = 0;
 
-    let groupRows: any[] = [];
+    let groupRows: Group[] = [];
     do {
       const chunk = (
         await (
@@ -176,7 +186,7 @@ export default class D4HMembersProvider implements MemberProvider {
             },
           })
         ).json()
-      )?.data as any[];
+      )?.data as Group[];
 
       offset += D4H_FETCH_LIMIT;
       groupRows = groupRows.concat(chunk);

--- a/src/lib/server/memberProviders/memberProvider.ts
+++ b/src/lib/server/memberProviders/memberProvider.ts
@@ -8,11 +8,10 @@ export interface MemberInfo {
 export interface MemberAuthInfo {
   provider: string;
   email: string;
-  [key: string]: any;
 }
 
 export interface MemberProvider {
-  getMemberInfo(organizationId: string, authPayload: MemberAuthInfo, providerOptions: any): Promise<MemberInfo | undefined>;
+  getMemberInfo<TOptions = undefined>(organizationId: string, authPayload: MemberAuthInfo, providerOptions: TOptions): Promise<MemberInfo | undefined>;
   getMemberInfoById(memberId: string): Promise<MemberInfo | undefined>;
   getMemberPhoto(memberId: string): Promise<ArrayBuffer | undefined>;
   refresh(force?: boolean): Promise<{ ok: boolean; runtime: number; cached?: boolean }>;

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -1,7 +1,7 @@
 import { v4 as uuid } from 'uuid';
 
 const pickSafely = <ObjectType>(keys: readonly `${string & keyof ObjectType}`[]) => {
-  return (object: any) => {
+  return <Input extends ObjectType>(object: Input) => {
     const resultObject: ObjectType = {} as unknown as ObjectType;
     for (let index = 0; index < keys.length; index += 1) {
       const key = keys[index] as unknown as keyof ObjectType;


### PR DESCRIPTION
We had a number of `no-explicit-any` linter warnings that were bugging me. This PR fixes _almost_ all of them.

Most of them were fixed by finding the correct type instead of using Any. This included adding generic types or defining types.

A few of them required disabling that warning. I only did this when the code was clearly type fiddling, and did it on a per-line basis. I Whoever is writing code dynamically adding and removing properties should write the code to be resilient to whatever is passed to them.

The lone exception to the above is disabling the warning when the code had a comment explaining why it was doing the "wrong" thing. That comment made sense, so disabling the linter's warning continues that comment.

Finally, there was one warning I was unable to fix. It is clearly _not_ type fiddling, yet I could not get the types to be happy for the life of me. That was on line 60 of `lib\server\stateManager.ts`. I still wanted to get this PR out with the fixes I have. If you can fix that one, please do so.