### PR TITLE
Participant Edit Miles

### DIFF
--- a/src/components/ParticipantMilesInput.tsx
+++ b/src/components/ParticipantMilesInput.tsx
@@ -13,19 +13,20 @@ type MilesAction = {
 };
 
 const reducer: Reducer<ParticipantMilesState, MilesAction> = (state: ParticipantMilesState, action: MilesAction) => {
+  const hasMiles = action.miles > 0;
   switch (action.type) {
     case 'set_total': {
-      return { ...state, miles: action.miles };
+      return { ...state, miles: hasMiles ? action.miles : state.initialMiles };
     }
     case 'add_miles': {
-      return { ...state, miles: state.initialMiles + action.miles };
+      return { ...state, miles: state.initialMiles + (hasMiles ? action.miles : 0) };
     }
   }
 };
 
 export function ParticipantMileageInput({ currentMiles, onChange }: { currentMiles: number; onChange: (miles: number) => void }) {
   const [state, dispatch] = useReducer<Reducer<ParticipantMilesState, MilesAction>>(reducer, { initialMiles: currentMiles, miles: 0 });
-  const [value, setValue] = useState(currentMiles);
+  const [value, setValue] = useState(0);
   const [isTotalMiles, setIsTotalMiles] = useState<boolean>(true);
 
   useEffect(() => {
@@ -45,7 +46,7 @@ export function ParticipantMileageInput({ currentMiles, onChange }: { currentMil
           <FormControlLabel value="false" control={<Radio size="small" />} label="Add leg" />
         </RadioGroup>
       </FormControl>
-      <TextField value={value} onChange={(event) => setValue(event.target.value ? parseInt(event.target.value) : 0)} type="number" variant="outlined" label={isTotalMiles ? 'Round-Trip Miles' : 'Leg Miles'} />
+      <TextField inputMode="numeric" onChange={(event) => setValue(event.target.value !== undefined ? parseInt(event.target.value) : 0)} type="number" variant="outlined" label={isTotalMiles ? 'Round-Trip Miles' : 'Leg Miles'} />
       <Typography>New round-trip miles: {state.miles}</Typography>
     </Stack>
   );

--- a/src/components/ParticipantMilesInput.tsx
+++ b/src/components/ParticipantMilesInput.tsx
@@ -46,7 +46,15 @@ export function ParticipantMileageInput({ currentMiles, onChange }: { currentMil
           <FormControlLabel value="false" control={<Radio size="small" />} label="Add leg" />
         </RadioGroup>
       </FormControl>
-      <TextField inputMode="numeric" onChange={(event) => setValue(event.target.value !== undefined ? parseInt(event.target.value) : 0)} type="number" variant="outlined" label={isTotalMiles ? 'Round-Trip Miles' : 'Leg Miles'} />
+      <TextField
+        inputMode="numeric"
+        onChange={(event) => {
+          setValue(event.target.value !== undefined ? parseInt(event.target.value) : 0);
+        }}
+        type="number"
+        variant="outlined"
+        label={isTotalMiles ? 'Round-Trip Miles' : 'Leg Miles'}
+      />
       <Typography>New round-trip miles: {state.miles}</Typography>
     </Stack>
   );

--- a/src/components/ParticipantMilesInput.tsx
+++ b/src/components/ParticipantMilesInput.tsx
@@ -1,0 +1,52 @@
+import { Reducer, useEffect, useReducer, useState } from 'react';
+
+import { FormControl, FormControlLabel, Radio, RadioGroup, Stack, TextField, Typography } from './Material';
+
+type ParticipantMilesState = {
+  initialMiles: number;
+  miles: number;
+};
+
+type MilesAction = {
+  type: 'set_total' | 'add_miles';
+  miles: number;
+};
+
+const reducer: Reducer<ParticipantMilesState, MilesAction> = (state: ParticipantMilesState, action: MilesAction) => {
+  switch (action.type) {
+    case 'set_total': {
+      return { ...state, miles: action.miles };
+    }
+    case 'add_miles': {
+      return { ...state, miles: state.initialMiles + action.miles };
+    }
+  }
+};
+
+export function ParticipantMileageInput({ currentMiles, onChange }: { currentMiles: number; onChange: (miles: number) => void }) {
+  const [state, dispatch] = useReducer<Reducer<ParticipantMilesState, MilesAction>>(reducer, { initialMiles: currentMiles, miles: 0 });
+  const [value, setValue] = useState(currentMiles);
+  const [isTotalMiles, setIsTotalMiles] = useState<boolean>(true);
+
+  useEffect(() => {
+    dispatch({ type: isTotalMiles ? 'set_total' : 'add_miles', miles: value });
+  }, [value, isTotalMiles]);
+
+  useEffect(() => {
+    onChange(state.miles);
+  }, [state, onChange]);
+
+  return (
+    <Stack spacing={1}>
+      <Typography>You currently have {currentMiles} round-trip miles.</Typography>
+      <FormControl>
+        <RadioGroup row value={isTotalMiles} onChange={(event) => setIsTotalMiles(event.target.value === 'true')}>
+          <FormControlLabel value="true" control={<Radio size="small" />} label="Change total" />
+          <FormControlLabel value="false" control={<Radio size="small" />} label="Add leg" />
+        </RadioGroup>
+      </FormControl>
+      <TextField value={value} onChange={(event) => setValue(event.target.value ? parseInt(event.target.value) : 0)} type="number" variant="outlined" label={isTotalMiles ? 'Round-Trip Miles' : 'Leg Miles'} />
+      <Typography>New round-trip miles: {state.miles}</Typography>
+    </Stack>
+  );
+}

--- a/src/components/StatusUpdater/UpdateStatusForm.tsx
+++ b/src/components/StatusUpdater/UpdateStatusForm.tsx
@@ -9,7 +9,7 @@ import { MyOrganization } from '@respond/types/organization';
 import { UserInfo } from '@respond/types/userInfo';
 
 import { DialogContentText, FormControl, FormHelperText, Stack } from '../Material';
-import { ParticipantMileageInput } from '../participant/ParticipantMilesInput';
+import { ParticipantMilesInput } from '../participant/ParticipantMilesInput';
 import { formatTime } from '../RelativeTimeText';
 
 interface FormValues {
@@ -144,7 +144,7 @@ export const UpdateStatusForm = ({ form }: { form: FormLogic }) => {
           control={form.control}
           render={() => (
             <FormControl error={!!form.errors.miles?.message}>
-              <ParticipantMileageInput currentMiles={participant?.miles ?? 0} onChange={(miles) => form.setValue('miles', miles)} />
+              <ParticipantMilesInput currentMiles={participant?.miles ?? 0} onChange={(miles) => form.setValue('miles', miles)} />
               <FormHelperText>{form.errors.miles?.message}</FormHelperText>
             </FormControl>
           )}

--- a/src/components/StatusUpdater/UpdateStatusForm.tsx
+++ b/src/components/StatusUpdater/UpdateStatusForm.tsx
@@ -1,7 +1,6 @@
-import { FormControlLabel } from '@mui/material';
 import { DateTimePicker } from '@mui/x-date-pickers';
 import { useEffect, useState } from 'react';
-import { Control, Controller, FieldErrors, Resolver, ResolverResult, SubmitHandler, useForm } from 'react-hook-form';
+import { Controller, Resolver, ResolverResult, SubmitHandler, useForm } from 'react-hook-form';
 
 import { useAppDispatch } from '@respond/lib/client/store';
 import { ActivityActions } from '@respond/lib/state';
@@ -9,12 +8,12 @@ import { Activity, OrganizationStatus, Participant, ParticipantStatus } from '@r
 import { MyOrganization } from '@respond/types/organization';
 import { UserInfo } from '@respond/types/userInfo';
 
-import { DialogContentText, FormControl, FormHelperText, Radio, RadioGroup, Stack, TextField, Typography } from '../Material';
+import { DialogContentText, FormControl, FormHelperText, Stack } from '../Material';
+import { ParticipantMileageInput } from '../ParticipantMilesInput';
 import { formatTime } from '../RelativeTimeText';
 
 interface FormValues {
   miles: number | '';
-  addMiles: number | '';
   statusTime: number;
 }
 
@@ -27,12 +26,6 @@ export function useFormLogic(activity: Activity, user: UserInfo, respondingOrg: 
       errors: {},
     };
 
-    if (values.addMiles != null && values.addMiles < 0) {
-      result.errors.addMiles = {
-        type: 'min',
-        message: 'Must be a positive number',
-      };
-    }
     if (values.miles != null && values.miles < 0) {
       result.errors.miles = {
         type: 'min',
@@ -60,17 +53,10 @@ export function useFormLogic(activity: Activity, user: UserInfo, respondingOrg: 
 
   const form = useForm<FormValues>({
     resolver,
-    defaultValues: { miles: participant?.miles ?? '', addMiles: '', statusTime: new Date().getTime() },
+    defaultValues: { miles: participant?.miles ?? '', statusTime: new Date().getTime() },
   });
-  if (form.getValues().miles !== (participant?.miles ?? '')) {
-    form.reset({ miles: participant?.miles ?? '', addMiles: '' });
-  }
 
   const onSubmit: SubmitHandler<FormValues> = (data) => {
-    if (data.addMiles !== undefined) {
-      data.miles = Number(data.miles ?? 0) + Number(data.addMiles);
-    }
-
     const time = new Date(data.statusTime).getTime();
 
     if (!activity.organizations[respondingOrg.id]) {
@@ -105,82 +91,6 @@ export function useFormLogic(activity: Activity, user: UserInfo, respondingOrg: 
   };
 }
 type FormLogic = ReturnType<typeof useFormLogic>;
-
-export const TotalMilesInput = ({ control, errors }: { control: Control<FormValues>; errors: FieldErrors<FormValues> }) => {
-  return (
-    <Controller
-      name="miles"
-      control={control}
-      render={({ field }) => (
-        <FormControl error={!!errors.miles?.message}>
-          <TextField {...field} type="number" variant="outlined" label="Round-trip Miles" />
-          <FormHelperText>{errors.miles?.message}</FormHelperText>
-        </FormControl>
-      )}
-    />
-  );
-};
-
-const MileageSection = ({ existingMiles, form: { control, errors, getValues, setValue } }: { form: FormLogic; existingMiles: number | undefined }) => {
-  const [isTotalMiles, setIsTotalMiles] = useState<boolean>(true);
-  const [addMilesPreview, setAddMilesPreview] = useState<number | ''>(getValues().addMiles);
-
-  function handleMilesType(evt: React.ChangeEvent<HTMLInputElement>) {
-    const v = evt.target.value === 'true';
-    setIsTotalMiles(v);
-    if (!v) {
-      setValue('addMiles', '');
-      setAddMilesPreview('');
-    }
-  }
-
-  function handleAddMiles(evt: React.ChangeEvent<HTMLInputElement>) {
-    let addMiles: number | '' = parseInt(evt.target.value);
-    if (isNaN(addMiles)) {
-      addMiles = '';
-    }
-    setValue('addMiles', addMiles);
-    setAddMilesPreview(addMiles);
-  }
-
-  function formatMilesSum(existing: number | '', added: number | '') {
-    if (existing === '' && added === '') {
-      return undefined;
-    }
-    return Number(existing ?? 0) + Number(added ?? 0);
-  }
-
-  return existingMiles == null ? (
-    <TotalMilesInput control={control} errors={errors} />
-  ) : (
-    <Stack>
-      <Typography>You currently have {existingMiles} round-trip miles.</Typography>
-      <FormControl>
-        <RadioGroup row value={isTotalMiles} onChange={handleMilesType}>
-          <FormControlLabel value="true" control={<Radio size="small" />} label="Change total" />
-          <FormControlLabel value="false" control={<Radio size="small" />} label="Add leg" />
-        </RadioGroup>
-      </FormControl>
-      {isTotalMiles ? (
-        <TotalMilesInput control={control} errors={errors} />
-      ) : (
-        <>
-          <Controller
-            name="addMiles"
-            control={control}
-            render={({ field }) => (
-              <FormControl error={!!errors.miles?.message}>
-                <TextField {...field} onChange={handleAddMiles} type="number" variant="outlined" label="Leg Miles" />
-                <FormHelperText>{errors.miles?.message}</FormHelperText>
-              </FormControl>
-            )}
-          />
-          <Typography>New Total Miles: {formatMilesSum(getValues().miles, addMilesPreview)}</Typography>
-        </>
-      )}
-    </Stack>
-  );
-};
 
 export const StatusTimeInput = ({ form: { control, errors } }: { form: FormLogic }) => {
   return (
@@ -228,7 +138,18 @@ export const UpdateStatusForm = ({ form }: { form: FormLogic }) => {
     <Stack flexGrow={1} spacing={2} justifyContent="space-between">
       <DialogContentText id="status-update-dialog-description">Change your status for {activity.title}?</DialogContentText>
       <StatusTimeInput form={form} />
-      {newStatus === ParticipantStatus.SignedOut ? <MileageSection form={form} existingMiles={participant?.miles} /> : undefined}
+      {newStatus === ParticipantStatus.SignedOut ? (
+        <Controller
+          name="miles"
+          control={form.control}
+          render={() => (
+            <FormControl error={!!form.errors.miles?.message}>
+              <ParticipantMileageInput currentMiles={participant?.miles ?? 0} onChange={(miles) => form.setValue('miles', miles)} />
+              <FormHelperText>{form.errors.miles?.message}</FormHelperText>
+            </FormControl>
+          )}
+        />
+      ) : undefined}
     </Stack>
   );
 };

--- a/src/components/StatusUpdater/UpdateStatusForm.tsx
+++ b/src/components/StatusUpdater/UpdateStatusForm.tsx
@@ -142,9 +142,15 @@ export const UpdateStatusForm = ({ form }: { form: FormLogic }) => {
         <Controller
           name="miles"
           control={form.control}
-          render={() => (
+          render={({ field }) => (
             <FormControl error={!!form.errors.miles?.message}>
-              <ParticipantMilesInput currentMiles={participant?.miles ?? 0} onChange={(miles) => form.setValue('miles', miles)} />
+              <ParticipantMilesInput
+                value={field.value}
+                currentMiles={participant?.miles ?? 0}
+                onChange={(miles) => {
+                  field.onChange(miles);
+                }}
+              />
               <FormHelperText>{form.errors.miles?.message}</FormHelperText>
             </FormControl>
           )}

--- a/src/components/StatusUpdater/UpdateStatusForm.tsx
+++ b/src/components/StatusUpdater/UpdateStatusForm.tsx
@@ -9,7 +9,7 @@ import { MyOrganization } from '@respond/types/organization';
 import { UserInfo } from '@respond/types/userInfo';
 
 import { DialogContentText, FormControl, FormHelperText, Stack } from '../Material';
-import { ParticipantMileageInput } from '../ParticipantMilesInput';
+import { ParticipantMileageInput } from '../participant/ParticipantMilesInput';
 import { formatTime } from '../RelativeTimeText';
 
 interface FormValues {

--- a/src/components/activities/RosterPanel.tsx
+++ b/src/components/activities/RosterPanel.tsx
@@ -164,7 +164,7 @@ function ParticipantMiles({ activityId, participant }: { activityId: string; par
           <Typography variant="h6">Updating Miles</Typography>
           <ParticipantMilesUpdater
             activityId={activityId}
-            participant={participant}
+            participant={{ ...participant, miles: miles }}
             onCancel={() => setEdit(false)}
             onSubmit={(newMiles) => {
               setMiles(newMiles);

--- a/src/components/activities/RosterPanel.tsx
+++ b/src/components/activities/RosterPanel.tsx
@@ -6,11 +6,9 @@ import { useTheme } from '@mui/material/styles';
 import { FunctionComponent, ReactNode, useEffect, useState } from 'react';
 
 import { Box, Dialog, DialogContent, DialogTitle, Paper, Stack, Typography, useMediaQuery } from '@respond/components/Material';
-import { useAppDispatch } from '@respond/lib/client/store';
-import { ActivityActions } from '@respond/lib/state';
 import { Activity, getOrganizationName, getStatusCssColor, getStatusText, isActive, Participant, ParticipantStatus, ParticipantUpdate, ParticipatingOrg } from '@respond/types/activity';
 
-import { ParticipantMileageInput } from '../participant/ParticipantMilesInput';
+import { ParticipantMilesUpdater } from '../participant/ParticipantMilesUpdater';
 
 import ParticipantTimeline from './ParticipantTimeline';
 
@@ -147,7 +145,6 @@ function ParticipantHoursText({ participant }: { participant: Participant }) {
 }
 
 function ParticipantMiles({ activityId, participant }: { activityId: string; participant: Participant }) {
-  const dispatch = useAppDispatch();
   const [miles, setMiles] = useState(participant.miles ?? 0);
   const [edit, setEdit] = useState(false);
   return (
@@ -165,15 +162,14 @@ function ParticipantMiles({ activityId, participant }: { activityId: string; par
       {edit && (
         <>
           <Typography variant="h6">Updating Miles</Typography>
-          <ParticipantMileageInput
-            currentMiles={participant.miles ?? 0}
+          <ParticipantMilesUpdater
+            activityId={activityId}
+            participant={participant}
             onCancel={() => setEdit(false)}
             onSubmit={(newMiles) => {
               setMiles(newMiles);
-              dispatch(ActivityActions.participantMilesUpdate(activityId, participant.id, newMiles));
               setEdit(false);
             }}
-            submittable
           />
         </>
       )}

--- a/src/components/participant/ParticipantMilesInput.tsx
+++ b/src/components/participant/ParticipantMilesInput.tsx
@@ -1,6 +1,6 @@
 import { Reducer, useEffect, useReducer, useState } from 'react';
 
-import { Button, FormControl, FormControlLabel, Radio, RadioGroup, Stack, TextField, Typography } from '../Material';
+import { FormControl, FormControlLabel, Radio, RadioGroup, Stack, TextField, Typography } from '../Material';
 
 type ParticipantMilesState = {
   initialMiles: number;
@@ -24,7 +24,7 @@ const reducer: Reducer<ParticipantMilesState, MilesAction> = (state: Participant
   }
 };
 
-export function ParticipantMileageInput({ currentMiles, submittable, onChange, onSubmit, onCancel }: { currentMiles: number; submittable?: boolean; onChange?: (miles: number) => void; onCancel?: () => void; onSubmit?: (miles: number) => void }) {
+export function ParticipantMilesInput({ currentMiles, onChange }: { currentMiles: number; onChange?: (miles: number) => void }) {
   const [state, dispatch] = useReducer<Reducer<ParticipantMilesState, MilesAction>>(reducer, { initialMiles: currentMiles, miles: 0 });
   const [value, setValue] = useState(0);
   const [isTotalMiles, setIsTotalMiles] = useState<boolean>(true);
@@ -36,14 +36,6 @@ export function ParticipantMileageInput({ currentMiles, submittable, onChange, o
   useEffect(() => {
     if (onChange) onChange(state.miles);
   }, [state, onChange]);
-
-  const handleSubmit = () => {
-    if (onSubmit) onSubmit(state.miles);
-  };
-
-  const handleCancel = () => {
-    if (onCancel) onCancel();
-  };
 
   return (
     <Stack spacing={1}>
@@ -64,18 +56,6 @@ export function ParticipantMileageInput({ currentMiles, submittable, onChange, o
         label={isTotalMiles ? 'Round-Trip Miles' : 'Leg Miles'}
       />
       <Typography>New round-trip miles: {state.miles}</Typography>
-      <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent={'right'} spacing={2}>
-        {submittable && (
-          <>
-            <Button variant={'outlined'} onClick={handleCancel}>
-              Cancel
-            </Button>
-            <Button variant={'contained'} onClick={handleSubmit}>
-              Update
-            </Button>
-          </>
-        )}
-      </Stack>
     </Stack>
   );
 }

--- a/src/components/participant/ParticipantMilesInput.tsx
+++ b/src/components/participant/ParticipantMilesInput.tsx
@@ -1,6 +1,6 @@
 import { Reducer, useEffect, useReducer, useState } from 'react';
 
-import { FormControl, FormControlLabel, Radio, RadioGroup, Stack, TextField, Typography } from './Material';
+import { Button, FormControl, FormControlLabel, Radio, RadioGroup, Stack, TextField, Typography } from '../Material';
 
 type ParticipantMilesState = {
   initialMiles: number;
@@ -24,7 +24,7 @@ const reducer: Reducer<ParticipantMilesState, MilesAction> = (state: Participant
   }
 };
 
-export function ParticipantMileageInput({ currentMiles, onChange }: { currentMiles: number; onChange: (miles: number) => void }) {
+export function ParticipantMileageInput({ currentMiles, submittable, onChange, onSubmit, onCancel }: { currentMiles: number; submittable?: boolean; onChange?: (miles: number) => void; onCancel?: () => void; onSubmit?: (miles: number) => void }) {
   const [state, dispatch] = useReducer<Reducer<ParticipantMilesState, MilesAction>>(reducer, { initialMiles: currentMiles, miles: 0 });
   const [value, setValue] = useState(0);
   const [isTotalMiles, setIsTotalMiles] = useState<boolean>(true);
@@ -34,8 +34,16 @@ export function ParticipantMileageInput({ currentMiles, onChange }: { currentMil
   }, [value, isTotalMiles]);
 
   useEffect(() => {
-    onChange(state.miles);
+    if (onChange) onChange(state.miles);
   }, [state, onChange]);
+
+  const handleSubmit = () => {
+    if (onSubmit) onSubmit(state.miles);
+  };
+
+  const handleCancel = () => {
+    if (onCancel) onCancel();
+  };
 
   return (
     <Stack spacing={1}>
@@ -56,6 +64,18 @@ export function ParticipantMileageInput({ currentMiles, onChange }: { currentMil
         label={isTotalMiles ? 'Round-Trip Miles' : 'Leg Miles'}
       />
       <Typography>New round-trip miles: {state.miles}</Typography>
+      <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent={'right'} spacing={2}>
+        {submittable && (
+          <>
+            <Button variant={'outlined'} onClick={handleCancel}>
+              Cancel
+            </Button>
+            <Button variant={'contained'} onClick={handleSubmit}>
+              Update
+            </Button>
+          </>
+        )}
+      </Stack>
     </Stack>
   );
 }

--- a/src/components/participant/ParticipantMilesUpdater.tsx
+++ b/src/components/participant/ParticipantMilesUpdater.tsx
@@ -13,8 +13,8 @@ export function ParticipantMilesUpdater({ activityId, participant, onCancel, onS
 
   const [miles, setMiles] = useState(participant.miles ?? 0);
 
-  const handleChange = (miles: number) => {
-    setMiles(miles);
+  const handleChange = (miles: number | string) => {
+    setMiles(Number(miles));
   };
 
   const handleSubmit = () => {
@@ -24,7 +24,7 @@ export function ParticipantMilesUpdater({ activityId, participant, onCancel, onS
 
   return (
     <Stack spacing={1}>
-      <ParticipantMilesInput currentMiles={participant.miles ?? 0} onChange={handleChange} />
+      <ParticipantMilesInput currentMiles={participant.miles ?? 0} value={miles} onChange={handleChange} />
       <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent={'right'} spacing={2}>
         <Button variant={'outlined'} onClick={onCancel}>
           Cancel

--- a/src/components/participant/ParticipantMilesUpdater.tsx
+++ b/src/components/participant/ParticipantMilesUpdater.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+
+import { useAppDispatch } from '@respond/lib/client/store';
+import { ActivityActions } from '@respond/lib/state';
+import { Participant } from '@respond/types/activity';
+
+import { Button, Stack } from '../Material';
+
+import { ParticipantMilesInput } from './ParticipantMilesInput';
+
+export function ParticipantMilesUpdater({ activityId, participant, onCancel, onSubmit }: { activityId: string; participant: Participant; onCancel: () => void; onSubmit: (miles: number) => void }) {
+  const dispatch = useAppDispatch();
+
+  const [miles, setMiles] = useState(participant.miles ?? 0);
+
+  const handleChange = (miles: number) => {
+    setMiles(miles);
+  };
+
+  const handleSubmit = () => {
+    dispatch(ActivityActions.participantMilesUpdate(activityId, participant.id, miles));
+    onSubmit(miles);
+  };
+
+  return (
+    <Stack spacing={1}>
+      <ParticipantMilesInput currentMiles={participant.miles ?? 0} onChange={handleChange} />
+      <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent={'right'} spacing={2}>
+        <Button variant={'outlined'} onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button variant={'contained'} onClick={handleSubmit} disabled={participant.miles === miles}>
+          Update
+        </Button>
+      </Stack>
+    </Stack>
+  );
+}

--- a/src/lib/client/store/activities.ts
+++ b/src/lib/client/store/activities.ts
@@ -29,6 +29,7 @@ const activitySliceArgs = {
       .addCase(ActivityActions.complete, BasicActivityReducers[ActivityActions.complete.type])
       .addCase(ActivityActions.appendOrganizationTimeline, BasicActivityReducers[ActivityActions.appendOrganizationTimeline.type])
       .addCase(ActivityActions.participantTimelineUpdate, BasicActivityReducers[ActivityActions.participantTimelineUpdate.type])
+      .addCase(ActivityActions.participantMilesUpdate, BasicActivityReducers[ActivityActions.participantMilesUpdate.type])
       .addCase(ActivityActions.participantUpdate, BasicActivityReducers[ActivityActions.participantUpdate.type])
       .addCase(ActivityActions.tagParticipant, BasicActivityReducers[ActivityActions.tagParticipant.type]);
   },

--- a/src/lib/state/activityActions.ts
+++ b/src/lib/state/activityActions.ts
@@ -62,6 +62,15 @@ const participantTimelineUpdate = createAction('participant/timeline', (activity
   meta: { sync: true },
 }));
 
+const participantMilesUpdate = createAction('participant/etaUpdate', (activityId: string, participantId: string, miles: number) => ({
+  payload: {
+    activityId,
+    participantId,
+    miles,
+  },
+  meta: { sync: true },
+}));
+
 const tagParticipant = createAction('participant/tag', (activityId: string, participantId: string, tags: string[]) => ({
   payload: {
     activityId,
@@ -80,6 +89,7 @@ export const ActivityActions = {
   appendOrganizationTimeline,
   participantUpdate,
   participantTimelineUpdate,
+  participantMilesUpdate,
   tagParticipant,
 };
 

--- a/src/lib/state/activityActions.ts
+++ b/src/lib/state/activityActions.ts
@@ -67,10 +67,10 @@ const participantMilesUpdate = createAction('participant/milesUpdate', (activity
     activityId,
     participantId,
     miles,
-  }
+  },
   meta: { sync: true },
 }));
-    
+
 const participantEtaUpdate = createAction('participant/etaUpdate', (activityId: string, participantId: string, eta: number) => ({
   payload: {
     activityId,

--- a/src/lib/state/activityActions.ts
+++ b/src/lib/state/activityActions.ts
@@ -62,7 +62,7 @@ const participantTimelineUpdate = createAction('participant/timeline', (activity
   meta: { sync: true },
 }));
 
-const participantMilesUpdate = createAction('participant/etaUpdate', (activityId: string, participantId: string, miles: number) => ({
+const participantMilesUpdate = createAction('participant/milesUpdate', (activityId: string, participantId: string, miles: number) => ({
   payload: {
     activityId,
     participantId,

--- a/src/lib/state/activityReducers.ts
+++ b/src/lib/state/activityReducers.ts
@@ -155,7 +155,7 @@ export const BasicReducers: ActivityReducers = {
     }
     person.miles = payload.miles;
   },
-    
+
   [ActivityActions.participantEtaUpdate.type]: (state, { payload }) => {
     const activity = state.list.find((f) => f.id === payload.activityId);
     if (!activity) {
@@ -165,7 +165,7 @@ export const BasicReducers: ActivityReducers = {
     if (!person) {
       return;
     }
-    
+
     person.eta = payload.eta;
   },
 

--- a/src/lib/state/activityReducers.ts
+++ b/src/lib/state/activityReducers.ts
@@ -144,6 +144,18 @@ export const BasicReducers: ActivityReducers = {
     person.timeline[payload.index] = payload.update;
   },
 
+  [ActivityActions.participantMilesUpdate.type]: (state, { payload }) => {
+    const activity = state.list.find((f) => f.id === payload.activityId);
+    if (!activity) {
+      return;
+    }
+    const person = activity.participants[payload.participantId];
+    if (!person) {
+      return;
+    }
+    person.miles = payload.miles;
+  },
+
   [ActivityActions.tagParticipant.type]: (state, { payload }) => {
     const activity = state.list.find((f) => f.id === payload.activityId);
     if (activity) {


### PR DESCRIPTION
This commit enables editing of participant mileage, separate from a "Sign Out" status update.
- re-implemented the participant miles input so that it is re-usable
- re-arranged the participant dialog a bit so the edit functionality has enough space and the UI is not too small to tap on in Mobile
- added edit miles functionality in the participant dialog.

## Refactored Miles Input on the Sign Out Form
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/579e10f9-54d1-4ea0-8c2e-6e77222b5b81)
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/987967d8-c34a-4827-8501-1711aeacda8b)

## Rearranged Participant Dialog
I changed it to 2 columns, instead of three on desktop. It was always 1 column on mobile (no change.) I also made the Total Hours and Total Miles a larger to match the timeline font. The Total Miles row can be clicked/tapped to edit, just like the existing timeline edit functionality.

![image](https://github.com/KingCountySAR/respond-next/assets/11284884/1e9fa11f-63bc-4d36-8b56-e7d2600362a1)
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/11efb643-4537-40ca-8411-673fa1a6892d)

## Editing on the Dialog
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/10e7a87d-77e3-4e08-9c08-27f701914cd1)
![image](https://github.com/KingCountySAR/respond-next/assets/11284884/612a7921-64f1-4e2b-9046-6fd34c203108)

