### PR TITLE
Timeline Edit

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.11.12",
     "@mui/x-data-grid": "^6.0.3",
+    "@mui/x-date-pickers": "^6.18.2",
     "@react-oauth/google": "^0.8.0",
     "@reduxjs/toolkit": "^1.9.3",
     "@types/jest": "^29.5.8",

--- a/src/components/ClientOnly.tsx
+++ b/src/components/ClientOnly.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { LocalizationProvider } from '@mui/x-date-pickers';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import React, { ReactNode, useEffect, useState } from 'react';
 
 export default function ClientOnly({ children }: { children: ReactNode }) {
@@ -9,5 +11,5 @@ export default function ClientOnly({ children }: { children: ReactNode }) {
     return () => setMounted(false);
   }, []);
 
-  return mounted ? <>{children}</> : null;
+  return mounted ? <LocalizationProvider dateAdapter={AdapterDateFns}>{children}</LocalizationProvider> : null;
 }

--- a/src/components/activities/RosterPanel.tsx
+++ b/src/components/activities/RosterPanel.tsx
@@ -72,8 +72,11 @@ function EditTime({ datetime, onChange }: { datetime: number; onChange: (time: n
       {edit ? (
         <DateTimePicker value={time} format="MM/dd HH:mm" onAccept={handleAccept} onClose={() => setEdit(false)} />
       ) : (
-        <ButtonBase onClick={() => setEdit(true)}>
-          <Typography>{formatDate(time, 'HHmm')}</Typography>
+        <ButtonBase sx={{ width: '100%' }} onClick={() => setEdit(true)}>
+          <Typography variant="caption">{formatDate(time, 'MM/dd')}</Typography>
+          <Typography sx={{ ml: 2 }} variant="h6">
+            {formatDate(time, 'HHmm')}
+          </Typography>
         </ButtonBase>
       )}
     </>

--- a/src/components/activities/RosterPanel.tsx
+++ b/src/components/activities/RosterPanel.tsx
@@ -56,13 +56,14 @@ export function RosterRowCard({ status, children, onClick, ...props }: PaperProp
   );
 }
 
-function EditTime({ datetime }: { datetime: number }) {
+function EditTime({ datetime, onChange }: { datetime: number; onChange: (time: number) => void }) {
   const [edit, setEdit] = useState<boolean>(false);
   const [time, setTime] = useState(datetime);
   const handleAccept = (newTime: number | null) => {
     if (newTime) {
       setTime(newTime);
     }
+    onChange(time);
   };
   return (
     <>
@@ -109,7 +110,7 @@ export function ParticipantDialog({ open, participant, activity, onClose }: { op
                     <TableCell>{activity.organizations[t.organizationId].rosterName ?? activity.organizations[t.organizationId].title}</TableCell>
                     <TableCell>{getStatusText(t.status)}</TableCell>
                     <TableCell>
-                      <EditTime datetime={t.time} />
+                      <EditTime datetime={t.time} onChange={(time) => console.log('!!!', time)} />
                     </TableCell>
                   </TableRow>
                 ))}

--- a/src/components/activities/RosterPanel.tsx
+++ b/src/components/activities/RosterPanel.tsx
@@ -1,8 +1,9 @@
-import { Button, Chip, DialogActions, Divider, Table, TableBody, TableCell, TableFooter, TableRow } from '@mui/material';
+import { Button, ButtonBase, Chip, DialogActions, Divider, Table, TableBody, TableCell, TableFooter, TableRow } from '@mui/material';
 import Card from '@mui/material/Card';
 import CardActionArea from '@mui/material/CardActionArea';
 import { PaperProps } from '@mui/material/Paper';
 import { useTheme } from '@mui/material/styles';
+import { DateTimePicker } from '@mui/x-date-pickers';
 import { format as formatDate } from 'date-fns';
 import { FunctionComponent, ReactNode, useEffect, useState } from 'react';
 
@@ -55,6 +56,27 @@ export function RosterRowCard({ status, children, onClick, ...props }: PaperProp
   );
 }
 
+function EditTime({ datetime }: { datetime: number }) {
+  const [edit, setEdit] = useState<boolean>(false);
+  const [time, setTime] = useState(datetime);
+  const handleAccept = (newTime: number | null) => {
+    if (newTime) {
+      setTime(newTime);
+    }
+  };
+  return (
+    <>
+      {edit ? (
+        <DateTimePicker value={time} format="MM/dd HH:mm" onAccept={handleAccept} onClose={() => setEdit(false)} />
+      ) : (
+        <ButtonBase onClick={() => setEdit(true)}>
+          <Typography>{formatDate(time, 'HHmm')}</Typography>
+        </ButtonBase>
+      )}
+    </>
+  );
+}
+
 export function ParticipantDialog({ open, participant, activity, onClose }: { open: boolean; onClose: () => void; participant?: Participant; activity: Activity }) {
   const isMobile = useMediaQuery(useTheme().breakpoints.down('md'));
 
@@ -86,7 +108,9 @@ export function ParticipantDialog({ open, participant, activity, onClose }: { op
                   <TableRow key={t.time}>
                     <TableCell>{activity.organizations[t.organizationId].rosterName ?? activity.organizations[t.organizationId].title}</TableCell>
                     <TableCell>{getStatusText(t.status)}</TableCell>
-                    <TableCell>{formatDate(t.time, 'EEE yyyy-MM-dd HHmm')}</TableCell>
+                    <TableCell>
+                      <EditTime datetime={t.time} />
+                    </TableCell>
                   </TableRow>
                 ))}
               </TableBody>

--- a/src/components/activities/RosterPanel.tsx
+++ b/src/components/activities/RosterPanel.tsx
@@ -119,7 +119,7 @@ export function ParticipantDialog({ open, participant, activity, onClose }: { op
                       <TableCell>{activity.organizations[t.organizationId].rosterName ?? activity.organizations[t.organizationId].title}</TableCell>
                       <TableCell>{getStatusText(t.status)}</TableCell>
                       <TableCell>
-                        <EditTime datetime={t.time} onChange={(time) => updateTimeline({ ...t, time: time }, i)} />
+                        <EditTime datetime={t.time} onChange={(time) => updateTimeline({ ...t, time }, i)} />
                       </TableCell>
                     </TableRow>
                   ))

--- a/src/lib/client/store/activities.ts
+++ b/src/lib/client/store/activities.ts
@@ -31,6 +31,7 @@ const activitySliceArgs = {
       .addCase(ActivityActions.reactivate, BasicReducers[ActivityActions.reactivate.type])
       .addCase(ActivityActions.complete, BasicReducers[ActivityActions.complete.type])
       .addCase(ActivityActions.appendOrganizationTimeline, BasicReducers[ActivityActions.appendOrganizationTimeline.type])
+      .addCase(ActivityActions.participantTimelineUpdate, BasicReducers[ActivityActions.participantTimelineUpdate.type])
       .addCase(ActivityActions.participantUpdate, BasicReducers[ActivityActions.participantUpdate.type])
       .addCase(ActivityActions.tagParticipant, BasicReducers[ActivityActions.tagParticipant.type]);
   },

--- a/src/lib/state/activityActions.ts
+++ b/src/lib/state/activityActions.ts
@@ -1,6 +1,6 @@
 import { createAction } from '@reduxjs/toolkit';
 
-import { Activity, OrganizationStatus, ParticipantStatus, pickActivityProperties } from '@respond/types/activity';
+import { Activity, OrganizationStatus, ParticipantStatus, ParticipantUpdate, pickActivityProperties } from '@respond/types/activity';
 
 import { ActivityState } from '.';
 
@@ -52,6 +52,16 @@ const participantUpdate = createAction('participant/update', (activityId: string
   meta: { sync: true },
 }));
 
+const participantTimelineUpdate = createAction('participant/timeline', (activityId: string, participantId: string, update: ParticipantUpdate, index: number) => ({
+  payload: {
+    activityId,
+    participantId,
+    update,
+    index,
+  },
+  meta: { sync: true },
+}));
+
 const tagParticipant = createAction('participant/tag', (activityId: string, participantId: string, tags: string[]) => ({
   payload: {
     activityId,
@@ -69,6 +79,7 @@ export const ActivityActions = {
   complete,
   appendOrganizationTimeline,
   participantUpdate,
+  participantTimelineUpdate,
   tagParticipant,
 };
 

--- a/src/lib/state/activityReducers.ts
+++ b/src/lib/state/activityReducers.ts
@@ -126,6 +126,18 @@ export const BasicReducers: ActivityReducers = {
     }
   },
 
+  [ActivityActions.participantTimelineUpdate.type]: (state, { payload }) => {
+    const activity = state.list.find((f) => f.id === payload.activityId);
+    if (!activity) {
+      return;
+    }
+    const person = activity.participants[payload.participantId];
+    if (!person) {
+      return;
+    }
+    person.timeline[payload.index] = payload.update;
+  },
+
   [ActivityActions.tagParticipant.type]: (state, { payload }) => {
     const activity = state.list.find((f) => f.id === payload.activityId);
     if (activity) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -298,6 +298,13 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+"@babel/runtime@^7.23.2", "@babel/runtime@^7.23.4":
+  version "7.23.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.5.tgz#11edb98f8aeec529b82b211028177679144242db"
+  integrity sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.22.15", "@babel/template@^7.3.3":
   version "7.22.15"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.15.tgz#09576efc3830f0430f4548ef971dde1350ef2f38"
@@ -510,6 +517,33 @@
   version "8.36.0"
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.36.0.tgz#9837f768c03a1e4a30bd304a64fb8844f0e72efe"
   integrity sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==
+
+"@floating-ui/core@^1.4.2":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.5.0.tgz#5c05c60d5ae2d05101c3021c1a2a350ddc027f8c"
+  integrity sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==
+  dependencies:
+    "@floating-ui/utils" "^0.1.3"
+
+"@floating-ui/dom@^1.5.1":
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.5.3.tgz#54e50efcb432c06c23cd33de2b575102005436fa"
+  integrity sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==
+  dependencies:
+    "@floating-ui/core" "^1.4.2"
+    "@floating-ui/utils" "^0.1.3"
+
+"@floating-ui/react-dom@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.0.4.tgz#b076fafbdfeb881e1d86ae748b7ff95150e9f3ec"
+  integrity sha512-CF8k2rgKeh/49UrnIBs4BdxPUV6vize/Db1d/YbCLyp9GiVZ0BEwf5AiDSxJRCr6yOkGqTFHtmrULxkEfYZ7dQ==
+  dependencies:
+    "@floating-ui/dom" "^1.5.1"
+
+"@floating-ui/utils@^0.1.3":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.6.tgz#22958c042e10b67463997bd6ea7115fe28cbcaf9"
+  integrity sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==
 
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
@@ -784,6 +818,19 @@
     prop-types "^15.8.1"
     react-is "^18.2.0"
 
+"@mui/base@^5.0.0-beta.22":
+  version "5.0.0-beta.25"
+  resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-beta.25.tgz#e1bc39f7a2daa9851fa8d0774ae6d89f0453bdc3"
+  integrity sha512-Iiv+IcappRRv6IBlknIVmLkXxfp51NEX1+l9f+dIbBuPU4PaRULegr1lCeHKsC45KU5ruxM5xMg4R/de03aJQg==
+  dependencies:
+    "@babel/runtime" "^7.23.4"
+    "@floating-ui/react-dom" "^2.0.4"
+    "@mui/types" "^7.2.10"
+    "@mui/utils" "^5.14.19"
+    "@popperjs/core" "^2.11.8"
+    clsx "^2.0.0"
+    prop-types "^15.8.1"
+
 "@mui/core-downloads-tracker@^5.11.12":
   version "5.11.12"
   resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.11.12.tgz#b2ea89ba71321a79c89dfb6b2a1b1886dc7de6e4"
@@ -847,6 +894,11 @@
     csstype "^3.1.1"
     prop-types "^15.8.1"
 
+"@mui/types@^7.2.10":
+  version "7.2.10"
+  resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.10.tgz#13e3e9aa07ee6d593cfacd538e02e8e896d7a12f"
+  integrity sha512-wX1vbDC+lzF7FlhT6A3ffRZgEoKWPF8VqRoTu4lZwouFX2t90KyCMsgepMw5DxLak1BSp/KP86CmtZttikb/gQ==
+
 "@mui/types@^7.2.3":
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.3.tgz#06faae1c0e2f3a31c86af6f28b3a4a42143670b9"
@@ -874,6 +926,16 @@
     prop-types "^15.8.1"
     react-is "^18.2.0"
 
+"@mui/utils@^5.14.16", "@mui/utils@^5.14.19":
+  version "5.14.19"
+  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.14.19.tgz#39a5846a74ba199f1a2b067ea197dc6b9c8f442f"
+  integrity sha512-qAHvTXzk7basbyqPvhgWqN6JbmI2wLB/mf97GkSlz5c76MiKYV6Ffjvw9BjKZQ1YRb8rDX9kgdjRezOcoB91oQ==
+  dependencies:
+    "@babel/runtime" "^7.23.4"
+    "@types/prop-types" "^15.7.11"
+    prop-types "^15.8.1"
+    react-is "^18.2.0"
+
 "@mui/x-data-grid@^6.0.3":
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/@mui/x-data-grid/-/x-data-grid-6.0.3.tgz#ff780a83c7f298ada6c1c02149e4269e7eece4d3"
@@ -884,6 +946,19 @@
     clsx "^1.2.1"
     prop-types "^15.8.1"
     reselect "^4.1.7"
+
+"@mui/x-date-pickers@^6.18.2":
+  version "6.18.2"
+  resolved "https://registry.yarnpkg.com/@mui/x-date-pickers/-/x-date-pickers-6.18.2.tgz#07f76c4a9ba022b8916607d9b3501c39160787c2"
+  integrity sha512-HJq4uoFQSu5isa/mesWw2BKh8KBRYUQb+KaSlVlWfJNgP3YhPvWZ6yqCNYyxOAiPMxb0n3nBjS9ErO27OHjFMA==
+  dependencies:
+    "@babel/runtime" "^7.23.2"
+    "@mui/base" "^5.0.0-beta.22"
+    "@mui/utils" "^5.14.16"
+    "@types/react-transition-group" "^4.4.8"
+    clsx "^2.0.0"
+    prop-types "^15.8.1"
+    react-transition-group "^4.4.5"
 
 "@next/env@13.2.4":
   version "13.2.4"
@@ -1026,6 +1101,11 @@
   version "2.11.6"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
   integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
+
+"@popperjs/core@^2.11.8":
+  version "2.11.8"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
+  integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
 
 "@react-oauth/google@^0.8.0":
   version "0.8.0"
@@ -1328,6 +1408,11 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
 
+"@types/prop-types@^15.7.11":
+  version "15.7.11"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.11.tgz#2596fb352ee96a1379c657734d4b913a613ad563"
+  integrity sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==
+
 "@types/qs@*":
   version "6.9.7"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
@@ -1356,6 +1441,13 @@
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.5.tgz#aae20dcf773c5aa275d5b9f7cdbca638abc5e416"
   integrity sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-transition-group@^4.4.8":
+  version "4.4.9"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.9.tgz#12a1a1b5b8791067198149867b0823fbace31579"
+  integrity sha512-ZVNmWumUIh5NhH8aMD9CR2hdW0fNuYInlocZHaZ+dgk/1K49j1w/HoAuK1ki+pgscQrOFRTlXeoURtuzEkV3dg==
   dependencies:
     "@types/react" "*"
 
@@ -2040,6 +2132,11 @@ clsx@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
   integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
+
+clsx@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.0.0.tgz#12658f3fd98fafe62075595a5c30e43d18f3d00b"
+  integrity sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==
 
 co@^4.6.0:
   version "4.6.0"
@@ -4940,6 +5037,11 @@ regenerator-runtime@^0.13.11:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
+
+regenerator-runtime@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz#5e19d68eb12d486f797e15a3c6a918f7cec5eb45"
+  integrity sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==
 
 regexp.prototype.flags@^1.4.3:
   version "1.4.3"


### PR DESCRIPTION
Ok, alternate approach to the roster-edit PR.

* Make Timeline records editable
* The roster view would be read-only and the timeline scrub would be on-demand, for that view; not persisted.
  * Roster view is not included here, just the timeline edit functionality.

This update makes the timeline editable from within the responder dialog; clicking on any of the times populates a `DateTimePicker` and selecting a new time updates the corresponding time in the participant's timeline.

BUG: There is currently a UI bug that I haven't tracked down -- the changes are persisted in the database, but if you close the dialog and re-open it, they are not reflected. After refreshing the page, the updated times appear.

Notes:
* Date format TBD, per ongoing discussion. I have it set to just the time right now but that's subject to change.
* I have not done any validation on whether the date results in time travel; potentially allowing you to become your own grandpa.

![image](https://github.com/KingCountySAR/respond-next/assets/11284884/6d786f01-c9eb-4800-a42e-dcd5d973539b)

![image](https://github.com/KingCountySAR/respond-next/assets/11284884/d6606bbf-ea90-41f4-96b2-0f049cdfae0a)

