### PR TITLE
fix bottom nav filler on mobile

### DIFF
--- a/src/components/activities/MobileActivityPage.tsx
+++ b/src/components/activities/MobileActivityPage.tsx
@@ -16,6 +16,8 @@ import { ManagerPanel } from './ManagerPanel';
 import { ParticipatingOrgChips } from './ParticipatingOrgChips';
 import { ParticipantDialog, RosterPanel, RosterRowCard } from './RosterPanel';
 
+const MOBILE_FOOTER_HEIGHT_PIXELS = 124.5;
+
 export enum MobilePageId {
   Briefing = 'Briefing',
   Roster = 'Roster',
@@ -108,7 +110,7 @@ function MobileActivityContents({ activity, startRemove, startChangeState }: Act
       {bottomNav === MobilePageId.Roster && <MobileRosterScreen activity={activity} />}
       {bottomNav === MobilePageId.Briefing && <MobileBriefingScreen activity={activity} />}
       {bottomNav === MobilePageId.Manage && <MobileManageScreen activity={activity} startRemove={startRemove} startChangeState={startChangeState} />}
-      <Box sx={{ height: 40 }}>{/* filler for bottomnav */}</Box>
+      <Box sx={{ height: MOBILE_FOOTER_HEIGHT_PIXELS }}>{/* filler for bottomnav */}</Box>
       <Paper sx={{ position: 'fixed', bottom: 0, left: 0, right: 0, borderRadius: 0 }} elevation={3}>
         {isActive(activity) && (
           <Box padding={2}>

--- a/src/components/activities/MobileActivityPage.tsx
+++ b/src/components/activities/MobileActivityPage.tsx
@@ -17,8 +17,8 @@ import { ParticipatingOrgChips } from './ParticipatingOrgChips';
 import { ParticipantDialog, RosterPanel, RosterRowCard } from './RosterPanel';
 
 const MOBILE_BOTTOM_NAV_TAB_HEIGHT = 56;
-const MOBILE_STATUS_UPDATER_HEITHT = 68.5;
-const MOBILE_FOOTER_HEIGHT_PIXELS = MOBILE_BOTTOM_NAV_TAB_HEIGHT + MOBILE_STATUS_UPDATER_HEITHT;
+const MOBILE_STATUS_UPDATER_HEIGHT = 68.5;
+const MOBILE_FOOTER_HEIGHT_PIXELS = MOBILE_BOTTOM_NAV_TAB_HEIGHT + MOBILE_STATUS_UPDATER_HEIGHT;
 
 export enum MobilePageId {
   Briefing = 'Briefing',

--- a/src/components/activities/MobileActivityPage.tsx
+++ b/src/components/activities/MobileActivityPage.tsx
@@ -16,7 +16,9 @@ import { ManagerPanel } from './ManagerPanel';
 import { ParticipatingOrgChips } from './ParticipatingOrgChips';
 import { ParticipantDialog, RosterPanel, RosterRowCard } from './RosterPanel';
 
-const MOBILE_FOOTER_HEIGHT_PIXELS = 124.5;
+const MOBILE_BOTTOM_NAV_TAB_HEIGHT = 56;
+const MOBILE_STATUS_UPDATER_HEITHT = 68.5;
+const MOBILE_FOOTER_HEIGHT_PIXELS = MOBILE_BOTTOM_NAV_TAB_HEIGHT + MOBILE_STATUS_UPDATER_HEITHT;
 
 export enum MobilePageId {
   Briefing = 'Briefing',


### PR DESCRIPTION
The bottom nav requires more reserved height. The nav tabs are 56 pixels and the status updater is 68.5. updated the filler to 124.5 pixels.