### PR TITLE
Roster Print/Save PDF View and CSV Download

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-dom": "18.2.0",
     "react-hook-form": "^7.43.6",
     "react-redux": "^8.0.5",
+    "react-to-print": "^2.14.15",
     "socket.io": "^4.6.1",
     "socket.io-client": "^4.6.1",
     "typescript": "4.9.5",

--- a/src/app/(main)/roster/[activityId]/page.tsx
+++ b/src/app/(main)/roster/[activityId]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
-import { RosterView } from '@respond/components/activities/RosterView';
+import { RosterReview } from '@respond/components/activities/RosterView';
 
 export default function ViewRoster({ params }: { params: { activityId: string } }) {
-  return <RosterView activityId={params.activityId} />;
+  return <RosterReview activityId={params.activityId} />;
 }

--- a/src/app/(main)/roster/[activityId]/print/page.tsx
+++ b/src/app/(main)/roster/[activityId]/print/page.tsx
@@ -1,6 +1,0 @@
-'use client';
-import { RosterPrint } from '@respond/components/activities/RosterView';
-
-export default function ViewPrintRoster({ params }: { params: { activityId: string } }) {
-  return <RosterPrint activityId={params.activityId} />;
-}

--- a/src/app/(main)/roster/[activityId]/print/page.tsx
+++ b/src/app/(main)/roster/[activityId]/print/page.tsx
@@ -1,0 +1,6 @@
+'use client';
+import { RosterPrint } from '@respond/components/activities/RosterView';
+
+export default function ViewPrintRoster({ params }: { params: { activityId: string } }) {
+  return <RosterPrint activityId={params.activityId} />;
+}

--- a/src/components/activities/RosterView.tsx
+++ b/src/components/activities/RosterView.tsx
@@ -24,7 +24,7 @@ export function RosterReview({ activityId }: { activityId: string }) {
         .map((v) => `"${v}"`) // quote it
         .join(','); // comma-separated;
     });
