### PR TITLE
Fix preferences race condition

### DIFF
--- a/src/components/AppMenu.tsx
+++ b/src/components/AppMenu.tsx
@@ -68,7 +68,7 @@ export function AppMenu() {
           </MenuItem>
         </Menu>
       </div>
-      {openPreferences && <PreferencesDialog open={openPreferences} onClose={handleClosePreferences} />}
+      <PreferencesDialog open={openPreferences} onClose={handleClosePreferences} />
     </>
   );
 }

--- a/src/components/AppMenu.tsx
+++ b/src/components/AppMenu.tsx
@@ -68,7 +68,7 @@ export function AppMenu() {
           </MenuItem>
         </Menu>
       </div>
-      <PreferencesDialog open={openPreferences} onClose={handleClosePreferences} />
+      {openPreferences && <PreferencesDialog open={openPreferences} onClose={handleClosePreferences} />}
     </>
   );
 }

--- a/src/components/Preferences.tsx
+++ b/src/components/Preferences.tsx
@@ -1,57 +1,67 @@
-import { Button, Dialog, DialogContent, DialogTitle, FormControl, InputLabel, MenuItem, Select, SelectChangeEvent, Stack } from '@mui/material';
-import { useState } from 'react';
+import { Button, Dialog, DialogContent, DialogTitle, FormControl, FormHelperText, InputLabel, MenuItem, Select, Stack } from '@mui/material';
+import { Controller, useForm } from 'react-hook-form';
 
 import { useAppDispatch, useAppSelector } from '@respond/lib/client/store';
-import { PreferenceActions } from '@respond/lib/client/store/preferences';
+import { PerferencesState, PreferenceActions } from '@respond/lib/client/store/preferences';
 
 import { MobilePageId } from './activities/MobileActivityPage';
 
-interface PreferenceDialogProps {
-  open: boolean;
-  onClose: () => void;
-}
-
-export function PreferencesDialog(props: PreferenceDialogProps) {
-  const { onClose, open } = props;
+export function PreferencesDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
   const dispatch = useAppDispatch();
-  const initialState = useAppSelector((state) => state.preferences);
-  const [preferences, setPreferences] = useState(initialState);
 
-  const handleClose = (): void => {
-    setPreferences(initialState);
-    onClose();
-  };
-
-  const handleSave = (): void => {
+  const handleSubmit = (preferences: PerferencesState) => {
     dispatch(PreferenceActions.update(preferences));
     onClose();
   };
 
-  const handleDefaultMobileViewChange = (event: SelectChangeEvent): void => {
-    setPreferences({ ...preferences, defaultMobileView: event.target.value as MobilePageId });
+  const handleCancel = () => {
+    onClose();
   };
 
   return (
-    <Dialog fullWidth={true} onClose={handleClose} open={open}>
+    <Dialog fullWidth={true} onClose={onClose} open={open}>
       <DialogTitle>Preferences</DialogTitle>
-      <DialogContent>
-        <Stack spacing={2} marginTop={2}>
-          <FormControl fullWidth>
-            <InputLabel id="default-mobile-view-select-label">Default Mobile View</InputLabel>
-            <Select labelId="default-mobile-view-select-label" id="default-mobile-view-select" value={preferences.defaultMobileView} label="Default Mobile View" onChange={handleDefaultMobileViewChange}>
-              <MenuItem value={MobilePageId.Manage}>{MobilePageId.Manage}</MenuItem>
-              <MenuItem value={MobilePageId.Roster}>{MobilePageId.Roster}</MenuItem>
-              <MenuItem value={MobilePageId.Briefing}>{MobilePageId.Briefing}</MenuItem>
-            </Select>
-          </FormControl>
-          <Button variant="contained" onClick={handleSave}>
-            Save
-          </Button>
-          <Button variant="outlined" onClick={handleClose}>
-            Cancel
-          </Button>
-        </Stack>
-      </DialogContent>
+      <DialogContent>{open && <PreferencesForm onSubmit={handleSubmit} onCancel={handleCancel} />}</DialogContent>
     </Dialog>
+  );
+}
+
+function PreferencesForm({ onCancel, onSubmit }: { onCancel: () => void; onSubmit: (preferences: PerferencesState) => void }) {
+  const defaultValues = useAppSelector((state) => state.preferences);
+
+  const {
+    control,
+    handleSubmit,
+    formState: { isDirty, errors },
+  } = useForm<PerferencesState>({
+    defaultValues,
+  });
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Stack spacing={2} marginTop={2}>
+        <Controller
+          name="defaultMobileView"
+          control={control}
+          render={({ field }) => (
+            <FormControl fullWidth error={!!errors.defaultMobileView?.message}>
+              <InputLabel variant="outlined">Default Mobile View</InputLabel>
+              <Select {...field} variant="outlined" label="Default Mobile View">
+                <MenuItem value={MobilePageId.Manage}>{MobilePageId.Manage}</MenuItem>
+                <MenuItem value={MobilePageId.Roster}>{MobilePageId.Roster}</MenuItem>
+                <MenuItem value={MobilePageId.Briefing}>{MobilePageId.Briefing}</MenuItem>
+              </Select>
+              <FormHelperText>{errors.defaultMobileView?.message}</FormHelperText>
+            </FormControl>
+          )}
+        />
+        <Button disabled={!isDirty} type="submit" variant="contained">
+          Save
+        </Button>
+        <Button variant="outlined" onClick={onCancel}>
+          Cancel
+        </Button>
+      </Stack>
+    </form>
   );
 }


### PR DESCRIPTION
I found a minor bug with the Preferences dialog: On first open, the dialog loads with the default state. If you cancel and re-open it, it has the actual saved state. There seems to be a race condition between the dialog initializing and the redux store loading. I refactored the AppMenu so that the Preferences Dialog is only rendered if it is open; this means that the dialog does not check the store for the user's preferences until it is accessed.