### PR TITLE
Mobile UI Adjustments

### DIFF
--- a/src/components/SplitButton.tsx
+++ b/src/components/SplitButton.tsx
@@ -12,7 +12,7 @@ export function splitOptionsFromStrings(options: string[]) {
   return options.map((o) => ({ id: o, text: o }));
 }
 
-export function SplitButton<K extends string | number | EnumMember, T extends IdOption<K>>({ options, selected, onClick }: { options: T[]; selected?: K; onClick?: (value: K) => void }) {
+export function SplitButton<K extends string | number | EnumMember, T extends IdOption<K>>({ fullWidth, options, selected, onClick }: { fullWidth?: boolean; options: T[]; selected?: K; onClick?: (value: K) => void }) {
   const [open, setOpen] = useState(false);
   const [buttonId] = useState(Math.random() * 10000);
   const anchorRef = useRef<HTMLDivElement>(null);
@@ -47,10 +47,10 @@ export function SplitButton<K extends string | number | EnumMember, T extends Id
   const menuOptions = options.filter((option) => option.id !== selected);
   return (
     <>
-      <ButtonGroup variant="contained" ref={anchorRef} aria-label="split button">
+      <ButtonGroup fullWidth={fullWidth} variant="contained" ref={anchorRef} aria-label="split button">
         <Button onClick={handleClick}>{options[selectedIndex].text}</Button>
         {!!menuOptions.length && (
-          <Button size="small" aria-controls={open ? 'split-button-menu' + buttonId : undefined} aria-expanded={open ? 'true' : undefined} aria-label="select merge strategy" aria-haspopup="menu" onClick={handleToggle}>
+          <Button fullWidth={fullWidth ? false : undefined} size="small" aria-controls={open ? 'split-button-menu' + buttonId : undefined} aria-expanded={open ? 'true' : undefined} aria-label="select merge strategy" aria-haspopup="menu" onClick={handleToggle}>
             <ArrowDropDownIcon />
           </Button>
         )}

--- a/src/components/StatusUpdater/index.tsx
+++ b/src/components/StatusUpdater/index.tsx
@@ -79,14 +79,14 @@ function getStatusOptions(current: ParticipantStatus | undefined, startTime: num
   return statusOptions[status];
 }
 
-export const StatusUpdater = ({ activity, current }: { activity: Activity; current?: ParticipantStatus }) => {
+export const StatusUpdater = ({ activity, current, fullWidth }: { activity: Activity; current?: ParticipantStatus; fullWidth: boolean }) => {
   const user = useAppSelector((state) => state.auth.userInfo);
   const thisOrg = useAppSelector((state) => state.organization.mine);
 
-  return user && thisOrg ? <StatusUpdaterProtected activity={activity} current={current} user={user} thisOrg={thisOrg} /> : null;
+  return user && thisOrg ? <StatusUpdaterProtected activity={activity} current={current} user={user} thisOrg={thisOrg} fullWidth={fullWidth} /> : null;
 };
 
-const StatusUpdaterProtected = ({ activity, current, user, thisOrg }: { activity: Activity; user: UserInfo; thisOrg: MyOrganization; current?: ParticipantStatus }) => {
+const StatusUpdaterProtected = ({ activity, current, fullWidth, user, thisOrg }: { activity: Activity; user: UserInfo; fullWidth: boolean; thisOrg: MyOrganization; current?: ParticipantStatus }) => {
   const [confirming, setConfirming] = useState<boolean>(false);
   const [confirmTitle, setConfirmTitle] = useState<string>('');
   const [confirmStatus, setConfirmStatus] = useState<ParticipantStatus>(ParticipantStatus.SignedIn);
@@ -110,6 +110,7 @@ const StatusUpdaterProtected = ({ activity, current, user, thisOrg }: { activity
       <SplitButton
         options={actions}
         selected={actions[0].id}
+        fullWidth={fullWidth}
         onClick={(optionId) => {
           confirmPrompt('Update Status', optionId);
         }}

--- a/src/components/StatusUpdater/index.tsx
+++ b/src/components/StatusUpdater/index.tsx
@@ -79,14 +79,14 @@ function getStatusOptions(current: ParticipantStatus | undefined, startTime: num
   return statusOptions[status];
 }
 
-export const StatusUpdater = ({ activity, current, fullWidth }: { activity: Activity; current?: ParticipantStatus; fullWidth: boolean }) => {
+export const StatusUpdater = ({ activity, current, fullWidth }: { activity: Activity; current?: ParticipantStatus; fullWidth?: boolean }) => {
   const user = useAppSelector((state) => state.auth.userInfo);
   const thisOrg = useAppSelector((state) => state.organization.mine);
 
   return user && thisOrg ? <StatusUpdaterProtected activity={activity} current={current} user={user} thisOrg={thisOrg} fullWidth={fullWidth} /> : null;
 };
 
-const StatusUpdaterProtected = ({ activity, current, fullWidth, user, thisOrg }: { activity: Activity; user: UserInfo; fullWidth: boolean; thisOrg: MyOrganization; current?: ParticipantStatus }) => {
+const StatusUpdaterProtected = ({ activity, current, fullWidth, user, thisOrg }: { activity: Activity; user: UserInfo; fullWidth?: boolean; thisOrg: MyOrganization; current?: ParticipantStatus }) => {
   const [confirming, setConfirming] = useState<boolean>(false);
   const [confirmTitle, setConfirmTitle] = useState<string>('');
   const [confirmStatus, setConfirmStatus] = useState<ParticipantStatus>(ParticipantStatus.SignedIn);

--- a/src/components/activities/MobileActivityPage.tsx
+++ b/src/components/activities/MobileActivityPage.tsx
@@ -98,7 +98,7 @@ function MobileManageScreen({ activity, startRemove, startChangeState }: { activ
 }
 
 function MobileActivityContents({ activity, startRemove, startChangeState }: ActivityContentProps) {
-  const [bottomNav, setBottomNav] = useState<MobilePageId>(MobilePageId.Roster);
+  const [bottomNav, setBottomNav] = useState<MobilePageId>(MobilePageId.Briefing);
   const user = useAppSelector((state) => state.auth.userInfo);
   const myParticipation = activity?.participants[user?.userId ?? ''];
   return (

--- a/src/components/activities/MobileActivityPage.tsx
+++ b/src/components/activities/MobileActivityPage.tsx
@@ -37,16 +37,7 @@ export function MobileActivityPage({ activity }: { activity?: Activity }) {
 }
 
 function MobileBriefingScreen({ activity }: { activity: Activity }) {
-  const user = useAppSelector((state) => state.auth.userInfo);
-  const myParticipation = activity?.participants[user?.userId ?? ''];
-  const isActivityActive = isActive(activity);
-
-  return (
-    <>
-      <Box sx={{ my: 2 }}>{isActivityActive && <StatusUpdater activity={activity} current={myParticipation?.timeline[0].status} />}</Box>
-      <BriefingPanel activity={activity} />
-    </>
-  );
+  return <BriefingPanel activity={activity} />;
 }
 
 function MobileRosterScreen({ activity }: { activity: Activity }) {
@@ -54,12 +45,8 @@ function MobileRosterScreen({ activity }: { activity: Activity }) {
   const [participantOpen, setParticipantOpen] = useState<boolean>(false);
   const [selectedParticipant, setSelectedParticipant] = useState<Participant>();
 
-  const user = useAppSelector((state) => state.auth.userInfo);
-  const myParticipation = activity?.participants[user?.userId ?? ''];
-
   return (
     <>
-      <Box sx={{ my: 2 }}>{isActive(activity) && <StatusUpdater activity={activity} current={myParticipation?.timeline[0].status} />}</Box>
       <ParticipatingOrgChips activity={activity} orgFilter={orgFilter} setOrgFilter={setOrgFilter} />
       <Box style={{ overflowY: 'auto', height: 0, paddingBottom: '16px' }} flex="1 1 auto">
         <RosterPanel //
@@ -111,8 +98,9 @@ function MobileManageScreen({ activity, startRemove, startChangeState }: { activ
 }
 
 function MobileActivityContents({ activity, startRemove, startChangeState }: ActivityContentProps) {
-  const [bottomNav, setBottomNav] = useState<MobilePageId>(MobilePageId.Briefing);
-
+  const [bottomNav, setBottomNav] = useState<MobilePageId>(MobilePageId.Roster);
+  const user = useAppSelector((state) => state.auth.userInfo);
+  const myParticipation = activity?.participants[user?.userId ?? ''];
   return (
     <>
       <Typography variant="h5">{activity.title}</Typography>
@@ -120,7 +108,12 @@ function MobileActivityContents({ activity, startRemove, startChangeState }: Act
       {bottomNav === MobilePageId.Briefing && <MobileBriefingScreen activity={activity} />}
       {bottomNav === MobilePageId.Manage && <MobileManageScreen activity={activity} startRemove={startRemove} startChangeState={startChangeState} />}
       <Box sx={{ height: 40 }}>{/* filler for bottomnav */}</Box>
-      <Paper sx={{ position: 'fixed', bottom: 0, left: 0, right: 0 }} elevation={3}>
+      <Paper sx={{ position: 'fixed', bottom: 0, left: 0, right: 0, borderRadius: 0 }} elevation={3}>
+        {isActive(activity) && (
+          <Box padding={2}>
+            <StatusUpdater fullWidth={true} activity={activity} current={myParticipation?.timeline[0].status} />
+          </Box>
+        )}
         <BottomNavigation
           showLabels
           value={bottomNav}


### PR DESCRIPTION
A few additional adjustments to the mobile view.
- ~Default the mobile view to the roster panel.~
- Position `StatusUpdater` in the footer component so that it is available in all mobile views.
- Add optional `fullWidth` property to `StatusUpdater`.

![image](https://github.com/KingCountySAR/respond-next/assets/11284884/c4347bb5-7228-480c-90f5-47f539570ce1)
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/4deae70b-bef6-426f-9a11-9c7a3e701cf0)
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/0c98aa0a-56d9-484a-87f8-c1cd203fc5b1)
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/f5ce036d-45e6-4db1-91c0-f91c42572828)


