### PR TITLE
Implement client preferences using local storage.

### DIFF
--- a/src/components/AppMenu.tsx
+++ b/src/components/AppMenu.tsx
@@ -8,47 +8,67 @@ import * as React from 'react';
 import { useAppDispatch, useAppSelector } from '@respond/lib/client/store';
 import { AuthActions } from '@respond/lib/client/store/auth';
 
+import { PreferencesDialog } from './Preferences';
+
 export function AppMenu() {
   const dispatch = useAppDispatch();
   const { userInfo } = useAppSelector((state) => state.auth);
   const [menuAnchor, setMenuAnchor] = React.useState<HTMLElement | null>(null);
   const handleMenu = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => setMenuAnchor(event.currentTarget);
   const handleClose = () => setMenuAnchor(null);
+
+  const [openPreferences, setOpenPreferences] = React.useState(false);
+  const handleOpenPreferences = () => {
+    setOpenPreferences(true);
+  };
+  const handleClosePreferences = () => setOpenPreferences(false);
+
   return (
-    <div style={{ display: 'inline-block' }}>
-      <IconButton size="large" aria-label="account of current user" aria-controls="menu-appbar" aria-haspopup="true" onClick={handleMenu} color="inherit">
-        <AccountCircle />
-      </IconButton>
-      <Menu
-        id="menu-appbar"
-        anchorEl={menuAnchor}
-        anchorOrigin={{
-          vertical: 'top',
-          horizontal: 'right',
-        }}
-        keepMounted
-        transformOrigin={{
-          vertical: 'top',
-          horizontal: 'right',
-        }}
-        open={Boolean(menuAnchor)}
-        onClose={handleClose}
-      >
-        {userInfo ? <MenuItem disabled>{userInfo.name}</MenuItem> : undefined}
-        <MenuItem
-          disabled={!userInfo}
-          onClick={() => {
-            handleClose();
-            dispatch(AuthActions.logout());
+    <>
+      <div style={{ display: 'inline-block' }}>
+        <IconButton size="large" aria-label="account of current user" aria-controls="menu-appbar" aria-haspopup="true" onClick={handleMenu} color="inherit">
+          <AccountCircle />
+        </IconButton>
+        <Menu
+          id="menu-appbar"
+          anchorEl={menuAnchor}
+          anchorOrigin={{
+            vertical: 'top',
+            horizontal: 'right',
           }}
+          keepMounted
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'right',
+          }}
+          open={Boolean(menuAnchor)}
+          onClose={handleClose}
         >
-          Sign Out
-        </MenuItem>
-        <Divider />
-        <MenuItem component={Link} href="/about">
-          About
-        </MenuItem>
-      </Menu>
-    </div>
+          {userInfo ? <MenuItem disabled>{userInfo.name}</MenuItem> : undefined}
+          <MenuItem
+            onClick={() => {
+              handleClose();
+              handleOpenPreferences();
+            }}
+          >
+            Preferences
+          </MenuItem>
+          <MenuItem
+            disabled={!userInfo}
+            onClick={() => {
+              handleClose();
+              dispatch(AuthActions.logout());
+            }}
+          >
+            Sign Out
+          </MenuItem>
+          <Divider />
+          <MenuItem component={Link} href="/about">
+            About
+          </MenuItem>
+        </Menu>
+      </div>
+      <PreferencesDialog open={openPreferences} onClose={handleClosePreferences} />
+    </>
   );
 }

