### PR TITLE
Participant ETA

### DIFF
--- a/src/components/InlineTimeEdit.tsx
+++ b/src/components/InlineTimeEdit.tsx
@@ -1,0 +1,16 @@
+import { Close } from '@mui/icons-material';
+import { DateTimePicker } from '@mui/x-date-pickers';
+import { DateOrTimeViewWithMeridiem } from '@mui/x-date-pickers/internals/models';
+
+import { IconButton, Stack } from './Material';
+
+export function InlineTimeEdit({ label, format, openTo, onChange, onClose }: { label: string; format: string; openTo: DateOrTimeViewWithMeridiem | undefined; onChange: (time: number | null) => void; onClose: () => void }) {
+  return (
+    <Stack flexGrow={1} direction="row" justifyContent="space-between">
+      <DateTimePicker value={new Date().getTime()} label={label} format={format} onAccept={onChange} onClose={onClose} openTo={openTo} />
+      <IconButton disableRipple onClick={onClose}>
+        <Close />
+      </IconButton>
+    </Stack>
+  );
+}

--- a/src/components/activities/DesktopActivityPage.tsx
+++ b/src/components/activities/DesktopActivityPage.tsx
@@ -92,10 +92,9 @@ function RosterRow({ participant, orgs, onClick }: { participant: Participant; o
               {orgs[participant.organizationId]?.rosterName ?? orgs[participant.organizationId]?.title} {participant.tags?.join(', ')}
             </Typography>
           </Stack>
-          <Stack>
-            <Typography variant="body1">
-              {getStatusText(participant.timeline[0].status)} {isEnrouteOrStandby(participant.timeline[0].status) && participant.eta ? <>(ETA {formatDate(participant.eta, 'HHmm')})</> : <></>}
-            </Typography>
+          <Stack textAlign={'right'} justifyContent={'space-between'}>
+            <Typography variant="body2">{getStatusText(participant.timeline[0].status)}</Typography>
+            <Typography variant="body2">{isEnrouteOrStandby(participant.timeline[0].status) && participant.eta ? <>ETA {formatDate(participant.eta, 'HHmm')}</> : <></>}</Typography>
           </Stack>
         </Stack>
       </Stack>

--- a/src/components/activities/MobileActivityPage.tsx
+++ b/src/components/activities/MobileActivityPage.tsx
@@ -85,10 +85,9 @@ function RosterRow({ participant, orgs, onClick }: { participant: Participant; o
             {orgs[participant.organizationId]?.rosterName ?? orgs[participant.organizationId]?.title} {participant.tags?.join(', ')}
           </Typography>
         </Stack>
-        <Stack>
-          <Typography variant="body1">
-            {getStatusText(participant.timeline[0].status)} {isEnrouteOrStandby(participant.timeline[0].status) && participant.eta ? <>({formatDate(participant.eta, 'HHmm')})</> : <></>}
-          </Typography>
+        <Stack textAlign={'right'} justifyContent={'space-between'}>
+          <Typography variant="body2">{getStatusText(participant.timeline[0].status)}</Typography>
+          <Typography variant="body2">{isEnrouteOrStandby(participant.timeline[0].status) && participant.eta ? <>ETA {formatDate(participant.eta, 'HHmm')}</> : <></>}</Typography>
         </Stack>
       </Stack>
     </RosterRowCard>

--- a/src/components/participant/ParticipantEtaUpdater.tsx
+++ b/src/components/participant/ParticipantEtaUpdater.tsx
@@ -1,0 +1,93 @@
+import { Close } from '@mui/icons-material';
+import AccessTime from '@mui/icons-material/AccessTime';
+import AddIcon from '@mui/icons-material/Add';
+import RemoveIcon from '@mui/icons-material/Remove';
+import { DateTimePicker } from '@mui/x-date-pickers';
+import { format as formatDate } from 'date-fns';
+import { useEffect, useState } from 'react';
+
+import { useAppDispatch } from '@respond/lib/client/store';
+import { ActivityActions } from '@respond/lib/state';
+
+import { Button, IconButton, Stack, Typography } from '../Material';
+
+const ONE_MINUTE_MILLISECONDS = 60 * 1000;
+const FIFTEEN_MINUTES_MILLISECONDS = 15 * 60 * 1000;
+const THIRTY_MINUTES_MILLISECONDS = 30 * 60 * 1000;
+const SIXTY_MINUTES_MILLISECONDS = 60 * 60 * 1000;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const useDebounce = (value: any, delay: number) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+};
+
+export function ParticipantEtaUpdater({ activityId, participantId, participantEta }: { activityId: string; participantId: string; participantEta?: number }) {
+  const dispatch = useAppDispatch();
+
+  const [eta, setEta] = useState<number | undefined | null>(participantEta);
+  const [editing, setEditing] = useState(false);
+  const debouncedEta = useDebounce(eta, 1000);
+
+  useEffect(() => {
+    dispatch(ActivityActions.participantEtaUpdate(activityId, participantId, debouncedEta));
+  }, [debouncedEta, activityId, participantId, dispatch]);
+
+  return (
+    <Stack direction={'row'} spacing={2} alignItems={'center'} justifyContent={'space-between'}>
+      {editing && (
+        <InlineTimeEdit
+          onChange={(time) => {
+            if (time) setEta(new Date(time).getTime());
+            setEditing(false);
+          }}
+          onClose={() => setEditing(false)}
+        />
+      )}
+      {!editing && eta && (
+        <>
+          <Typography variant="h6">ETA</Typography>
+          <Typography variant="h6">{formatDate(eta, 'HHmm')}</Typography>
+          <IconButton onClick={() => setEta(eta - ONE_MINUTE_MILLISECONDS)}>
+            <RemoveIcon />
+          </IconButton>
+          <IconButton onClick={() => setEta(eta + ONE_MINUTE_MILLISECONDS)}>
+            <AddIcon />
+          </IconButton>
+          <Button onClick={() => setEta(null)}>clear</Button>
+        </>
+      )}
+      {!editing && !eta && (
+        <>
+          <Typography variant="h6">ETA</Typography>
+          <Stack direction={'row'} spacing={2} alignItems={'center'} justifyContent={'space-between'}>
+            <IconButton onClick={() => setEta(new Date().getTime() + FIFTEEN_MINUTES_MILLISECONDS)}>15</IconButton>
+            <IconButton onClick={() => setEta(new Date().getTime() + THIRTY_MINUTES_MILLISECONDS)}>30</IconButton>
+            <IconButton onClick={() => setEta(new Date().getTime() + SIXTY_MINUTES_MILLISECONDS)}>60</IconButton>
+            <IconButton onClick={() => setEditing(true)}>
+              <AccessTime />
+            </IconButton>
+          </Stack>
+        </>
+      )}
+    </Stack>
+  );
+}
+
+export function InlineTimeEdit({ onChange, onClose }: { onChange: (time: number | null) => void; onClose: () => void }) {
+  return (
+    <Stack flexGrow={1} direction="row" justifyContent="space-between">
+      <DateTimePicker value={new Date().getTime()} label="ETA" format="MM/dd HH:mm" onAccept={onChange} onClose={onClose} openTo={'hours'} />
+      <IconButton disableRipple onClick={onClose}>
+        <Close />
+      </IconButton>
+    </Stack>
+  );
+}

--- a/src/components/participant/ParticipantEtaUpdater.tsx
+++ b/src/components/participant/ParticipantEtaUpdater.tsx
@@ -1,14 +1,13 @@
-import { Close } from '@mui/icons-material';
 import AccessTime from '@mui/icons-material/AccessTime';
 import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
-import { DateTimePicker } from '@mui/x-date-pickers';
 import { format as formatDate } from 'date-fns';
 import { useEffect, useState } from 'react';
 
 import { useAppDispatch } from '@respond/lib/client/store';
 import { ActivityActions } from '@respond/lib/state';
 
+import { InlineTimeEdit } from '../InlineTimeEdit';
 import { Button, IconButton, Stack, Typography } from '../Material';
 
 const ONE_MINUTE_MILLISECONDS = 60 * 1000;
@@ -44,6 +43,9 @@ export function ParticipantEtaUpdater({ activityId, participantId, participantEt
     <Stack direction={'row'} spacing={2} alignItems={'center'} justifyContent={'space-between'}>
       {editing && (
         <InlineTimeEdit
+          label="ETA"
+          format="MM/dd HH:mm"
+          openTo="hours"
           onChange={(time) => {
             if (time) setEta(new Date(time).getTime());
             setEditing(false);
@@ -77,17 +79,6 @@ export function ParticipantEtaUpdater({ activityId, participantId, participantEt
           </Stack>
         </>
       )}
-    </Stack>
-  );
-}
-
-export function InlineTimeEdit({ onChange, onClose }: { onChange: (time: number | null) => void; onClose: () => void }) {
-  return (
-    <Stack flexGrow={1} direction="row" justifyContent="space-between">
-      <DateTimePicker value={new Date().getTime()} label="ETA" format="MM/dd HH:mm" onAccept={onChange} onClose={onClose} openTo={'hours'} />
-      <IconButton disableRipple onClick={onClose}>
-        <Close />
-      </IconButton>
     </Stack>
   );
 }

--- a/src/components/participant/ParticipantEtaUpdater.tsx
+++ b/src/components/participant/ParticipantEtaUpdater.tsx
@@ -4,6 +4,7 @@ import RemoveIcon from '@mui/icons-material/Remove';
 import { format as formatDate } from 'date-fns';
 import { useEffect, useState } from 'react';
 
+import { useDebounce } from '@respond/hooks/useDebounce';
 import { useAppDispatch } from '@respond/lib/client/store';
 import { ActivityActions } from '@respond/lib/state';
 
@@ -14,19 +15,6 @@ const ONE_MINUTE_MILLISECONDS = 60 * 1000;
 const FIFTEEN_MINUTES_MILLISECONDS = 15 * 60 * 1000;
 const THIRTY_MINUTES_MILLISECONDS = 30 * 60 * 1000;
 const SIXTY_MINUTES_MILLISECONDS = 60 * 60 * 1000;
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const useDebounce = (value: any, delay: number) => {
-  const [debouncedValue, setDebouncedValue] = useState(value);
-  useEffect(() => {
-    const timer = setTimeout(() => setDebouncedValue(value), delay);
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [value, delay]);
-
-  return debouncedValue;
-};
 
 export function ParticipantEtaUpdater({ activityId, participantId, participantEta }: { activityId: string; participantId: string; participantEta?: number }) {
   const dispatch = useAppDispatch();

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const useDebounce = (value: any, delay: number) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+  return debouncedValue;
+};

--- a/src/lib/client/store/activities.ts
+++ b/src/lib/client/store/activities.ts
@@ -29,6 +29,7 @@ const activitySliceArgs = {
       .addCase(ActivityActions.complete, BasicActivityReducers[ActivityActions.complete.type])
       .addCase(ActivityActions.appendOrganizationTimeline, BasicActivityReducers[ActivityActions.appendOrganizationTimeline.type])
       .addCase(ActivityActions.participantTimelineUpdate, BasicActivityReducers[ActivityActions.participantTimelineUpdate.type])
+      .addCase(ActivityActions.participantEtaUpdate, BasicActivityReducers[ActivityActions.participantEtaUpdate.type])
       .addCase(ActivityActions.participantUpdate, BasicActivityReducers[ActivityActions.participantUpdate.type])
       .addCase(ActivityActions.tagParticipant, BasicActivityReducers[ActivityActions.tagParticipant.type]);
   },

--- a/src/lib/state/activityActions.ts
+++ b/src/lib/state/activityActions.ts
@@ -62,6 +62,15 @@ const participantTimelineUpdate = createAction('participant/timeline', (activity
   meta: { sync: true },
 }));
 
+const participantEtaUpdate = createAction('participant/etaUpdate', (activityId: string, participantId: string, eta: number) => ({
+  payload: {
+    activityId,
+    participantId,
+    eta,
+  },
+  meta: { sync: true },
+}));
+
 const tagParticipant = createAction('participant/tag', (activityId: string, participantId: string, tags: string[]) => ({
   payload: {
     activityId,
@@ -80,6 +89,7 @@ export const ActivityActions = {
   appendOrganizationTimeline,
   participantUpdate,
   participantTimelineUpdate,
+  participantEtaUpdate,
   tagParticipant,
 };
 

--- a/src/lib/state/activityReducers.ts
+++ b/src/lib/state/activityReducers.ts
@@ -144,6 +144,18 @@ export const BasicReducers: ActivityReducers = {
     person.timeline[payload.index] = payload.update;
   },
 
+  [ActivityActions.participantEtaUpdate.type]: (state, { payload }) => {
+    const activity = state.list.find((f) => f.id === payload.activityId);
+    if (!activity) {
+      return;
+    }
+    const person = activity.participants[payload.participantId];
+    if (!person) {
+      return;
+    }
+    person.eta = payload.eta;
+  },
+
   [ActivityActions.tagParticipant.type]: (state, { payload }) => {
     const activity = state.list.find((f) => f.id === payload.activityId);
     if (activity) {

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -64,6 +64,10 @@ export function getOrganizationName(activity: Activity, organizationId: string) 
   return activity.organizations[organizationId].rosterName ?? activity.organizations[organizationId].title;
 }
 
+export function isEnrouteOrStandby(status?: ParticipantStatus) {
+  return status && [ParticipantStatus.Standby, ParticipantStatus.SignedIn].includes(status);
+}
+
 export function isActive(status: ParticipantStatus) {
   return [ParticipantStatus.Standby, ParticipantStatus.Remote, ParticipantStatus.SignedIn, ParticipantStatus.Available, ParticipantStatus.Assigned, ParticipantStatus.Demobilized].includes(status);
 }
@@ -103,6 +107,7 @@ export interface Participant {
   timeline: ParticipantUpdate[];
   tags?: string[];
   miles?: number;
+  eta?: number;
 }
 
 export interface ParticipatingOrg {


### PR DESCRIPTION
Participants in "Standby" or "SignedIn" status will see `ParticipantEtaUpdater`. If the user reports an ETA, then it will be displayed next to their current status in the roster tile.

- When the Participant *has not* reported an ETA they will see options to quickly report a 15, 30, or 60 minute ETA, or to enter a specific time. Clicking on the "clock" button opens an inline `DateTimePicker`.

- When the Participant *has* reported an ETA it will show the current value and has options to increment by 1 minute or to clear the value.

- If the Participant is not in "Standby" or "SignedIn" status the `ParticipantEtaUpdater` is hidden and the roster tile will not display the ETA.

## Screenshots
Mobile: iPhone 5/SE

![image](https://github.com/KingCountySAR/respond-next/assets/11284884/64fb223b-c0f1-4cf9-8305-22374f5d7280)

![image](https://github.com/KingCountySAR/respond-next/assets/11284884/8c233600-302c-44ca-8c1d-10c4506b18b6)

![image](https://github.com/KingCountySAR/respond-next/assets/11284884/1f012075-333a-41ef-b403-789cd8f36e66)

![image](https://github.com/KingCountySAR/respond-next/assets/11284884/b5fe0c21-db11-4481-a777-81b044961323)

![image](https://github.com/KingCountySAR/respond-next/assets/11284884/e4317a63-885b-4a02-9964-913ecd820a2f)

![image](https://github.com/KingCountySAR/respond-next/assets/11284884/6fe1d3de-ff3b-434a-943d-72ed34b1d47f)
