### PR TITLE
add base kiosk mode

### DIFF
--- a/src/app/(main)/event/[eventId]/kiosk/page.tsx
+++ b/src/app/(main)/event/[eventId]/kiosk/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import ActivityKiosk from '@respond/components/activities/ActivityKiosk';
+
+export default function Kiosk({ params }: { params: { eventId: string } }) {
+  return <ActivityKiosk activityId={params.eventId} />;
+}

--- a/src/app/(main)/mission/[missionId]/kiosk/page.tsx
+++ b/src/app/(main)/mission/[missionId]/kiosk/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import ActivityKiosk from '@respond/components/activities/ActivityKiosk';
+
+export default function Kiosk({ params }: { params: { missionId: string } }) {
+  return <ActivityKiosk activityId={params.missionId} />;
+}

--- a/src/app/api/v1/organizations/[orgId]/members/find/[query]/route.ts
+++ b/src/app/api/v1/organizations/[orgId]/members/find/[query]/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getCookieAuth, userFromAuth } from '@respond/lib/server/auth';
+import * as Mongo from '@respond/lib/server/mongodb';
+import { getServices } from '@respond/lib/server/services';
+
+export async function GET(_request: NextRequest, { params }: { params: { orgId: string; query: string } }) {
+  const user = userFromAuth(await getCookieAuth());
+  if (user == null) {
+    return NextResponse.json({ status: 'not authenticated' }, { status: 401 });
+  }
+
+  const organizationDoc = await Mongo.getOrganizationById(params.orgId);
+  if (!organizationDoc) {
+    return NextResponse.json({ status: 'unknown organization' }, { status: 500 });
+  }
+
+  const memberProvider = (await getServices()).memberProviders.get(organizationDoc.memberProvider.provider);
+  if (!memberProvider) {
+    console.log(`Can't find memberProvider for org ${organizationDoc.id}: ${organizationDoc.memberProvider?.provider}`);
+    return NextResponse.json({ status: 'unknown member provider' }, { status: 500 });
+  }
+
+  const list = await memberProvider.findMembersByName(params.query);
+
+  if (!list) {
+    return NextResponse.json({ status: 'not found' }, { status: 404 });
+  }
+  return NextResponse.json({
+    status: 'ok',
+    data: list,
+  });
+}

--- a/src/app/api/v1/organizations/route.ts
+++ b/src/app/api/v1/organizations/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import * as Mongo from '@respond/lib/server/mongodb';
+
+export async function GET(_request: NextRequest) {
+  const organizations = await Mongo.getOrganizations();
+  if (!organizations) {
+    return NextResponse.json({ status: 'get organizations failed' }, { status: 500 });
+  }
+  console.log(organizations);
+  return NextResponse.json({
+    status: 'ok',
+    data: organizations,
+  });
+}

--- a/src/components/AsyncSearch.tsx
+++ b/src/components/AsyncSearch.tsx
@@ -1,0 +1,92 @@
+import Autocomplete from '@mui/material/Autocomplete';
+import CircularProgress from '@mui/material/CircularProgress';
+import TextField from '@mui/material/TextField';
+import * as React from 'react';
+
+import { useDebounce } from '@respond/hooks/useDebounce';
+
+export interface AsyncSearchProps {
+  label: string;
+  variant: TextFieldVariant;
+  onInputChange: (value: string) => Promise<AsyncSearchResult[]>;
+  onChange: (value: AsyncSearchResult) => void;
+  onClear?: () => void;
+}
+
+export interface AsyncSearchResult {
+  label: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  value: any;
+}
+
+type TextFieldVariant = 'filled' | 'outlined' | 'standard';
+
+export default function AsyncSearch({ label, variant, onInputChange, onChange, onClear }: AsyncSearchProps) {
+  const [open, setOpen] = React.useState(false);
+  const [options, setOptions] = React.useState<readonly AsyncSearchResult[]>([]);
+  const [loading, setLoading] = React.useState(false);
+
+  const [search, setSearch] = React.useState('');
+  const debouncedSearch = useDebounce(search, 500);
+
+  React.useEffect(() => {
+    if (debouncedSearch) {
+      onInputChange(debouncedSearch).then((options) => {
+        setOptions(options);
+        setLoading(false);
+      });
+    }
+  }, [debouncedSearch, onInputChange]);
+
+  return (
+    <Autocomplete
+      open={open}
+      onOpen={() => {
+        setOpen(true);
+      }}
+      onClose={() => {
+        setOpen(false);
+      }}
+      onInputChange={(event, value) => {
+        if (value) setLoading(true);
+        setSearch(value);
+      }}
+      onChange={(event, value, reason) => {
+        if (onClear && reason === 'clear') {
+          onClear();
+        }
+        if (value) {
+          onChange(typeof value === 'string' ? { label: value, value } : value);
+        }
+      }}
+      freeSolo={true}
+      isOptionEqualToValue={(option, value) => option.label === value.label}
+      getOptionLabel={(option) => (typeof option === 'string' ? option : option.label)}
+      renderOption={(props, option) => {
+        return (
+          <li {...props} key={option.label}>
+            {option.label}
+          </li>
+        );
+      }}
+      options={options}
+      loading={loading}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={label}
+          variant={variant ?? 'outlined'}
+          InputProps={{
+            ...params.InputProps,
+            endAdornment: (
+              <React.Fragment>
+                {loading ? <CircularProgress color="inherit" size={20} /> : null}
+                {params.InputProps.endAdornment}
+              </React.Fragment>
+            ),
+          }}
+        />
+      )}
+    />
+  );
+}

