### PR TITLE
Fix Roster Parsing Untracked Stage Issue

### DIFF
--- a/src/components/activities/RosterView.tsx
+++ b/src/components/activities/RosterView.tsx
@@ -24,9 +24,18 @@ export function RosterView({ activityId }: { activityId: string }) {
     for (let i = timeline.length - 1; i >= 0; i--) {
       const stage: RosterStage = rosterStages[timeline[i].status] ?? undefined;
       if (!stage) continue; // The participant status is not relavent to the roster.
-      const rosterEntry = findRosterEntry(participant) ?? createRosterEntry(participant, timeline[i].organizationId);
+      let rosterEntry = findRosterEntry(participant);
+      if (rosterEntry === undefined) {
+        if (stage !== RosterStage.SignIn) {
+          continue; // Skip signouts and unreportable transitions.
+        } else {
+          rosterEntry = createRosterEntry(participant, timeline[i].organizationId);
+        }
+      }
       rosterEntry.timestamps[stage] = timeline[i].time;
     }
+    // Miles are currently only tracked in aggregate at the participant level. For now, we only
+    // want to append them to the first roster entry for this participant.
     const firstEntry = rosterEntries.reverse().find((entry) => entry.participantId === participant.id);
     if (firstEntry) {
       firstEntry.miles = participant.miles ?? 0;

--- a/src/components/activities/RosterView.tsx
+++ b/src/components/activities/RosterView.tsx
@@ -27,7 +27,7 @@ export function RosterView({ activityId }: { activityId: string }) {
       let rosterEntry = findRosterEntry(participant);
       if (rosterEntry === undefined) {
         if (stage !== RosterStage.SignIn) {
-          continue; // Skip signouts and unreportable transitions.
+          continue; // Skip orphaned status transitions by requiring a sign in status first.
         } else {
           rosterEntry = createRosterEntry(participant, timeline[i].organizationId);
         }


### PR DESCRIPTION
While working on the Switch Units functionality I uncovered a problem with the roster view: status transitions that go from an un-tracked status to signed out were creating unexpected results. Namely, Standby => Sign out was resulting in a bunch of sing out only rows. This will account for other unexpected timeline chronology better, in any case, though.

## Fixed
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/3560c699-cc38-4952-b26d-aba9e6f68779)

## Borked
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/b869473a-688b-4374-be08-41f18cdbe596)