### PR TITLE
Fix Status Time Bug

### DIFF
--- a/src/components/StatusUpdater/UpdateStatusForm.tsx
+++ b/src/components/StatusUpdater/UpdateStatusForm.tsx
@@ -131,6 +131,7 @@ export const UpdateStatusForm = ({ form }: { form: FormLogic }) => {
 
       // Set fields with dynamic default values.
       form.setValue('miles', participant?.miles ?? '');
+      form.setValue('statusTime', new Date().getTime());
     }
   }, [isInitialized, form, participant?.miles]);
 


### PR DESCRIPTION
## Description
The Status Updater form does not default to the current time after the first time it pops up. The time in the form shows the time that the form was first accessed.

## Steps to Reproduce
1. Create a Mission or Event.
2. Choose a Status Updater option to open the Status Updater (note the current time.)
3. Close the form; it doesn't matter if the status change is submitted or cancelled.
4. Wait at least 1 minute.
5. Choose a Status Updater option to open the Status Updater.
6. Note the time still shows whatever time it was when the form was first accessed.

## Root Cause
There is a `useEffect` in the `UpdateStatusForm` component that resets the default values each time the status updater is shown. One of the `setValue()` calls was dropped inadvertently in the commit that updated to consistent date inputs.

The bug was introduced in [Commit #85](https://github.com/KingCountySAR/respond-next/commit/8fdd329ebd193f30789ed5d1bfca0ea0f86d8947) and deployed to production in version [v0.6.0](https://github.com/KingCountySAR/respond-next/releases/tag/v0.6.0).