-    data.unshift(`"id","participant_name","organization_name","sign_in","arrive_base","depart_base","sign_out","miles"`);
+    data.unshift(`"participant_id","participant_name","organization_name","sign_in","arrive_base","depart_base","sign_out","miles"`);
     const blob = new Blob([data.join('\r\n')], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(blob);
 

--- a/src/components/activities/RosterView.tsx
+++ b/src/components/activities/RosterView.tsx
@@ -1,99 +1,106 @@
-import { Box, Paper, Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material';
-import { differenceInCalendarDays } from 'date-fns';
+import { Box, Button, Divider, Paper, Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material';
+import { differenceInCalendarDays, format as formatDate } from 'date-fns';
+import { useRouter } from 'next/navigation';
 
 import { ToolbarPage } from '@respond/components/ToolbarPage';
 import { useAppSelector } from '@respond/lib/client/store';
 import { buildActivitySelector } from '@respond/lib/client/store/activities';
-import { getOrganizationName, Participant, ParticipantStatus, ParticipantUpdate } from '@respond/types/activity';
+import { Activity, getOrganizationName, Participant, ParticipantStatus, ParticipantUpdate } from '@respond/types/activity';
 
 import { OutputForm, OutputText, OutputTime } from '../OutputForm';
 
 const headerCellStyle = { fontWeight: 700, width: 20 };
 
-export function RosterView({ activityId }: { activityId: string }) {
+export function RosterReview({ activityId }: { activityId: string }) {
+  const router = useRouter();
   const activity = useAppSelector(buildActivitySelector(activityId));
+  const rosterEntries = getRosterEntries(activity);
 
-  if (!activity) {
-    return <ActivityNotFound />;
-  }
+  const download = () => {
+    const data = rosterEntries.map((e) => {
+      return [e.participantId, e.participantName, e.organizationName, ...Object.values(e.timestamps).map((t) => (t ? formatDate(t, 'MM/dd/yy hh:mm a') : '')), e.miles]
+        .map(String) // convert every value to String
+        .map((v) => v.replaceAll('"', '""')) // escape double quotes
+        .map((v) => `"${v}"`) // quote it
+        .join(','); // comma-separated;
+    });
+    data.unshift(`"id","participant_name","organization_name","sign_in","arrive_base","depart_base","sign_out","miles"`);
+    const blob = new Blob([data.join('\r\n')], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
 
-  const rosterEntries: Array<RosterEntry> = [];
-
-  const buildRosterEntries = (participant: Participant) => {
-    const timeline: Array<ParticipantUpdate> = scrubTimeline(participant.timeline);
-    for (let i = timeline.length - 1; i >= 0; i--) {
-      const stage: RosterStage = rosterStages[timeline[i].status] ?? undefined;
-      if (!stage) continue; // The participant status is not relavent to the roster.
-      let rosterEntry = findRosterEntry(participant);
-      if (rosterEntry === undefined) {
-        if (stage !== RosterStage.SignIn) {
-          continue; // Skip orphaned status transitions by requiring a sign in status first.
-        } else {
-          rosterEntry = createRosterEntry(participant, timeline[i].organizationId);
-        }
-      }
-      rosterEntry.timestamps[stage] = timeline[i].time;
-    }
-    // Miles are currently only tracked in aggregate at the participant level. For now, we only
-    // want to append them to the first roster entry for this participant.
-    const firstEntry = rosterEntries.reverse().find((entry) => entry.participantId === participant.id);
-    if (firstEntry) {
-      firstEntry.miles = participant.miles ?? 0;
-    }
+    // Create a link to download it
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.setAttribute('download', 'roster.csv');
+    anchor.click();
+    anchor.remove();
   };
-
-  const createRosterEntry = (participant: Participant, organizationId: string) => {
-    const org = getOrganizationName(activity, organizationId);
-    const newEntry = buildRosterEntry(participant, org);
-    rosterEntries.unshift(newEntry);
-    return newEntry;
-  };
-
-  const findRosterEntry = (participant: Participant) => {
-    return rosterEntries.find((entry) => entry.participantId === participant.id && !isComplete(entry));
-  };
-
-  Object.values(activity.participants ?? {}).forEach((participant: Participant) => {
-    buildRosterEntries(participant);
-  });
 
   return (
     <ToolbarPage maxWidth="lg">
-      <Paper>
-        <Table size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell colSpan={7}>
-                <OutputForm columns={2}>
-                  <Stack>
-                    <OutputText label="Name" value={activity?.title}></OutputText>
-                    <OutputText label="State #" value={activity?.idNumber}></OutputText>
-                  </Stack>
-                  <Stack>
-                    <OutputTime time={activity.startTime} label="Start Time"></OutputTime>
-                    <OutputTime time={activity.endTime} label="End Time"></OutputTime>
-                  </Stack>
-                </OutputForm>
-              </TableCell>
-            </TableRow>
-            <TableRow>
-              <TableCell sx={headerCellStyle}>Particpant Name</TableCell>
-              <TableCell sx={headerCellStyle}>Organization</TableCell>
-              <TableCell sx={headerCellStyle}>Sign In</TableCell>
-              <TableCell sx={headerCellStyle}>Arrive Base</TableCell>
-              <TableCell sx={headerCellStyle}>Depart Base</TableCell>
-              <TableCell sx={headerCellStyle}>Sign Out</TableCell>
-              <TableCell sx={headerCellStyle}>Miles</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {rosterEntries.map((entry, i) => (
-              <RosterRow key={i} rosterEntry={entry} activityStartTime={activity.startTime} />
-            ))}
-          </TableBody>
-        </Table>
-      </Paper>
+      <Stack direction="row" flex="1 1 auto" spacing={1} divider={<Divider orientation="vertical" flexItem />}>
+        <Box display="flex" flex="1 1 auto" flexDirection="column">
+          <Paper>{activity ? <Roster activity={activity} rosterEntries={rosterEntries} /> : <ActivityNotFound />}</Paper>
+        </Box>
+        <Stack alignItems="stretch" spacing={2}>
+          <Button variant="outlined" onClick={download}>
+            Download (csv)
+          </Button>
+          <Button variant="outlined" onClick={() => router.push(`/roster/${activityId}/print`)}>
+            Print
+          </Button>
+        </Stack>
+      </Stack>
     </ToolbarPage>
+  );
+}
+
+export function RosterPrint({ activityId }: { activityId: string }) {
+  const router = useRouter();
+  const activity = useAppSelector(buildActivitySelector(activityId));
+  const rosterEntries = getRosterEntries(activity);
+  window.onafterprint = () => router.back();
+  setTimeout(() => {
+    window.print();
+  }, 1000);
+  return <>{activity ? <Roster activity={activity} rosterEntries={rosterEntries} /> : <ActivityNotFound />}</>;
+}
+
+function Roster({ activity, rosterEntries }: { activity: Activity; rosterEntries: Array<RosterEntry> }) {
+  if (!rosterEntries.length) return <ActivityNotFound />;
+  return (
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          <TableCell colSpan={7}>
+            <OutputForm columns={2}>
+              <Stack>
+                <OutputText label="Name" value={activity?.title}></OutputText>
+                <OutputText label="State #" value={activity?.idNumber}></OutputText>
+              </Stack>
+              <Stack>
+                <OutputTime time={activity.startTime} label="Start Time"></OutputTime>
+                <OutputTime time={activity.endTime} label="End Time"></OutputTime>
+              </Stack>
+            </OutputForm>
+          </TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell sx={headerCellStyle}>Particpant Name</TableCell>
+          <TableCell sx={headerCellStyle}>Organization</TableCell>
+          <TableCell sx={headerCellStyle}>Sign In</TableCell>
+          <TableCell sx={headerCellStyle}>Arrive Base</TableCell>
+          <TableCell sx={headerCellStyle}>Depart Base</TableCell>
+          <TableCell sx={headerCellStyle}>Sign Out</TableCell>
+          <TableCell sx={headerCellStyle}>Miles</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {rosterEntries.map((entry, i) => (
+          <RosterRow key={i} rosterEntry={entry} activityStartTime={activity.startTime} />
+        ))}
+      </TableBody>
+    </Table>
   );
 }
 
@@ -208,4 +215,50 @@ const buildRosterEntry = (participant: Participant, organizationName: string): R
 
 const isComplete = (entry: RosterEntry): boolean => {
   return !!entry.timestamps[RosterStage.SignOut];
+};
+
+const getRosterEntries = (activity?: Activity) => {
+  if (!activity) return [];
+
+  const rosterEntries: Array<RosterEntry> = [];
+
+  const buildRosterEntries = (participant: Participant) => {
+    const timeline: Array<ParticipantUpdate> = scrubTimeline(participant.timeline);
+    for (let i = timeline.length - 1; i >= 0; i--) {
+      const stage: RosterStage = rosterStages[timeline[i].status] ?? undefined;
+      if (!stage) continue; // The participant status is not relavent to the roster.
+      let rosterEntry = findRosterEntry(participant);
+      if (rosterEntry === undefined) {
+        if (stage !== RosterStage.SignIn) {
+          continue; // Skip orphaned status transitions by requiring a sign in status first.
+        } else {
+          rosterEntry = createRosterEntry(participant, timeline[i].organizationId);
+        }
+      }
+      rosterEntry.timestamps[stage] = timeline[i].time;
+    }
+    // Miles are currently only tracked in aggregate at the participant level. For now, we only
+    // want to append them to the first roster entry for this participant.
+    const firstEntry = rosterEntries.reverse().find((entry) => entry.participantId === participant.id);
+    if (firstEntry) {
+      firstEntry.miles = participant.miles ?? 0;
+    }
+  };
+
+  const createRosterEntry = (participant: Participant, organizationId: string) => {
+    const org = getOrganizationName(activity, organizationId);
+    const newEntry = buildRosterEntry(participant, org);
+    rosterEntries.unshift(newEntry);
+    return newEntry;
+  };
+
+  const findRosterEntry = (participant: Participant) => {
+    return rosterEntries.find((entry) => entry.participantId === participant.id && !isComplete(entry));
+  };
+
+  Object.values(activity.participants ?? {}).forEach((participant: Participant) => {
+    buildRosterEntries(participant);
+  });
+
+  return rosterEntries;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4995,6 +4995,11 @@ react-redux@^8.0.5:
     react-is "^18.0.0"
     use-sync-external-store "^1.0.0"
 
+react-to-print@^2.14.15:
+  version "2.14.15"
+  resolved "https://registry.yarnpkg.com/react-to-print/-/react-to-print-2.14.15.tgz#edb4ce8a92205cf37fd8c3d57de829034aa5c911"
+  integrity sha512-SKnwOzU2cJ8eaAkoJO7+gNhvfEDmm+Y34IdcHsjtHioUevUPhprqbVtvNJlZ2JkGJ8ExK2QNWM9pXECTDR5D8w==
+
 react-transition-group@^4.4.5:
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"


### PR DESCRIPTION
Refactor of the Roster page to implement cleaner print view and add option for CSV download.
* The print/save PDF view only renders the table; auto pops the print dialog; redirects back to the roster view after the print dialog closes.
* Download to CSV was a feedback ask after the initial roster view rollout.

![image](https://github.com/KingCountySAR/respond-next/assets/11284884/8b05b2ef-ef87-498a-a2ab-4fcb9ef18482)

![image](https://github.com/KingCountySAR/respond-next/assets/11284884/4afddc75-75ac-4491-b692-f63efee3e8b4)

![image](https://github.com/KingCountySAR/respond-next/assets/11284884/6afc5580-7ea1-452b-8e12-a6cd02315b2c)
