### PR TITLE
Implement Consistent Date Inputs

### DIFF
--- a/src/components/StatusUpdater/UpdateStatusForm.tsx
+++ b/src/components/StatusUpdater/UpdateStatusForm.tsx
@@ -193,6 +193,9 @@ export const StatusTimeInput = ({ form: { control, errors } }: { form: FormLogic
             label="Status Time"
             value={field.value}
             inputRef={field.ref}
+            onChange={(date) => {
+              field.onChange(date);
+            }}
             onAccept={(date) => {
               field.onChange(date);
             }}

--- a/src/components/StatusUpdater/UpdateStatusForm.tsx
+++ b/src/components/StatusUpdater/UpdateStatusForm.tsx
@@ -1,5 +1,5 @@
 import { FormControlLabel } from '@mui/material';
-import { format as formatDate, parse as parseDate } from 'date-fns';
+import { DateTimePicker } from '@mui/x-date-pickers';
 import { useEffect, useState } from 'react';
 import { Control, Controller, FieldErrors, Resolver, ResolverResult, SubmitHandler, useForm } from 'react-hook-form';
 
@@ -9,13 +9,13 @@ import { Activity, OrganizationStatus, Participant, ParticipantStatus } from '@r
 import { MyOrganization } from '@respond/types/organization';
 import { UserInfo } from '@respond/types/userInfo';
 
-import { Box, DialogContentText, FormControl, FormHelperText, Radio, RadioGroup, Stack, TextField, Typography } from '../Material';
-import { formatTime, TextBoxDateFormat } from '../RelativeTimeText';
+import { DialogContentText, FormControl, FormHelperText, Radio, RadioGroup, Stack, TextField, Typography } from '../Material';
+import { formatTime } from '../RelativeTimeText';
 
 interface FormValues {
   miles: number | '';
   addMiles: number | '';
-  statusTime: string;
+  statusTime: number;
 }
 
 export function useFormLogic(activity: Activity, user: UserInfo, respondingOrg: MyOrganization, participant: Participant | undefined, currentStatus: ParticipantStatus | undefined, newStatus: ParticipantStatus, onFinish: () => void) {
@@ -47,9 +47,8 @@ export function useFormLogic(activity: Activity, user: UserInfo, respondingOrg: 
       };
     }
 
-    const statusTimeAsDate = parseDate(values.statusTime, TextBoxDateFormat, new Date());
     const lastStatusChangeTime = participant?.timeline[0].time;
-    if (lastStatusChangeTime && !isNaN(lastStatusChangeTime) && statusTimeAsDate.getTime() < lastStatusChangeTime) {
+    if (lastStatusChangeTime && !isNaN(lastStatusChangeTime) && values.statusTime < lastStatusChangeTime) {
       result.errors.statusTime = {
         type: 'min',
         message: 'Cannot be earlier than previous status change at ' + formatTime(lastStatusChangeTime),
@@ -61,7 +60,7 @@ export function useFormLogic(activity: Activity, user: UserInfo, respondingOrg: 
 
   const form = useForm<FormValues>({
     resolver,
-    defaultValues: { miles: participant?.miles ?? '', addMiles: '', statusTime: '' },
+    defaultValues: { miles: participant?.miles ?? '', addMiles: '', statusTime: new Date().getTime() },
   });
   if (form.getValues().miles !== (participant?.miles ?? '')) {
     form.reset({ miles: participant?.miles ?? '', addMiles: '' });
@@ -72,8 +71,7 @@ export function useFormLogic(activity: Activity, user: UserInfo, respondingOrg: 
       data.miles = Number(data.miles ?? 0) + Number(data.addMiles);
     }
 
-    const statusTimeAsDate = parseDate(data.statusTime, TextBoxDateFormat, new Date());
-    const time = statusTimeAsDate.getTime();
+    const time = new Date(data.statusTime).getTime();
 
     if (!activity.organizations[respondingOrg.id]) {
       dispatch(
@@ -115,7 +113,7 @@ export const TotalMilesInput = ({ control, errors }: { control: Control<FormValu
       control={control}
       render={({ field }) => (
         <FormControl error={!!errors.miles?.message}>
-          <TextField {...field} type="number" variant="filled" size="small" label="Round-trip Miles" />
+          <TextField {...field} type="number" variant="outlined" label="Round-trip Miles" />
           <FormHelperText>{errors.miles?.message}</FormHelperText>
         </FormControl>
       )}
@@ -155,7 +153,7 @@ const MileageSection = ({ existingMiles, form: { control, errors, getValues, set
   return existingMiles == null ? (
     <TotalMilesInput control={control} errors={errors} />
   ) : (
-    <Box>
+    <Stack>
       <Typography>You currently have {existingMiles} round-trip miles.</Typography>
       <FormControl>
         <RadioGroup row value={isTotalMiles} onChange={handleMilesType}>
@@ -164,27 +162,23 @@ const MileageSection = ({ existingMiles, form: { control, errors, getValues, set
         </RadioGroup>
       </FormControl>
       {isTotalMiles ? (
-        <Box>
-          <TotalMilesInput control={control} errors={errors} />
-        </Box>
+        <TotalMilesInput control={control} errors={errors} />
       ) : (
         <>
-          <Box>
-            <Controller
-              name="addMiles"
-              control={control}
-              render={({ field }) => (
-                <FormControl error={!!errors.miles?.message}>
-                  <TextField {...field} onChange={handleAddMiles} type="number" variant="filled" size="small" label="Leg Miles" />
-                  <FormHelperText>{errors.miles?.message}</FormHelperText>
-                </FormControl>
-              )}
-            />
-          </Box>
+          <Controller
+            name="addMiles"
+            control={control}
+            render={({ field }) => (
+              <FormControl error={!!errors.miles?.message}>
+                <TextField {...field} onChange={handleAddMiles} type="number" variant="outlined" label="Leg Miles" />
+                <FormHelperText>{errors.miles?.message}</FormHelperText>
+              </FormControl>
+            )}
+          />
           <Typography>New Total Miles: {formatMilesSum(getValues().miles, addMilesPreview)}</Typography>
         </>
       )}
-    </Box>
+    </Stack>
   );
 };
 
@@ -195,7 +189,15 @@ export const StatusTimeInput = ({ form: { control, errors } }: { form: FormLogic
       control={control}
       render={({ field }) => (
         <FormControl error={!!errors.statusTime?.message}>
-          <TextField {...field} type="datetime-local" variant="filled" size="small" />
+          <DateTimePicker
+            label="Status Time"
+            value={field.value}
+            inputRef={field.ref}
+            onAccept={(date) => {
+              field.onChange(date);
+            }}
+            format="MM/dd HH:mm"
+          />
           <FormHelperText>{errors.statusTime?.message}</FormHelperText>
         </FormControl>
       )}
@@ -214,17 +216,13 @@ export const UpdateStatusForm = ({ form }: { form: FormLogic }) => {
       // Reset the form as the same useForm object is reused.
       form.reset();
 
-      const currentTime = new Date();
-      const currentTimeAsString = formatDate(currentTime, TextBoxDateFormat);
-
       // Set fields with dynamic default values.
       form.setValue('miles', participant?.miles ?? '');
-      form.setValue('statusTime', currentTimeAsString);
     }
   }, [isInitialized, form, participant?.miles]);
 
   return (
-    <Stack spacing={2} alignItems="flex-start">
+    <Stack flexGrow={1} spacing={2} justifyContent="space-between">
       <DialogContentText id="status-update-dialog-description">Change your status for {activity.title}?</DialogContentText>
       <StatusTimeInput form={form} />
       {newStatus === ParticipantStatus.SignedOut ? <MileageSection form={form} existingMiles={participant?.miles} /> : undefined}

--- a/src/components/activities/ActivityEditPage.tsx
+++ b/src/components/activities/ActivityEditPage.tsx
@@ -271,6 +271,9 @@ export const ActivityEditPage = ({ activityType, activityId }: { activityType: A
                       label="Start Time"
                       value={field.value}
                       inputRef={field.ref}
+                      onChange={(date) => {
+                        field.onChange(date);
+                      }}
                       onAccept={(date) => {
                         field.onChange(date);
                       }}

--- a/src/components/activities/ParticipantTimeline.tsx
+++ b/src/components/activities/ParticipantTimeline.tsx
@@ -46,7 +46,7 @@ function ParticipantUpdateTile({ record, onChange }: { record: EnrichedParticipa
     <Box>
       {edit ? (
         <Stack flexGrow={1} direction="row" justifyContent="space-between">
-          <DateTimePicker value={initialTime} label={`${record.organizationName} - ${record.statusText}`} format="MM/dd HH:mm" onAccept={handleAccept} onClose={handleClose} />
+          <DateTimePicker value={initialTime} label={`${record.organizationName} - ${record.statusText}`} format="MM/dd HH:mm" onChange={handleAccept} onAccept={handleAccept} onClose={handleClose} />
           <IconButton disableRipple onClick={handleClose}>
             <Close />
           </IconButton>


### PR DESCRIPTION
There are 3 places where we have date inputs:
* ActivityEditPage
* UpdateStatusForm
* ParticipantTimeline

This migrates `ActivityEditPage` and `UpdateStatusForm` to use `DateTimePicker`; `ParticipantTimeline` already implements it.

`DateTimePicker` handles millisecond datetime values directly, eliminating the need to do string conversions/parsing and separation of the date and time values. It also lets mobile devices handle the datetime using default UI for the device.

Since I was already messing with the form fields, I also migrated them to the "outlined" variant. on these pages.

**Note: This update deprecated a bunch of string conversion logic around `Activity.startTime`. I think it would be prudent to put this in the dev environment and test it with some meetings/trainings to make sure there aren't any issues.**

## Activity Edit Page
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/1127f55b-9e5d-4d34-a2e4-599eb9d07c7b)

## UpdateStatusTime
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/c3fcf701-9e6a-4f1f-96f2-87bd98bfc06f)