--- a/src/components/Preferences.tsx
+++ b/src/components/Preferences.tsx
@@ -34,6 +34,7 @@ export function PreferencesDialog(props: PreferenceDialogProps) {
   const { onClose, open } = props;
 
   const handleClose = (): void => {
+    setPreferences(getPreferences());
     onClose();
   };
 

--- a/src/components/Preferences.tsx
+++ b/src/components/Preferences.tsx
@@ -1,28 +1,10 @@
 import { Button, Dialog, DialogContent, DialogTitle, FormControl, InputLabel, MenuItem, Select, SelectChangeEvent, Stack } from '@mui/material';
 import { useState } from 'react';
 
+import { useAppDispatch, useAppSelector } from '@respond/lib/client/store';
+import { PreferenceActions } from '@respond/lib/client/store/preferences';
+
 import { MobilePageId } from './activities/MobileActivityPage';
-
-export interface IPreferences {
-  defaultMobileView: MobilePageId;
-}
-
-class Preferences implements IPreferences {
-  defaultMobileView;
-  constructor() {
-    this.defaultMobileView = MobilePageId.Briefing;
-  }
-}
-
-const PREFERENCES_KEY = 'preferences';
-
-export const getPreferences = (): IPreferences => {
-  return Object.assign(new Preferences(), JSON.parse(localStorage.getItem(PREFERENCES_KEY) ?? '{}'));
-};
-
-const savePreferences = (preferences: IPreferences) => {
-  localStorage.setItem(PREFERENCES_KEY, JSON.stringify(preferences));
-};
 
 interface PreferenceDialogProps {
   open: boolean;
@@ -30,16 +12,18 @@ interface PreferenceDialogProps {
 }
 
 export function PreferencesDialog(props: PreferenceDialogProps) {
-  const [preferences, setPreferences] = useState(getPreferences());
   const { onClose, open } = props;
+  const dispatch = useAppDispatch();
+  const initialState = useAppSelector((state) => state.preferences);
+  const [preferences, setPreferences] = useState(initialState);
 
   const handleClose = (): void => {
-    setPreferences(getPreferences());
+    setPreferences(initialState);
     onClose();
   };
 
   const handleSave = (): void => {
-    savePreferences(preferences);
+    dispatch(PreferenceActions.update(preferences));
     onClose();
   };
 

--- a/src/components/Preferences.tsx
+++ b/src/components/Preferences.tsx
@@ -23,7 +23,6 @@ export function PreferencesDialog(props: PreferenceDialogProps) {
   };
 
   const handleSave = (): void => {
-    localStorage.preferences = JSON.stringify(preferences);
     dispatch(PreferenceActions.update(preferences));
     onClose();
   };

--- a/src/components/Preferences.tsx
+++ b/src/components/Preferences.tsx
@@ -23,6 +23,7 @@ export function PreferencesDialog(props: PreferenceDialogProps) {
   };
 
   const handleSave = (): void => {
+    localStorage.preferences = JSON.stringify(preferences);
     dispatch(PreferenceActions.update(preferences));
     onClose();
   };

--- a/src/components/Preferences.tsx
+++ b/src/components/Preferences.tsx
@@ -1,0 +1,72 @@
+import { Button, Dialog, DialogContent, DialogTitle, FormControl, InputLabel, MenuItem, Select, SelectChangeEvent, Stack } from '@mui/material';
+import { useState } from 'react';
+
+import { MobilePageId } from './activities/MobileActivityPage';
+
+export interface IPreferences {
+  defaultMobileView: MobilePageId;
+}
+
+class Preferences implements IPreferences {
+  defaultMobileView;
+  constructor() {
+    this.defaultMobileView = MobilePageId.Briefing;
+  }
+}
+
+const PREFERENCES_KEY = 'preferences';
+
+export const getPreferences = (): IPreferences => {
+  return Object.assign(new Preferences(), JSON.parse(localStorage.getItem(PREFERENCES_KEY) ?? '{}'));
+};
+
+const savePreferences = (preferences: IPreferences) => {
+  localStorage.setItem(PREFERENCES_KEY, JSON.stringify(preferences));
+};
+
+interface PreferenceDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function PreferencesDialog(props: PreferenceDialogProps) {
+  const [preferences, setPreferences] = useState(getPreferences());
+  const { onClose, open } = props;
+
+  const handleClose = (): void => {
+    onClose();
+  };
+
+  const handleSave = (): void => {
+    savePreferences(preferences);
+    onClose();
+  };
+
+  const handleDefaultMobileViewChange = (event: SelectChangeEvent): void => {
+    setPreferences({ ...preferences, defaultMobileView: event.target.value as MobilePageId });
+  };
+
+  return (
+    <Dialog fullWidth={true} onClose={handleClose} open={open}>
+      <DialogTitle>Preferences</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} marginTop={2}>
+          <FormControl fullWidth>
+            <InputLabel id="default-mobile-view-select-label">Default Mobile View</InputLabel>
+            <Select labelId="default-mobile-view-select-label" id="default-mobile-view-select" value={preferences.defaultMobileView} label="Default Mobile View" onChange={handleDefaultMobileViewChange}>
+              <MenuItem value={MobilePageId.Manage}>{MobilePageId.Manage}</MenuItem>
+              <MenuItem value={MobilePageId.Roster}>{MobilePageId.Roster}</MenuItem>
+              <MenuItem value={MobilePageId.Briefing}>{MobilePageId.Briefing}</MenuItem>
+            </Select>
+          </FormControl>
+          <Button variant="contained" onClick={handleSave}>
+            Save
+          </Button>
+          <Button variant="outlined" onClick={handleClose}>
+            Cancel
+          </Button>
+        </Stack>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/activities/MobileActivityPage.tsx
+++ b/src/components/activities/MobileActivityPage.tsx
@@ -10,8 +10,6 @@ import { useAppSelector } from '@respond/lib/client/store';
 import { isActive } from '@respond/lib/client/store/activities';
 import { Activity, Participant, ParticipatingOrg } from '@respond/types/activity';
 
-import { getPreferences, IPreferences } from '../Preferences';
-
 import { ActivityActionsBar, ActivityContentProps, ActivityGuardPanel } from './ActivityPage';
 import { BriefingPanel } from './BriefingPanel';
 import { ManagerPanel } from './ManagerPanel';
@@ -100,8 +98,8 @@ function MobileManageScreen({ activity, startRemove, startChangeState }: { activ
 }
 
 function MobileActivityContents({ activity, startRemove, startChangeState }: ActivityContentProps) {
-  const preferences: IPreferences = getPreferences();
-  const [bottomNav, setBottomNav] = useState<MobilePageId>(preferences.defaultMobileView ?? MobilePageId.Briefing);
+  const defaultMobileView: MobilePageId = useAppSelector((state) => state.preferences.defaultMobileView);
+  const [bottomNav, setBottomNav] = useState<MobilePageId>(defaultMobileView);
   const user = useAppSelector((state) => state.auth.userInfo);
   const myParticipation = activity?.participants[user?.userId ?? ''];
   return (

--- a/src/components/activities/MobileActivityPage.tsx
+++ b/src/components/activities/MobileActivityPage.tsx
@@ -10,16 +10,18 @@ import { useAppSelector } from '@respond/lib/client/store';
 import { isActive } from '@respond/lib/client/store/activities';
 import { Activity, Participant, ParticipatingOrg } from '@respond/types/activity';
 
+import { getPreferences, IPreferences } from '../Preferences';
+
 import { ActivityActionsBar, ActivityContentProps, ActivityGuardPanel } from './ActivityPage';
 import { BriefingPanel } from './BriefingPanel';
 import { ManagerPanel } from './ManagerPanel';
 import { ParticipatingOrgChips } from './ParticipatingOrgChips';
 import { ParticipantDialog, RosterPanel, RosterRowCard } from './RosterPanel';
 
-enum MobilePageId {
-  Briefing,
-  Roster,
-  Manage,
+export enum MobilePageId {
+  Briefing = 'Briefing',
+  Roster = 'Roster',
+  Manage = 'Manage',
 }
 
 export function MobileActivityPage({ activity }: { activity?: Activity }) {
@@ -111,7 +113,8 @@ function MobileManageScreen({ activity, startRemove, startChangeState }: { activ
 }
 
 function MobileActivityContents({ activity, startRemove, startChangeState }: ActivityContentProps) {
-  const [bottomNav, setBottomNav] = useState<MobilePageId>(MobilePageId.Briefing);
+  const preferences: IPreferences = getPreferences();
+  const [bottomNav, setBottomNav] = useState<MobilePageId>(preferences.defaultMobileView ?? MobilePageId.Briefing);
 
   return (
     <>

--- a/src/lib/client/store/index.ts
+++ b/src/lib/client/store/index.ts
@@ -6,6 +6,7 @@ import activitiesReducer from './activities';
 import authReducer from './auth';
 import configReducer from './config';
 import organizationReducer from './organization';
+import preferencesReducer from './preferences';
 import syncReducer from './sync';
 
 export const logMiddleware: Middleware<unknown, RootState> = (_storeApi) => (next) => (action: PayloadAction) => {
@@ -20,6 +21,7 @@ function buildClientReducers() {
     auth: authReducer,
     config: configReducer,
     organization: organizationReducer,
+    preferences: preferencesReducer,
     sync: syncReducer,
   });
   return rootReducer;

--- a/src/lib/client/store/preferences.ts
+++ b/src/lib/client/store/preferences.ts
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { MobilePageId } from '@respond/components/activities/MobileActivityPage';
+
+export interface PerferencesState {
+  defaultMobileView: MobilePageId;
+}
+
+let initialState: PerferencesState = {
+  defaultMobileView: MobilePageId.Briefing,
+};
+
+if (localStorage?.preferences) {
+  initialState = Object.assign(initialState, JSON.parse(localStorage.preferences));
+}
+
+const preferencesSlice = createSlice({
+  name: 'preferences',
+  initialState,
+  reducers: {
+    update: (state: PerferencesState, action: PayloadAction<PerferencesState>) => {
+      const newState = Object.assign(state, action.payload);
+      localStorage.preferences = JSON.stringify(newState);
+      return newState;
+    },
+  },
+});
+
+export default preferencesSlice.reducer;
+
+export const PreferenceActions = {
+  ...preferencesSlice.actions,
+};

--- a/src/lib/client/store/preferences.ts
+++ b/src/lib/client/store/preferences.ts
@@ -6,23 +6,18 @@ export interface PerferencesState {
   defaultMobileView: MobilePageId;
 }
 
-let initialState: PerferencesState = {
+const initialState: PerferencesState = {
   defaultMobileView: MobilePageId.Briefing,
 };
-
-if (localStorage?.preferences) {
-  try {
-    initialState = Object.assign(initialState, JSON.parse(localStorage.preferences));
-  } catch (error) {
-    console.error('saved preferences could not be parsed', error);
-  }
-}
 
 const preferencesSlice = createSlice({
   name: 'preferences',
   initialState,
   reducers: {
     update: (state: PerferencesState, action: PayloadAction<PerferencesState>) => {
+      return Object.assign(state, action.payload);
+    },
+    reload: (state: PerferencesState, action: PayloadAction<PerferencesState>) => {
       return Object.assign(state, action.payload);
     },
   },

--- a/src/lib/client/store/preferences.ts
+++ b/src/lib/client/store/preferences.ts
@@ -11,7 +11,11 @@ let initialState: PerferencesState = {
 };
 
 if (localStorage?.preferences) {
-  initialState = Object.assign(initialState, JSON.parse(localStorage.preferences));
+  try {
+    initialState = Object.assign(initialState, JSON.parse(localStorage.preferences));
+  } catch (error) {
+    console.error('saved preferences could not be parsed', error);
+  }
 }
 
 const preferencesSlice = createSlice({

--- a/src/lib/client/store/preferences.ts
+++ b/src/lib/client/store/preferences.ts
@@ -19,9 +19,7 @@ const preferencesSlice = createSlice({
   initialState,
   reducers: {
     update: (state: PerferencesState, action: PayloadAction<PerferencesState>) => {
-      const newState = Object.assign(state, action.payload);
-      localStorage.preferences = JSON.stringify(newState);
-      return newState;
+      return Object.assign(state, action.payload);
     },
   },
 });

--- a/src/lib/client/sync.ts
+++ b/src/lib/client/sync.ts
@@ -103,7 +103,6 @@ export class ClientSync {
     );
 
     if (localStorage?.preferences) {
-      console.log('LOAD PREFERENCES');
       try {
         this.dispatch(PreferenceActions.reload(JSON.parse(localStorage.preferences)));
       } catch (error) {

--- a/src/lib/client/sync.ts
+++ b/src/lib/client/sync.ts
@@ -8,6 +8,7 @@ import { ActivityAction, ActivityActions } from '../state';
 
 import { addAppListener, AppDispatch, AppStore } from './store';
 import { AuthActions } from './store/auth';
+import { PreferenceActions } from './store/preferences';
 import { Actions as SyncActions } from './store/sync';
 
 export class ClientSync {
@@ -88,6 +89,26 @@ export class ClientSync {
 
     if (localStorage.activities) {
       this.dispatch(ActivityActions.reload(JSON.parse(localStorage.activities)));
+    }
+
+    // Listen for preference updates, persist them to local storage.
+    this.dispatch(
+      addAppListener({
+        matcher: isAnyOf(PreferenceActions.update),
+        effect: (action, listenerApi) => {
+          console.log('SHOULD SAVE TO LOCALSTORAGE', listenerApi.getState().preferences);
+          localStorage.preferences = JSON.stringify(listenerApi.getState().preferences);
+        },
+      }),
+    );
+
+    if (localStorage?.preferences) {
+      console.log('LOAD PREFERENCES');
+      try {
+        this.dispatch(PreferenceActions.reload(JSON.parse(localStorage.preferences)));
+      } catch (error) {
+        console.error('saved preferences could not be parsed', error);
+      }
     }
 
     await this.restart();


### PR DESCRIPTION
Implements Local Storage to save client preferences.
- Initial use case is `defaultMobileView`.
  - If there is no saved preference, it defaults to "Briefing"
  - If there is a saved preference, the initial state is set accordingly

![image](https://github.com/KingCountySAR/respond-next/assets/11284884/64d364d8-d89b-4b0a-883e-f7d537ebf40b)
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/1961f8b2-f25e-44fd-aff2-2c08706cc0ab)
