### PR TITLE
fix: handle status time null

### DIFF
--- a/src/components/StatusUpdater/UpdateStatusForm.tsx
+++ b/src/components/StatusUpdater/UpdateStatusForm.tsx
@@ -39,6 +39,14 @@ export function useFormLogic(activity: Activity, user: UserInfo, respondingOrg: 
         message: 'Must be a positive number',
       };
     }
+
+    if (!values.statusTime) {
+      result.errors.statusTime = {
+        type: 'required',
+        message: 'Status time is required',
+      };
+    }
+
     const statusTimeAsDate = parseDate(values.statusTime, TextBoxDateFormat, new Date());
     const lastStatusChangeTime = participant?.timeline[0].time;
     if (lastStatusChangeTime && !isNaN(lastStatusChangeTime) && statusTimeAsDate.getTime() < lastStatusChangeTime) {

--- a/src/components/activities/ParticipantTimeline.tsx
+++ b/src/components/activities/ParticipantTimeline.tsx
@@ -29,8 +29,10 @@ export default function ParticipantTimeline({ participant, activity }: { partici
 }
 
 function ParticipantUpdateTile({ record, onChange }: { record: EnrichedParticipantUpdate; onChange: (time: number) => void }) {
+  const initialTime = record.time ?? new Date().getTime(); // Backward Compatability; timelines might have null time values. This ensures a value is present so it can be edited.
+
   const [edit, setEdit] = useState(false);
-  const [time, setTime] = useState(record.time);
+  const [time, setTime] = useState(initialTime);
   const handleAccept = (newTime: number | null) => {
     if (newTime) {
       setTime(newTime);
@@ -44,7 +46,7 @@ function ParticipantUpdateTile({ record, onChange }: { record: EnrichedParticipa
     <Box>
       {edit ? (
         <Stack flexGrow={1} direction="row" justifyContent="space-between">
-          <DateTimePicker value={record.time} label={`${record.organizationName} - ${record.statusText}`} format="MM/dd HH:mm" onAccept={handleAccept} onClose={handleClose} />
+          <DateTimePicker value={initialTime} label={`${record.organizationName} - ${record.statusText}`} format="MM/dd HH:mm" onAccept={handleAccept} onClose={handleClose} />
           <IconButton disableRipple onClick={handleClose}>
             <Close />
           </IconButton>


### PR DESCRIPTION
Bug Fix

Status updater allows `null` time entry. Subsequently, the `ParticipantUpdateTile` component is expecting a non-null value; it throws a fatal error on null.

![image](https://github.com/KingCountySAR/respond-next/assets/11284884/917a7cfd-e9fe-4121-af62-996aaba1d856)

![image](https://github.com/KingCountySAR/respond-next/assets/11284884/5367e31f-ce93-4e65-a047-a11f790a0c8a)

https://trello.com/c/MBwkL5WZ

* Adds validation for status time `!null` in `StatusUpdater`.
* Adds `null` handling for backwards compatibility in `ParticipantUpdateTile`

![image](https://github.com/KingCountySAR/respond-next/assets/11284884/22a6e066-3345-4bb0-8971-10654bb952f5)
