### PR TITLE
Roster View (Read Only)

### DIFF
--- a/src/app/(main)/roster/[activityId]/page.tsx
+++ b/src/app/(main)/roster/[activityId]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { RosterView } from '@respond/components/activities/RosterView';
 
-export default function EditRoster({ params }: { params: { activityId: string } }) {
+export default function ViewRoster({ params }: { params: { activityId: string } }) {
   return <RosterView activityId={params.activityId} />;
 }

--- a/src/app/(main)/roster/[activityId]/page.tsx
+++ b/src/app/(main)/roster/[activityId]/page.tsx
@@ -1,0 +1,6 @@
+'use client';
+import { RosterView } from '@respond/components/activities/RosterView';
+
+export default function EditRoster({ params }: { params: { activityId: string } }) {
+  return <RosterView activityId={params.activityId} />;
+}

--- a/src/components/OutputForm.tsx
+++ b/src/components/OutputForm.tsx
@@ -8,18 +8,22 @@ import { RelativeTimeText } from './RelativeTimeText';
 
 const DEFAULT_LINE_HEIGHT_PIXELS = 24;
 
-export const OutputForm = ({ children }: { children: ReactNode }) => {
+export const OutputForm = ({ children, columns }: { children: ReactNode; columns?: number }) => {
   const childrenArray = Children.toArray(children);
 
   const outputFields = childrenArray.map((child, index) => {
     return (
-      <Grid key={index} item xs={12}>
+      <Grid key={index} item xs={12} sm={12 / (columns ?? 1)}>
         {child}
       </Grid>
     );
   });
 
-  return <Grid columnSpacing={{ xs: 0, sm: 2 }}>{outputFields.length && outputFields}</Grid>;
+  return (
+    <Grid container columnSpacing={2}>
+      {outputFields.length && outputFields}
+    </Grid>
+  );
 };
 
 const OutputField = ({ label, multiline, children }: { label: string; multiline?: boolean; children: React.ReactNode }) => {

--- a/src/components/activities/DesktopActivityPage.tsx
+++ b/src/components/activities/DesktopActivityPage.tsx
@@ -1,4 +1,4 @@
-import { Divider, Typography } from '@mui/material';
+import { Button, Divider, Typography } from '@mui/material';
 import { ReactNode, useState } from 'react';
 
 import { Box, Stack } from '@respond/components/Material';
@@ -37,7 +37,12 @@ function DesktopActivityContents({ activity, startChangeState, startRemove }: Ac
       </Stack>
       <Stack direction="row" flex="1 1 auto" spacing={1} divider={<Divider orientation="vertical" flexItem />}>
         <Box display="flex" flex="1 1 auto" flexDirection="column">
-          <ParticipatingOrgChips activity={activity} orgFilter={orgFilter} setOrgFilter={setOrgFilter} display="flex" flexDirection="row" />
+          <Stack direction="row" justifyContent="space-between" alignItems="center">
+            <ParticipatingOrgChips activity={activity} orgFilter={orgFilter} setOrgFilter={setOrgFilter} display="flex" flexDirection="row" />
+            <Button href={`/roster/${activity.id}`} variant="outlined" size="small">
+              View Roster
+            </Button>
+          </Stack>
           <RosterPanel //
             activity={activity}
             filter={orgFilter}

--- a/src/components/activities/RosterView.tsx
+++ b/src/components/activities/RosterView.tsx
@@ -1,4 +1,5 @@
 import { Box, Paper, Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material';
+import { differenceInCalendarDays } from 'date-fns';
 
 import { ToolbarPage } from '@respond/components/ToolbarPage';
 import { useAppSelector } from '@respond/lib/client/store';
@@ -77,7 +78,7 @@ export function RosterView({ activityId }: { activityId: string }) {
           </TableHead>
           <TableBody>
             {rosterEntries.map((entry, i) => (
-              <RosterRow key={i} rosterEntry={entry} />
+              <RosterRow key={i} rosterEntry={entry} activityStartTime={activity.startTime} />
             ))}
           </TableBody>
         </Table>
@@ -98,14 +99,14 @@ function ActivityNotFound() {
   );
 }
 
-function RosterRow({ rosterEntry }: { rosterEntry: RosterEntry }) {
+function RosterRow({ activityStartTime, rosterEntry }: { activityStartTime: number; rosterEntry: RosterEntry }) {
   return (
     <TableRow>
       <TableCell size="small">{rosterEntry.participantName}</TableCell>
       <TableCell size="small">{rosterEntry.organizationName}</TableCell>
       {Object.values(rosterEntry.timestamps).map((time, i) => (
         <TableCell key={i} size="small">
-          <Stack>{time ? <RosterTimeValue time={time} /> : undefined}</Stack>
+          <Stack>{time ? <RosterTimeValue time={time} startTime={activityStartTime} /> : undefined}</Stack>
         </TableCell>
       ))}
       <TableCell size="small">
@@ -115,13 +116,15 @@ function RosterRow({ rosterEntry }: { rosterEntry: RosterEntry }) {
   );
 }
 
-function RosterTimeValue({ time }: { time: number }) {
+function RosterTimeValue({ startTime, time }: { startTime: number; time: number }) {
+  const dateDiff = Math.abs(differenceInCalendarDays(new Date(startTime), new Date(time)));
+
   const dateString = new Date(time).toLocaleString('en-US', { month: '2-digit', day: '2-digit', year: '2-digit' });
   const timeString = new Date(time).toLocaleString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit' }).replace(':', '');
   return (
     <>
       <Typography variant="h6">{timeString}</Typography>
-      <Typography variant="caption">{dateString}</Typography>
+      {dateDiff ? <Typography variant="caption">{dateString}</Typography> : <></>}
     </>
   );
 }

--- a/src/components/activities/RosterView.tsx
+++ b/src/components/activities/RosterView.tsx
@@ -104,26 +104,19 @@ interface IRosterEntry {
 
 const scrubTimeline = (timeline: Array<ParticipantUpdate>): Array<ParticipantUpdate> => {
   const newTimeline = [];
-  let priorStage = 0;
+  let priorStage = RosterStage.NA;
   for (let i = timeline.length - 1; i >= 0; i--) {
     const t = timeline[i];
     const stage: RosterStage = rosterStages[t.status] ?? undefined;
-    if (stage === RosterStage.NA) {
-      if (i === 0) {
-        newTimeline.unshift(t); // Keep if latest status
-        priorStage = stage;
-      }
-      continue;
-    }
-    if (stage === RosterStage.SignOut) {
+    if (stage === RosterStage.NA && i === 0) {
+      newTimeline.unshift(t); // Keep if latest status
+      priorStage = stage;
+    } else if (stage === RosterStage.SignOut) {
       newTimeline.unshift(t);
       priorStage = RosterStage.NA;
-      continue;
-    }
-    if (stage === priorStage + 1) {
+    } else if (stage === priorStage + 1) {
       newTimeline.unshift(t);
       priorStage = stage;
-      continue;
     }
   }
   return newTimeline;

--- a/src/components/activities/RosterView.tsx
+++ b/src/components/activities/RosterView.tsx
@@ -24,6 +24,10 @@ export function RosterView({ activityId }: { activityId: string }) {
       const rosterEntry = getRosterEntry(participant);
       rosterEntry.timestamps[stage] = timeline[i].time;
     }
+    const firstEntry = rosterEntries.reverse().find((entry) => entry.participantId === participant.id);
+    if (firstEntry) {
+      firstEntry.miles = participant.miles ?? 0;
+    }
   };
 
   const getRosterEntry = (participant: Participant): RosterEntry => {
@@ -31,7 +35,8 @@ export function RosterView({ activityId }: { activityId: string }) {
   };
 
   const createRosterEntry = (participant: Participant) => {
-    const newEntry = buildRosterEntry(participant);
+    const org = activity.organizations[participant.organizationId].rosterName ?? activity.organizations[participant.organizationId].title;
+    const newEntry = buildRosterEntry(participant, org);
     rosterEntries.unshift(newEntry);
     return newEntry;
   };
@@ -56,18 +61,12 @@ export function RosterView({ activityId }: { activityId: string }) {
           <TableHead>
             <TableRow>
               <TableCell sx={headerCellStyle}>Particpant Name</TableCell>
-              <TableCell align="center" sx={headerCellStyle}>
-                Sign In
-              </TableCell>
-              <TableCell align="center" sx={headerCellStyle}>
-                Arrive Base
-              </TableCell>
-              <TableCell align="center" sx={headerCellStyle}>
-                Depart Base
-              </TableCell>
-              <TableCell align="center" sx={headerCellStyle}>
-                Sign Out
-              </TableCell>
+              <TableCell sx={headerCellStyle}>Organization</TableCell>
+              <TableCell sx={headerCellStyle}>Sign In</TableCell>
+              <TableCell sx={headerCellStyle}>Arrive Base</TableCell>
+              <TableCell sx={headerCellStyle}>Depart Base</TableCell>
+              <TableCell sx={headerCellStyle}>Sign Out</TableCell>
+              <TableCell sx={headerCellStyle}>Miles</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -97,11 +96,15 @@ function RosterRow({ rosterEntry }: { rosterEntry: RosterEntry }) {
   return (
     <TableRow>
       <TableCell size="small">{rosterEntry.participantName}</TableCell>
+      <TableCell size="small">{rosterEntry.organizationName}</TableCell>
       {Object.values(rosterEntry.timestamps).map((time, i) => (
-        <TableCell key={i} align="center" size="small">
+        <TableCell key={i} size="small">
           <Stack>{time ? <RosterTimeValue time={time} /> : undefined}</Stack>
         </TableCell>
       ))}
+      <TableCell size="small">
+        <Typography variant="h6">{rosterEntry.miles}</Typography>
+      </TableCell>
     </TableRow>
   );
 }
@@ -139,6 +142,7 @@ const rosterStages: Record<ParticipantStatus, RosterStage> = {
 interface RosterEntry {
   participantId: string;
   participantName: string;
+  organizationName: string;
   timestamps: {
     [RosterStage.SignIn]: number;
     [RosterStage.ArriveBase]: number;
@@ -168,10 +172,11 @@ const scrubTimeline = (timeline: Array<ParticipantUpdate>): Array<ParticipantUpd
   return newTimeline;
 };
 
-const buildRosterEntry = (participant: Participant): RosterEntry => {
+const buildRosterEntry = (participant: Participant, organizationName: string): RosterEntry => {
   return {
     participantId: participant.id,
     participantName: `${participant.firstname} ${participant.lastname}`,
+    organizationName: organizationName,
     timestamps: {
       [RosterStage.SignIn]: 0,
       [RosterStage.ArriveBase]: 0,

--- a/src/components/activities/RosterView.tsx
+++ b/src/components/activities/RosterView.tsx
@@ -5,6 +5,8 @@ import { useAppSelector } from '@respond/lib/client/store';
 import { buildActivitySelector } from '@respond/lib/client/store/activities';
 import { Participant, ParticipantStatus, ParticipantUpdate } from '@respond/types/activity';
 
+import { OutputForm, OutputTime } from '../OutputForm';
+
 const headerCellStyle = { fontWeight: 700, width: 20 };
 
 export function RosterView({ activityId }: { activityId: string }) {
@@ -56,6 +58,10 @@ export function RosterView({ activityId }: { activityId: string }) {
           <Typography variant="h4">
             {activity?.idNumber} {activity?.title}
           </Typography>
+          <OutputForm columns={2}>
+            <OutputTime time={activity.startTime} label="Start Time"></OutputTime>
+            <OutputTime time={activity.endTime} label="End Time"></OutputTime>
+          </OutputForm>
         </Box>
         <Table>
           <TableHead>

--- a/src/components/activities/RosterView.tsx
+++ b/src/components/activities/RosterView.tsx
@@ -1,0 +1,200 @@
+import { Box, Paper, Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material';
+
+import { ToolbarPage } from '@respond/components/ToolbarPage';
+import { useAppSelector } from '@respond/lib/client/store';
+import { buildActivitySelector } from '@respond/lib/client/store/activities';
+import { Activity, Participant, ParticipantStatus, ParticipantUpdate } from '@respond/types/activity';
+
+const headerCellStyle = { fontWeight: 700, width: 20 };
+
+export function RosterView({ activityId }: { activityId: string }) {
+  const activity = useAppSelector(buildActivitySelector(activityId));
+  const roster = new Roster(activity!);
+  return (
+    <ToolbarPage maxWidth="lg">
+      <Paper>
+        <Box padding={2}>
+          <Typography variant="h4">
+            {activity?.idNumber} {activity?.title}
+          </Typography>
+        </Box>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell sx={headerCellStyle}>Particpant Name</TableCell>
+              <TableCell align="center" sx={headerCellStyle}>
+                Sign In
+              </TableCell>
+              <TableCell align="center" sx={headerCellStyle}>
+                Arrive Base
+              </TableCell>
+              <TableCell align="center" sx={headerCellStyle}>
+                Depart Base
+              </TableCell>
+              <TableCell align="center" sx={headerCellStyle}>
+                Sign Out
+              </TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {roster.entries.map((entry, i) => (
+              <RosterRow key={i} rosterEntry={entry} />
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
+    </ToolbarPage>
+  );
+}
+
+function RosterRow({ rosterEntry }: { rosterEntry: RosterEntry }) {
+  return (
+    <TableRow>
+      <TableCell size="small">{rosterEntry.participantName}</TableCell>
+      {Object.values(rosterEntry.timestamps).map((time, i) => (
+        <TableCell key={i} align="center" size="small">
+          <Stack>{time ? <RosterTimeValue time={time} /> : undefined}</Stack>
+        </TableCell>
+      ))}
+    </TableRow>
+  );
+}
+
+function RosterTimeValue({ time }: { time: number }) {
+  const dateString = new Date(time).toLocaleString('en-US', { month: '2-digit', day: '2-digit', year: '2-digit' });
+  const timeString = new Date(time).toLocaleString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit' }).replace(':', '');
+  return (
+    <>
+      <Typography variant="h6">{timeString}</Typography>
+      <Typography variant="caption">{dateString}</Typography>
+    </>
+  );
+}
+
+enum RosterStage {
+  NA = 0,
+  SignIn = 1,
+  ArriveBase = 2,
+  DepartBase = 3,
+  SignOut = 4,
+}
+
+const rosterStages: Record<ParticipantStatus, RosterStage> = {
+  [ParticipantStatus.NotResponding]: RosterStage.NA,
+  [ParticipantStatus.Standby]: RosterStage.NA,
+  [ParticipantStatus.Assigned]: RosterStage.NA,
+  [ParticipantStatus.SignedIn]: RosterStage.SignIn,
+  [ParticipantStatus.Remote]: RosterStage.SignIn,
+  [ParticipantStatus.Available]: RosterStage.ArriveBase,
+  [ParticipantStatus.Demobilized]: RosterStage.DepartBase,
+  [ParticipantStatus.SignedOut]: RosterStage.SignOut,
+};
+
+interface IRosterEntry {
+  participantId: string;
+  participantName: string;
+  timestamps: {
+    [RosterStage.SignIn]: number;
+    [RosterStage.ArriveBase]: number;
+    [RosterStage.DepartBase]: number;
+    [RosterStage.SignOut]: number;
+  };
+  miles: number;
+}
+
+const scrubTimeline = (timeline: Array<ParticipantUpdate>): Array<ParticipantUpdate> => {
+  const newTimeline = [];
+  let priorStage = 0;
+  for (let i = timeline.length - 1; i >= 0; i--) {
+    const t = timeline[i];
+    const stage: RosterStage = rosterStages[t.status] ?? undefined;
+    if (stage === RosterStage.NA) {
+      if (i === 0) {
+        newTimeline.unshift(t); // Keep if latest status
+        priorStage = stage;
+      }
+      continue;
+    }
+    if (stage === RosterStage.SignOut) {
+      newTimeline.unshift(t);
+      priorStage = RosterStage.NA;
+      continue;
+    }
+    if (stage === priorStage + 1) {
+      newTimeline.unshift(t);
+      priorStage = stage;
+      continue;
+    }
+  }
+  return newTimeline;
+};
+
+class Roster {
+  entries: Array<RosterEntry> = [];
+
+  constructor(activity: Activity) {
+    Object.values(activity.participants ?? {}).forEach((participant: Participant) => {
+      this.buildRosterEntries(participant);
+    });
+  }
+
+  buildRosterEntries(participant: Participant) {
+    const timeline: Array<ParticipantUpdate> = scrubTimeline(participant.timeline);
+    for (let i = timeline.length - 1; i >= 0; i--) {
+      const stage: RosterStage = rosterStages[timeline[i].status] ?? undefined;
+      if (!stage) continue; // The participant status is not relavent to the roster.
+      const rosterEntry = this.getRosterEntry(participant);
+      rosterEntry.timestamps[stage] = timeline[i].time;
+    }
+  }
+
+  getRosterEntry(participant: Participant): RosterEntry {
+    return this.findRosterEntry(participant) ?? this.createRosterEntry(participant);
+  }
+
+  createRosterEntry(participant: Participant) {
+    const newEntry = new RosterEntry(participant);
+    this.entries.unshift(newEntry);
+    return newEntry;
+  }
+
+  findRosterEntry(participant: Participant) {
+    return this.entries.find((entry) => entry.participantId === participant.id && !entry.isComplete());
+  }
+}
+
+class RosterEntry implements IRosterEntry {
+  participantId;
+  participantName;
+  timestamps;
+  miles;
+
+  constructor(participant: Participant) {
+    this.participantId = participant.id;
+    this.participantName = `${participant.firstname} ${participant.lastname}`;
+    this.timestamps = {
+      [RosterStage.SignIn]: 0,
+      [RosterStage.ArriveBase]: 0,
+      [RosterStage.DepartBase]: 0,
+      [RosterStage.SignOut]: 0,
+    };
+    this.miles = 0;
+  }
+
+  isComplete(): boolean {
+    return !!this.timestamps[RosterStage.SignOut];
+  }
+
+  getLatestStage(): RosterStage {
+    for (const [key, value] of Object.entries(this.timestamps).reverse()) {
+      if (value) {
+        return parseInt(key);
+      }
+    }
+    return RosterStage.NA;
+  }
+
+  isNext(newStage: RosterStage): boolean {
+    return this.getLatestStage() === newStage - 1;
+  }
+}


### PR DESCRIPTION
This is a revision of the roster-edit PR. In this version, the "scrubbed" roster view is read-only. This would be deployed in conjunction with the timeline-edit PR, which enables timeline editing on the participant dialog.

The use case for this view is for someone who is reviewing or entering the roster in the database. It could also be used to neatly format the roster for a print view.

I've added a "View Roster" button above the Participant cards on Desktop view, only. This is because the Roster View page doesn't scale very conveniently for mobile, and mobile isn't really the use case. This is not for someone responding to a mission, on their phone. It's for someone in base, or at home who needs a formatted view of all participant roster data for the activity.

![image](https://github.com/KingCountySAR/respond-next/assets/11284884/a4bf40c6-0425-4177-97c9-0ac3aa4f6490)

![image](https://github.com/KingCountySAR/respond-next/assets/11284884/529f3ba6-c334-4d71-a476-79f6cf77eb3e)

![image](https://github.com/KingCountySAR/respond-next/assets/11284884/6594291e-e5a7-4e0a-8d73-0ccabcb23a9e)
