### PR TITLE
Hide the 'Run as mock mission' option when creating events

### DIFF
--- a/src/components/activities/ActivityEditPage.tsx
+++ b/src/components/activities/ActivityEditPage.tsx
@@ -300,13 +300,13 @@ export const ActivityEditPage = ({ activityType, activityId }: { activityType: A
 
             <Grid container item xs={12} spacing={1} sx={{ mt: 1 }}>
               <Grid item xs={12} sm={6}>
-                {activityType === 'missions' ? null : (
+                {/* {activityType === 'missions' ? null : (
                   <Grid item xs={12}>
                     <FormGroup>
                       <Controller name="asMission" control={control} render={({ field }) => <FormControlLabel control={<Switch {...field} checked={field.value} color="primary" />} label="Run as mock mission" />} />
                     </FormGroup>
                   </Grid>
-                )}
+                )} */}
 
                 <Grid item xs={12}>
                   <FormGroup>


### PR DESCRIPTION
Hiding the run as mission option when creating events.

https://trello.com/c/K8tYyefy/68-hide-run-as-mission-for-events