--- a/src/components/StatusUpdater/index.tsx
+++ b/src/components/StatusUpdater/index.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useAppSelector } from '@respond/lib/client/store';
 import { defaultEarlySigninWindow, isFuture } from '@respond/lib/client/store/activities';
 import { Activity, getOrganizationName, isActive, isResponding, ParticipantStatus } from '@respond/types/activity';
+import { OrganizationDoc } from '@respond/types/data/organizationDoc';
 import { MyOrganization } from '@respond/types/organization';
 import { UserInfo } from '@respond/types/userInfo';
 
@@ -93,6 +94,20 @@ export const StatusUpdater = ({ activity, current, fullWidth }: { activity: Acti
   const user = useAppSelector((state) => state.auth.userInfo);
   const thisOrg = useAppSelector((state) => state.organization.mine);
 
+  return user && thisOrg ? <StatusUpdaterProtected activity={activity} current={current} user={user} thisOrg={thisOrg} fullWidth={fullWidth} /> : null;
+};
+
+export const AdminStatusUpdater = ({ activity, current, fullWidth, user, org }: { activity: Activity; current?: ParticipantStatus; fullWidth?: boolean; user: UserInfo; org: OrganizationDoc }) => {
+  const thisOrg = {
+    id: org.id,
+    title: org.title,
+    rosterName: org.rosterName,
+    canCreateMissions: org.canCreateMissions,
+    canCreateEvents: org.canCreateEvents,
+    partners: org.partners,
+    memberProvider: org.memberProvider.provider,
+    supportEmail: org.supportEmail,
+  };
   return user && thisOrg ? <StatusUpdaterProtected activity={activity} current={current} user={user} thisOrg={thisOrg} fullWidth={fullWidth} /> : null;
 };
 

--- a/src/components/activities/ActivityKiosk.tsx
+++ b/src/components/activities/ActivityKiosk.tsx
@@ -1,0 +1,135 @@
+import { Box, FormControl, InputLabel, MenuItem, Paper, Select } from '@mui/material';
+import { Card, CardContent, Stack, Typography } from '@mui/material';
+import { useEffect, useState } from 'react';
+
+import ParticipantTimeline from '@respond/components/activities/ParticipantTimeline';
+import AsyncSearch, { AsyncSearchResult } from '@respond/components/AsyncSearch';
+import { AdminStatusUpdater } from '@respond/components/StatusUpdater';
+import { ToolbarPage } from '@respond/components/ToolbarPage';
+import { apiFetch } from '@respond/lib/api';
+import { useAppSelector } from '@respond/lib/client/store';
+import { buildActivitySelector } from '@respond/lib/client/store/activities';
+import { D4HMemberResponse } from '@respond/lib/server/memberProviders/d4hMembersProvider';
+import { Participant } from '@respond/types/activity';
+import { OrganizationDoc } from '@respond/types/data/organizationDoc';
+import { UserInfo } from '@respond/types/userInfo';
+
+const findMembers = async (orgId: string, query: string) => {
+  return (await apiFetch<{ data: D4HMemberResponse[] }>(`/api/v1/organizations/${orgId}/members/find/${query}`)).data;
+};
+
+const findOrganizations = async () => {
+  return (await apiFetch<{ data: OrganizationDoc[] }>(`/api/v1/organizations`)).data;
+};
+
+export default function ActivityKiosk({ activityId }: { activityId: string }) {
+  const activity = useAppSelector(buildActivitySelector(activityId));
+
+  const [organizations, setOrganizations] = useState<OrganizationDoc[]>();
+  const [org, setOrg] = useState<OrganizationDoc>();
+  const [orgId, setOrgId] = useState<string>('');
+  const [member, setMember] = useState<D4HMemberResponse>();
+  const [participant, setParticipant] = useState<Participant>();
+  const [userInfo, setUserInfo] = useState<UserInfo>();
+
+  useEffect(() => {
+    findOrganizations().then((organizations) => {
+      organizations.forEach((o, i) => console.log(`org ${i}`, JSON.stringify(o)));
+      setOrganizations(organizations.filter((f) => !!f.memberProvider));
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!activity || !member) {
+      setParticipant(undefined);
+      setUserInfo(undefined);
+      return;
+    }
+    setParticipant(activity.participants[member.id]);
+    setUserInfo({
+      email: member.email ?? '',
+      userId: member.id.toString(),
+      organizationId: orgId,
+      participantId: member.id.toString(),
+      domain: org?.domain ?? '',
+      name: member.name,
+      given_name: member.name.split(',')[1].trim(),
+      family_name: member.name.split(',')[0].trim(),
+      picture: member.urls.image,
+    });
+    setOrg(organizations?.find((f) => f?.id === orgId));
+  }, [activity, member, organizations, orgId, org]);
+
+  const handleMemberQuery = async (value: string): Promise<AsyncSearchResult[]> => {
+    if (!orgId) return Promise.reject(new Error('no organization selected'));
+    return findMembers(orgId, value).then((list) =>
+      list.map((member) => {
+        const label = `${member.name} (${member.ref})`;
+        return { label: label, value: { ...member, label: label } };
+      }),
+    );
+  };
+
+  const handleMemberSelect = (member: AsyncSearchResult) => {
+    setMember(member.value);
+  };
+
+  const handleClear = () => {
+    setMember(undefined);
+  };
+
+  return (
+    <ToolbarPage maxWidth="lg">
+      <Typography variant="h4" paddingBottom={2}>
+        {activity?.idNumber} {activity?.title}
+      </Typography>
+      <Paper sx={{ p: 2 }}>
+        <Stack spacing={2}>
+          {organizations && (
+            <FormControl fullWidth>
+              <InputLabel id="org-select">Organization</InputLabel>
+              <Select labelId="org-select" label="Organization" disabled={!organizations} value={orgId} onChange={(event) => setOrgId(event.target.value)}>
+                {organizations.map((o) => (
+                  <MenuItem key={o.id} value={o.id}>
+                    {o.title}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+          {orgId && <AsyncSearch label="Search Members" onInputChange={handleMemberQuery} onChange={handleMemberSelect} onClear={handleClear} variant="outlined"></AsyncSearch>}
+          {member && <MemberInfo orgId={orgId} member={member} />}
+          {activity && userInfo && org && (
+            <Box sx={{ my: 2 }} display="flex" justifyContent="end">
+              <AdminStatusUpdater activity={activity} current={participant?.timeline[0].status} user={userInfo} org={org} />
+            </Box>
+          )}
+          {participant && activity && <ParticipantTimeline participant={participant} activity={activity} />}
+        </Stack>
+      </Paper>
+    </ToolbarPage>
+  );
+}
+
+function MemberInfo({ orgId, member }: { orgId: string; member: D4HMemberResponse }) {
+  return (
+    <Card>
+      <CardContent>
+        <Stack direction={{ sm: 'row' }} spacing={2}>
+          <img //
+            src={`/api/v1/organizations/${orgId}/members/${member.id}/photo`}
+            alt={`Photo of ${member.name}`}
+            style={{ width: '8rem', minHeight: '10rem', border: 'solid 1px #777', borderRadius: '4px' }}
+          />
+          <Stack>
+            <Typography>
+              Name: {member.name} ({member.ref})
+            </Typography>
+            <Typography>Phone: {member.mobilephone}</Typography>
+            <Typography>Email: {member.email}</Typography>
+          </Stack>
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/activities/DesktopActivityPage.tsx
+++ b/src/components/activities/DesktopActivityPage.tsx
@@ -44,9 +44,14 @@ function DesktopActivityContents({ activity, startChangeState, startRemove }: Ac
         <Box display="flex" flex="1 1 auto" flexDirection="column">
           <Stack direction="row" justifyContent="space-between" alignItems="center">
             <ParticipatingOrgChips activity={activity} orgFilter={orgFilter} setOrgFilter={setOrgFilter} display="flex" flexDirection="row" />
-            <Button href={`/roster/${activity.id}`} variant="outlined" size="small">
-              View Roster
-            </Button>
+            <Stack direction={'row'} spacing={1}>
+              <Button href={`/${activity.isMission ? 'mission' : 'event'}/${activity.id}/kiosk`} variant="outlined" size="small">
+                Base Kiosk
+              </Button>
+              <Button href={`/roster/${activity.id}`} variant="outlined" size="small">
+                View Roster
+              </Button>
+            </Stack>
           </Stack>
           <RosterPanel //
             activity={activity}

--- a/src/lib/server/memberProviders/d4hMembersProvider.ts
+++ b/src/lib/server/memberProviders/d4hMembersProvider.ts
@@ -18,7 +18,7 @@ interface Group {
   title: string;
 }
 
-interface D4HMemberResponse {
+export interface D4HMemberResponse {
   id: number;
   ref?: string;
   name: string;
@@ -76,6 +76,21 @@ export default class D4HMembersProvider implements MemberProvider {
         },
       });
       return await response.arrayBuffer();
+    }
+  }
+
+  async findMembersByName(query: string) {
+    await this.initialize();
+    for (const token in this.tokenFetchInfo) {
+      return (
+        await (
+          await fetch(`https://api.d4h.org/v2/team/members?status=Operational&name=${query}`, {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          })
+        ).json()
+      )?.data as D4HMemberResponse[];
     }
   }
 

--- a/src/lib/server/memberProviders/memberProvider.ts
+++ b/src/lib/server/memberProviders/memberProvider.ts
@@ -1,6 +1,8 @@
 import { MemberProviderType } from '@respond/types/data/MemberProviderType';
 import { ParticipantInfo } from '@respond/types/participant';
 
+import { D4HMemberResponse } from './d4hMembersProvider';
+
 export interface MemberInfo {
   id: string;
   groups: string[];
@@ -18,6 +20,7 @@ export interface MemberProvider {
   getMemberInfoById(memberId: string): Promise<MemberInfo | undefined>;
   getMemberPhoto(memberId: string): Promise<ArrayBuffer | undefined>;
   getParticipantInfo(query: string): Promise<ParticipantInfo | undefined>;
+  findMembersByName(query: string): Promise<Array<D4HMemberResponse> | undefined>;
   refresh(force?: boolean): Promise<{ ok: boolean; runtime: number; cached?: boolean }>;
 }
 

--- a/src/lib/server/mongodb.ts
+++ b/src/lib/server/mongodb.ts
@@ -38,6 +38,12 @@ export default clientPromise.then(async (m) => {
   return m;
 });
 
+export async function getOrganizations() {
+  const client = await clientPromise;
+  const organizations = await client.db().collection<OrganizationDoc>(ORGS_COLLECTION).find().toArray();
+  return organizations;
+}
+
 export async function getOrganizationForDomain(domain: string) {
   const client = await clientPromise;
   const organization = await client.db().collection<OrganizationDoc>(ORGS_COLLECTION).findOne({ domain });


### PR DESCRIPTION
This enhancement adds a new "Base Kiosk" mode, accessible from Desktop Activity pages.

![image](https://github.com/user-attachments/assets/e80dbd6b-4dc4-45d6-b38f-1334bc782d46)

Accessing this mode allows users to manage their roster entries from a shared computer; e.g. at the command post. Similarly, it will allow users to add/update other responders to the roster.

On the Kiosk page, start by selecting which Organization to associate new roster entries with:

![image](https://github.com/user-attachments/assets/cca1bd6e-ff09-4691-a135-7c1040a21185)

Next, a search box appears which queries the MemberProvider for the selected Organization, entering a few characters will start a query:

![image](https://github.com/user-attachments/assets/2a5ddf8f-433a-4829-a1a7-e4c7729816df)

The status updater on this page updates the status of the currently selected member:

![image](https://github.com/user-attachments/assets/3da67c7f-158e-4b3a-9f62-9b283bb9589a)