### PR TITLE
Add/Manage Other Participants

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@mui/x-date-pickers": "^6.18.2",
     "@react-oauth/google": "^0.8.0",
     "@reduxjs/toolkit": "^1.9.3",
+    "@tanstack/react-query": "^5.90.21",
     "@types/jest": "^29.5.8",
     "@types/lodash.merge": "^4.6.7",
     "@types/node": "18.15.0",

--- a/src/app/api/v1/organizations/[orgId]/members/route.ts
+++ b/src/app/api/v1/organizations/[orgId]/members/route.ts
@@ -27,7 +27,7 @@ export async function GET(_request: NextRequest, { params }: { params: { orgId: 
     return NextResponse.json({ status: 'invalid query, must be at least 3 characters' }, { status: 400 });
   }
 
-  const list = await memberProvider.searchMembers(organizationDoc.id, query);
+  const list = await memberProvider.searchMembers(organizationDoc.id, encodeURIComponent(query));
 
   if (!list) {
     return NextResponse.json({ status: 'not found' }, { status: 404 });

--- a/src/app/api/v1/organizations/[orgId]/members/route.ts
+++ b/src/app/api/v1/organizations/[orgId]/members/route.ts
@@ -5,32 +5,39 @@ import * as Mongo from '@respond/lib/server/mongodb';
 import { getServices } from '@respond/lib/server/services';
 
 export async function GET(_request: NextRequest, { params }: { params: { orgId: string } }) {
-  const user = userFromAuth(await getCookieAuth());
-  if (user == null) {
-    return NextResponse.json({ status: 'not authenticated' }, { status: 401 });
-  }
+  try {
+    const user = userFromAuth(await getCookieAuth());
+    if (user == null) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
 
-  const organizationDoc = await Mongo.getOrganizationById(params.orgId);
-  if (!organizationDoc) {
-    return NextResponse.json({ status: 'unknown organization' }, { status: 500 });
-  }
+    const organizationDoc = await Mongo.getOrganizationById(params.orgId);
+    if (!organizationDoc) {
+      return NextResponse.json({ error: 'Organization not found' }, { status: 404 });
+    }
 
-  const memberProvider = (await getServices()).memberProviders.get(organizationDoc.memberProvider.provider);
-  if (!memberProvider) {
-    console.log(`Can't find memberProvider for org ${organizationDoc.id}: ${organizationDoc.memberProvider?.provider}`);
-    return NextResponse.json({ status: 'unknown member provider' }, { status: 500 });
-  }
+    const memberProvider = (await getServices()).memberProviders.get(organizationDoc.memberProvider.provider);
+    if (!memberProvider) {
+      console.error(`Member provider not found for org ${organizationDoc.id}: ${organizationDoc.memberProvider?.provider}`);
+      return NextResponse.json({ error: 'Member provider not configured' }, { status: 500 });
+    }
 
-  const searchParams = _request.nextUrl.searchParams;
-  const query = searchParams.get('query');
-  if (!query || query.length < 3) {
-    return NextResponse.json({ status: 'invalid query, must be at least 3 characters' }, { status: 400 });
-  }
+    const searchParams = _request.nextUrl.searchParams;
+    const query = searchParams.get('query')?.trim() ?? '';
 
-  const list = await memberProvider.searchMembers(organizationDoc.id, encodeURIComponent(query));
+    if (query.length < 3 || query.length > 100) {
+      return NextResponse.json({ error: 'Query must be between 3 and 100 characters' }, { status: 400 });
+    }
 
-  if (!list) {
-    return NextResponse.json({ status: 'not found' }, { status: 404 });
+    const list = await memberProvider.searchMembers(organizationDoc.id, query);
+
+    if (!list) {
+      return NextResponse.json({ error: 'No results found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ data: list });
+  } catch (error) {
+    console.error('Error searching members:', error);
+    return NextResponse.json({ error: 'Failed to search members' }, { status: 500 });
   }
-  return NextResponse.json({ status: 'ok', data: list });
 }

--- a/src/app/api/v1/organizations/[orgId]/members/route.ts
+++ b/src/app/api/v1/organizations/[orgId]/members/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getCookieAuth, userFromAuth } from '@respond/lib/server/auth';
+import * as Mongo from '@respond/lib/server/mongodb';
+import { getServices } from '@respond/lib/server/services';
+
+export async function GET(_request: NextRequest, { params }: { params: { orgId: string } }) {
+  const user = userFromAuth(await getCookieAuth());
+  if (user == null) {
+    return NextResponse.json({ status: 'not authenticated' }, { status: 401 });
+  }
+
+  const organizationDoc = await Mongo.getOrganizationById(params.orgId);
+  if (!organizationDoc) {
+    return NextResponse.json({ status: 'unknown organization' }, { status: 500 });
+  }
+
+  const memberProvider = (await getServices()).memberProviders.get(organizationDoc.memberProvider.provider);
+  if (!memberProvider) {
+    console.log(`Can't find memberProvider for org ${organizationDoc.id}: ${organizationDoc.memberProvider?.provider}`);
+    return NextResponse.json({ status: 'unknown member provider' }, { status: 500 });
+  }
+
+  const searchParams = _request.nextUrl.searchParams;
+  const query = searchParams.get('query');
+  if (!query || query.length < 3) {
+    return NextResponse.json({ status: 'invalid query, must be at least 3 characters' }, { status: 400 });
+  }
+
+  const list = await memberProvider.searchMembers(organizationDoc.id, query);
+
+  if (!list) {
+    return NextResponse.json({ status: 'not found' }, { status: 404 });
+  }
+  return NextResponse.json({ status: 'ok', data: list });
+}

--- a/src/app/api/v1/organizations/route.ts
+++ b/src/app/api/v1/organizations/route.ts
@@ -4,12 +4,17 @@ import { getCookieAuth, userFromAuth } from '@respond/lib/server/auth';
 import { getServices } from '@respond/lib/server/services';
 
 export async function GET() {
-  const user = userFromAuth(await getCookieAuth());
-  if (user == null) {
-    return NextResponse.json({ status: 'not authenticated' }, { status: 401 });
+  try {
+    const user = userFromAuth(await getCookieAuth());
+    if (user == null) {
+      return NextResponse.json({ status: 'not authenticated' }, { status: 401 });
+    }
+
+    const list = await (await getServices()).stateManager.getAllOrganizations();
+
+    return NextResponse.json({ status: 'ok', data: list });
+  } catch (error) {
+    console.error('Error fetching organizations:', error);
+    return NextResponse.json({ error: 'Failed to fetch organizations' }, { status: 500 });
   }
-
-  const list = await (await getServices()).stateManager.getAllOrganizations();
-
-  return NextResponse.json({ status: 'ok', data: list });
 }

--- a/src/app/api/v1/organizations/route.ts
+++ b/src/app/api/v1/organizations/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+
+import { getCookieAuth, userFromAuth } from '@respond/lib/server/auth';
+import { getServices } from '@respond/lib/server/services';
+
+export async function GET() {
+  const user = userFromAuth(await getCookieAuth());
+  if (user == null) {
+    return NextResponse.json({ status: 'not authenticated' }, { status: 401 });
+  }
+
+  const list = await (await getServices()).stateManager.getAllOrganizations();
+
+  return NextResponse.json({ status: 'ok', data: list });
+}

--- a/src/components/ClientProviders.tsx
+++ b/src/components/ClientProviders.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { GoogleOAuthProvider } from '@react-oauth/google';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactNode, useEffect, useMemo, useState } from 'react';
 import { Provider } from 'react-redux';
 
@@ -22,6 +23,7 @@ export interface SiteConfig {
 export default function ClientProviders({ googleClient, config, user, myOrg, children }: { googleClient: string; config: SiteConfig; user?: UserInfo; myOrg?: MyOrganization; children: ReactNode }) {
   const [store] = useState<AppStore>(buildClientStore([]));
   const [sync] = useState<ClientSync>(new ClientSync(store));
+  const [queryClient] = useState(() => new QueryClient());
 
   useEffect(() => {
     console.log('ClientProviders mounting ...');
@@ -60,8 +62,10 @@ export default function ClientProviders({ googleClient, config, user, myOrg, chi
   }
 
   return (
-    <Provider store={store}>
-      <ThemeProvider theme={hydratedTheme}>{inner}</ThemeProvider>
-    </Provider>
+    <QueryClientProvider client={queryClient}>
+      <Provider store={store}>
+        <ThemeProvider theme={hydratedTheme}>{inner}</ThemeProvider>
+      </Provider>
+    </QueryClientProvider>
   );
 }

--- a/src/components/StatusUpdater/UpdateStatusForm.tsx
+++ b/src/components/StatusUpdater/UpdateStatusForm.tsx
@@ -3,9 +3,10 @@ import { useEffect, useState } from 'react';
 import { Controller, Resolver, ResolverResult, SubmitHandler, useForm } from 'react-hook-form';
 
 import { useAppDispatch } from '@respond/lib/client/store';
+import { MemberInfo } from '@respond/lib/server/memberProviders/memberProvider';
 import { ActivityActions } from '@respond/lib/state';
 import { Activity, OrganizationStatus, Participant, ParticipantStatus } from '@respond/types/activity';
-import { MyOrganization } from '@respond/types/organization';
+import { Organization } from '@respond/types/organization';
 import { UserInfo } from '@respond/types/userInfo';
 
 import { DialogContentText, FormControl, FormHelperText, Stack } from '../Material';
@@ -17,8 +18,10 @@ interface FormValues {
   statusTime: number;
 }
 
-export function useFormLogic(activity: Activity, user: UserInfo, respondingOrg: MyOrganization, participant: Participant | undefined, currentStatus: ParticipantStatus | undefined, newStatus: ParticipantStatus, onFinish: () => void) {
+export function useFormLogic(activity: Activity, user: UserInfo | MemberInfo, respondingOrg: Organization, participant: Participant | undefined, currentStatus: ParticipantStatus | undefined, newStatus: ParticipantStatus, onFinish: () => void) {
   const dispatch = useAppDispatch();
+
+  const participantId = 'participantId' in user ? user.participantId : user.id;
 
   const resolver: Resolver<FormValues> = async (values) => {
     const result: ResolverResult<FormValues> = {
@@ -75,7 +78,7 @@ export function useFormLogic(activity: Activity, user: UserInfo, respondingOrg: 
         ),
       );
     }
-    dispatch(ActivityActions.participantUpdate(activity.id, user.participantId, user.given_name ?? '', user.family_name ?? '', respondingOrg.id, time, newStatus, data.miles === '' ? undefined : data.miles));
+    dispatch(ActivityActions.participantUpdate(activity.id, participantId, user.given_name ?? '', user.family_name ?? '', respondingOrg.id, time, newStatus, data.miles === '' ? undefined : data.miles));
     onFinish();
   };
 

--- a/src/components/StatusUpdater/index.tsx
+++ b/src/components/StatusUpdater/index.tsx
@@ -2,8 +2,9 @@ import { useState } from 'react';
 
 import { useAppSelector } from '@respond/lib/client/store';
 import { defaultEarlySigninWindow, isFuture } from '@respond/lib/client/store/activities';
+import { MemberInfo } from '@respond/lib/server/memberProviders/memberProvider';
 import { getOrganizationName, isActive, isResponding, ParticipantStatus } from '@respond/types/activity';
-import { MyOrganization } from '@respond/types/organization';
+import { Organization } from '@respond/types/organization';
 import { UserInfo } from '@respond/types/userInfo';
 
 import { useActivityContext } from '../activities/ActivityProvider';
@@ -90,21 +91,23 @@ function getStatusOptions(current: ParticipantStatus | undefined, startTime: num
   return statusOptions[status];
 }
 
-export const StatusUpdater = ({ fullWidth }: { fullWidth?: boolean }) => {
+export const StatusUpdater = ({ member, organization, fullWidth }: { member?: MemberInfo; organization?: Organization; fullWidth?: boolean }) => {
   const user = useAppSelector((state) => state.auth.userInfo);
   const thisOrg = useAppSelector((state) => state.organization.mine);
 
-  return user && thisOrg ? <StatusUpdaterProtected user={user} thisOrg={thisOrg} fullWidth={fullWidth} /> : null;
+  return user && thisOrg ? <StatusUpdaterProtected user={member || user} thisOrg={organization || thisOrg} fullWidth={fullWidth} /> : null;
 };
 
-const StatusUpdaterProtected = ({ fullWidth, user, thisOrg }: { user: UserInfo; fullWidth?: boolean; thisOrg: MyOrganization }) => {
+const StatusUpdaterProtected = ({ fullWidth, user, thisOrg }: { user: UserInfo | MemberInfo; fullWidth?: boolean; thisOrg: Organization }) => {
   const activity = useActivityContext();
   const [confirming, setConfirming] = useState<boolean>(false);
   const [confirmTitle, setConfirmTitle] = useState<string>('');
   const [confirmStatus, setConfirmStatus] = useState<ParticipantStatus>(ParticipantStatus.SignedIn);
   const [confirmLabel, setConfirmLabel] = useState<string>('');
 
-  const participant = activity.participants[user.participantId];
+  const participantId = 'participantId' in user ? user.participantId : user.id;
+
+  const participant = activity.participants[participantId];
   const current = participant?.timeline[0]?.status;
 
   const formLogic = useFormLogic(activity, user, thisOrg, participant, current, confirmStatus, () => setConfirming(false));

--- a/src/components/activities/AddParticipantButton.tsx
+++ b/src/components/activities/AddParticipantButton.tsx
@@ -1,0 +1,57 @@
+import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, Stack } from '@mui/material';
+import * as React from 'react';
+
+import { Activity } from '@respond/types/activity';
+
+import MemberSearch from '../member/MemberSearch';
+import OrganizationSelect from '../organization/OrganizationSelect';
+
+export default function AddParticipantButton({ activity }: { activity: Activity }) {
+  const [openDialog, setOpenDialog] = React.useState<boolean>(false);
+
+  const label = `Add ${activity.isMission ? 'Responder' : 'Participant'}`;
+
+  const handleResult = (data?: { memberId: string; organizationId: string }) => {
+    setOpenDialog(false);
+    if (data) console.log(`Add ${data.memberId}`);
+  };
+
+  return (
+    <>
+      <Button size="small" variant="outlined" onClick={() => setOpenDialog(true)}>
+        {label}
+      </Button>
+      <AddParticipantDialog open={openDialog} title={label} onAdd={handleResult} onClose={handleResult} />
+    </>
+  );
+}
+
+function AddParticipantDialog({ open, title, onClose, onAdd }: { open: boolean; title: string; onAdd: (data: { memberId: string; organizationId: string }) => void; onClose: () => void }) {
+  const [organizationId, setOrganizationId] = React.useState('');
+  const [memberId, setMemberId] = React.useState('');
+
+  const handleAdd = () => {
+    onAdd({ memberId, organizationId });
+    onClose();
+  };
+
+  return (
+    <Dialog fullWidth={true} open={open} onClose={onClose}>
+      <DialogTitle alignItems="center" justifyContent="space-between" display="flex">
+        <Box>{title}</Box>
+      </DialogTitle>
+      <DialogContent>
+        <Stack sx={{ py: 1 }} spacing={2}>
+          <OrganizationSelect onChange={(id: string) => setOrganizationId(id)}></OrganizationSelect>
+          <MemberSearch organizationId={organizationId} onChange={(id: string) => setMemberId(id)}></MemberSearch>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button disabled={!memberId || !organizationId} onClick={handleAdd} variant="contained">
+          Add
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/activities/AddParticipantButton.tsx
+++ b/src/components/activities/AddParticipantButton.tsx
@@ -1,56 +1,66 @@
 import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, Stack } from '@mui/material';
 import * as React from 'react';
 
-import { Activity } from '@respond/types/activity';
+import { MemberInfo } from '@respond/lib/server/memberProviders/memberProvider';
+import { Activity, Participant } from '@respond/types/activity';
+import { Organization } from '@respond/types/organization';
 
 import MemberSearch from '../member/MemberSearch';
 import OrganizationSelect from '../organization/OrganizationSelect';
+import { StatusUpdater } from '../StatusUpdater';
+
+import ParticipantTimeline from './ParticipantTimeline';
+
+const getTitle = (activity: Activity) => `Add ${activity.isMission ? 'Responder' : 'Participant'}`;
 
 export default function AddParticipantButton({ activity }: { activity: Activity }) {
   const [openDialog, setOpenDialog] = React.useState<boolean>(false);
 
-  const label = `Add ${activity.isMission ? 'Responder' : 'Participant'}`;
-
-  const handleResult = (data?: { memberId: string; organizationId: string }) => {
-    setOpenDialog(false);
-    if (data) console.log(`Add ${data.memberId}`);
-  };
-
   return (
     <>
       <Button size="small" variant="outlined" onClick={() => setOpenDialog(true)}>
-        {label}
+        {getTitle(activity)}
       </Button>
-      <AddParticipantDialog open={openDialog} title={label} onAdd={handleResult} onClose={handleResult} />
+      <AddParticipantDialog open={openDialog} activity={activity} onClose={() => setOpenDialog(false)} />
     </>
   );
 }
 
-function AddParticipantDialog({ open, title, onClose, onAdd }: { open: boolean; title: string; onAdd: (data: { memberId: string; organizationId: string }) => void; onClose: () => void }) {
-  const [organizationId, setOrganizationId] = React.useState('');
-  const [memberId, setMemberId] = React.useState('');
+function AddParticipantDialog({ open, activity, onClose }: { open: boolean; activity: Activity; onClose: () => void }) {
+  const [organization, setOrganization] = React.useState<Organization | undefined>(undefined);
+  const [member, setMember] = React.useState<MemberInfo | undefined>(undefined);
+  const [participant, setParticipant] = React.useState<Participant | undefined>(undefined);
 
-  const handleAdd = () => {
-    onAdd({ memberId, organizationId });
+  React.useEffect(() => {
+    if (member && activity.participants[member.id]) {
+      setParticipant(activity.participants[member.id]);
+    } else {
+      setParticipant(undefined);
+    }
+  }, [activity, member]);
+
+  const handleClose = () => {
+    setOrganization(undefined);
+    setMember(undefined);
+    setParticipant(undefined);
     onClose();
   };
 
   return (
     <Dialog fullWidth={true} open={open} onClose={onClose}>
       <DialogTitle alignItems="center" justifyContent="space-between" display="flex">
-        <Box>{title}</Box>
+        <Box>{getTitle(activity)}</Box>
       </DialogTitle>
       <DialogContent>
         <Stack sx={{ py: 1 }} spacing={2}>
-          <OrganizationSelect onChange={(id: string) => setOrganizationId(id)}></OrganizationSelect>
-          <MemberSearch organizationId={organizationId} onChange={(id: string) => setMemberId(id)}></MemberSearch>
+          <OrganizationSelect onChange={(organization) => setOrganization(organization)}></OrganizationSelect>
+          <MemberSearch organizationId={organization?.id} onChange={(member) => setMember(member)}></MemberSearch>
+          {participant && <ParticipantTimeline participant={participant} />}
+          {organization && member && <StatusUpdater member={member} organization={organization} fullWidth />}
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose}>Cancel</Button>
-        <Button disabled={!memberId || !organizationId} onClick={handleAdd} variant="contained">
-          Add
-        </Button>
+        <Button onClick={handleClose}>Close</Button>
       </DialogActions>
     </Dialog>
   );

--- a/src/components/activities/DesktopActivityPage.tsx
+++ b/src/components/activities/DesktopActivityPage.tsx
@@ -13,6 +13,7 @@ import { ParticipantEtaUpdater } from '../participant/ParticipantEtaUpdater';
 
 import { ActivityActionsBar } from './ActivityPage';
 import { useActivityContext } from './ActivityProvider';
+import AddParticipantButton from './AddParticipantButton';
 import { BriefingPanel } from './BriefingPanel';
 import { ManagerPanel } from './ManagerPanel';
 import { ParticipatingOrgChips } from './ParticipatingOrgChips';
@@ -42,9 +43,12 @@ export function DesktopActivityPage() {
         <Box display="flex" flex="1 1 auto" flexDirection="column">
           <Stack direction="row" justifyContent="space-between" alignItems="center">
             <ParticipatingOrgChips filter={orgFilter} setFilter={setOrgFilter} display="flex" flexDirection="row" />
-            <Button href={`/roster/${activity.id}`} variant="outlined" size="small">
-              View Roster
-            </Button>
+            <Stack direction="row" spacing={1} alignItems="center">
+              <AddParticipantButton activity={activity} />
+              <Button href={`/roster/${activity.id}`} variant="outlined" size="small">
+                View Roster
+              </Button>
+            </Stack>
           </Stack>
           <RosterPanel //
             filter={orgFilter}

--- a/src/components/activities/RosterPanel.tsx
+++ b/src/components/activities/RosterPanel.tsx
@@ -8,8 +8,8 @@ import { FunctionComponent, ReactNode, useEffect, useState } from 'react';
 
 import { Box, Dialog, DialogContent, DialogTitle, Paper, Stack, Typography, useMediaQuery } from '@respond/components/Material';
 import { apiFetch } from '@respond/lib/api';
+import { MemberInfo } from '@respond/lib/server/memberProviders/memberProvider';
 import { getOrganizationName, getStatusCssColor, getStatusText, isActive, Participant, ParticipantStatus, ParticipantUpdate, ParticipatingOrg } from '@respond/types/activity';
-import { ParticipantInfo } from '@respond/types/participant';
 
 import { ParticipantMilesUpdater } from '../participant/ParticipantMilesUpdater';
 
@@ -30,7 +30,7 @@ const sortArrivingNext = (a: Participant, b: Participant) => etaStatus(b.timelin
 const sortAlphabetical = (a: Participant, b: Participant) => a.firstname.localeCompare(b.firstname);
 
 const findMember = async (orgId: string, memberId: string) => {
-  return (await apiFetch<{ data: ParticipantInfo }>(`/api/v1/organizations/${orgId}/members/${memberId}`)).data;
+  return (await apiFetch<{ data: MemberInfo }>(`/api/v1/organizations/${orgId}/members/${memberId}`)).data;
 };
 
 const formatPhoneNumber = (phoneNumberString: string, includeIntlCode: boolean = false) => {
@@ -97,7 +97,7 @@ export function RosterRowCard({ status, children, onClick, ...props }: PaperProp
 export function ParticipantDialog({ open, participant, onClose }: { open: boolean; onClose: () => void; participant?: Participant }) {
   const activity = useActivityContext();
   const isMobile = useMediaQuery(useTheme().breakpoints.down('md'));
-  const [memberInfo, setMemberInfo] = useState<ParticipantInfo | undefined>();
+  const [memberInfo, setMemberInfo] = useState<MemberInfo | undefined>();
 
   useEffect(() => {
     if (participant) getMemberInfo(participant);

--- a/src/components/member/MemberSearch.tsx
+++ b/src/components/member/MemberSearch.tsx
@@ -1,80 +1,67 @@
 import Autocomplete from '@mui/material/Autocomplete';
 import CircularProgress from '@mui/material/CircularProgress';
 import TextField from '@mui/material/TextField';
+import { useQuery } from '@tanstack/react-query';
 import * as React from 'react';
 
 import { useDebounce } from '@respond/hooks/useDebounce';
 import { apiFetch } from '@respond/lib/api';
 import { MemberInfo } from '@respond/lib/server/memberProviders/memberProvider';
 
-const findMembers = async (organizationId: string, query: string) => {
-  return (await apiFetch<{ data: MemberInfo[] }>(`/api/v1/organizations/${organizationId}/members?query=${query}`)).data;
-};
-
 type TextFieldVariant = 'filled' | 'outlined' | 'standard';
 
 export default function MemberSearch({ organizationId, label = 'Member', variant = 'outlined', onChange }: { organizationId: string | undefined; label?: string; variant?: TextFieldVariant; onChange: (member: MemberInfo | undefined) => void }) {
   const [open, setOpen] = React.useState(false);
-  const [options, setOptions] = React.useState<readonly MemberInfo[]>([]);
-  const [loading, setLoading] = React.useState(false);
-
   const [search, setSearch] = React.useState('');
   const debouncedSearch = useDebounce(search, 500);
 
-  React.useEffect(() => {
-    if (organizationId && debouncedSearch) {
-      findMembers(organizationId, debouncedSearch).then((infos) => {
-        setOptions(infos);
-        setLoading(false);
-      });
-    }
-  }, [organizationId, debouncedSearch]);
+  const { data: options = [], isLoading } = useQuery({
+    queryKey: ['members', organizationId, debouncedSearch],
+    queryFn: async () => {
+      if (!organizationId || debouncedSearch.length < 3) return [];
+      const res = await apiFetch<{ data: MemberInfo[] }>(`/api/v1/organizations/${organizationId}/members?query=${debouncedSearch}`);
+      return res.data;
+    },
+    enabled: !!organizationId && debouncedSearch.length >= 3,
+  });
+
+  const handleChange = React.useCallback(
+    (event: React.SyntheticEvent, value: MemberInfo | null) => {
+      onChange(value ?? undefined);
+    },
+    [onChange],
+  );
 
   return (
     <Autocomplete
       disabled={!organizationId}
-      open={open}
-      onOpen={() => {
-        setOpen(true);
-      }}
-      onClose={() => {
-        setOpen(false);
-      }}
-      onInputChange={(event, value) => {
-        if ((value?.length ?? 0) >= 3) {
-          setLoading(true);
-          setSearch(value);
-        }
-      }}
-      onChange={(event, value) => {
-        if (value && typeof value !== 'string') {
-          onChange(value ? options.find((f) => f.id === value.id) : undefined);
-        }
-      }}
-      freeSolo={true}
-      isOptionEqualToValue={(option, value) => option.label === value.label}
-      getOptionLabel={(option) => (typeof option === 'string' ? option : option.label) ?? ''}
-      renderOption={(props, option) => {
-        return (
-          <li {...props} key={option.label}>
-            {option.label}
-          </li>
-        );
-      }}
+      open={open && !!debouncedSearch}
+      onOpen={() => setOpen(true)}
+      onClose={() => setOpen(false)}
+      onInputChange={(event, value) => setSearch(value)}
+      onChange={handleChange}
+      isOptionEqualToValue={(option, value) => option.id === value.id}
+      getOptionLabel={(option) => option.label ?? ''}
+      renderOption={(props, option) => (
+        <li {...props} key={option.id}>
+          {option.label}
+        </li>
+      )}
       options={options}
-      loading={loading}
+      loading={isLoading}
       renderInput={(params) => (
         <TextField
           {...params}
           label={label}
           variant={variant}
+          helperText="Search by member name or email (min 3 characters)"
           InputProps={{
             ...params.InputProps,
             endAdornment: (
-              <React.Fragment>
-                {loading ? <CircularProgress color="inherit" size={20} /> : null}
+              <>
+                {isLoading ? <CircularProgress color="inherit" size={20} /> : null}
                 {params.InputProps.endAdornment}
-              </React.Fragment>
+              </>
             ),
           }}
         />

--- a/src/components/member/MemberSearch.tsx
+++ b/src/components/member/MemberSearch.tsx
@@ -1,0 +1,84 @@
+import Autocomplete from '@mui/material/Autocomplete';
+import CircularProgress from '@mui/material/CircularProgress';
+import TextField from '@mui/material/TextField';
+import * as React from 'react';
+
+import { useDebounce } from '@respond/hooks/useDebounce';
+import { apiFetch } from '@respond/lib/api';
+import { MemberInfo } from '@respond/lib/server/memberProviders/memberProvider';
+
+const findMembers = async (organizationId: string, query: string) => {
+  return (await apiFetch<{ data: MemberInfo[] }>(`/api/v1/organizations/${organizationId}/members?query=${query}`)).data;
+};
+
+type TextFieldVariant = 'filled' | 'outlined' | 'standard';
+
+export default function MemberSearch({ organizationId, label = 'Member', variant = 'outlined', onChange }: { organizationId: string; label?: string; variant?: TextFieldVariant; onChange: (id: string) => void }) {
+  const [open, setOpen] = React.useState(false);
+  const [options, setOptions] = React.useState<readonly MemberInfo[]>([]);
+  const [loading, setLoading] = React.useState(false);
+
+  const [search, setSearch] = React.useState('');
+  const debouncedSearch = useDebounce(search, 500);
+
+  React.useEffect(() => {
+    if (debouncedSearch) {
+      findMembers(organizationId, debouncedSearch).then((infos) => {
+        setOptions(infos);
+        setLoading(false);
+      });
+    }
+  }, [organizationId, debouncedSearch]);
+
+  return (
+    <Autocomplete
+      disabled={!organizationId}
+      open={open}
+      onOpen={() => {
+        setOpen(true);
+      }}
+      onClose={() => {
+        setOpen(false);
+      }}
+      onInputChange={(event, value) => {
+        if ((value?.length ?? 0) >= 3) {
+          setLoading(true);
+          setSearch(value);
+        }
+      }}
+      onChange={(event, value) => {
+        if (value && typeof value !== 'string') {
+          onChange(value.id);
+        }
+      }}
+      freeSolo={true}
+      isOptionEqualToValue={(option, value) => option.label === value.label}
+      getOptionLabel={(option) => (typeof option === 'string' ? option : option.label) ?? ''}
+      renderOption={(props, option) => {
+        return (
+          <li {...props} key={option.label}>
+            {option.label}
+          </li>
+        );
+      }}
+      options={options}
+      loading={loading}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={label}
+          variant={variant}
+          InputProps={{
+            ...params.InputProps,
+            endAdornment: (
+              <React.Fragment>
+                {loading ? <CircularProgress color="inherit" size={20} /> : null}
+                {params.InputProps.endAdornment}
+              </React.Fragment>
+            ),
+          }}
+        />
+      )}
+    />
+  );
+}

--- a/src/components/member/MemberSearch.tsx
+++ b/src/components/member/MemberSearch.tsx
@@ -13,7 +13,7 @@ const findMembers = async (organizationId: string, query: string) => {
 
 type TextFieldVariant = 'filled' | 'outlined' | 'standard';
 
-export default function MemberSearch({ organizationId, label = 'Member', variant = 'outlined', onChange }: { organizationId: string; label?: string; variant?: TextFieldVariant; onChange: (id: string) => void }) {
+export default function MemberSearch({ organizationId, label = 'Member', variant = 'outlined', onChange }: { organizationId: string | undefined; label?: string; variant?: TextFieldVariant; onChange: (member: MemberInfo | undefined) => void }) {
   const [open, setOpen] = React.useState(false);
   const [options, setOptions] = React.useState<readonly MemberInfo[]>([]);
   const [loading, setLoading] = React.useState(false);
@@ -22,7 +22,7 @@ export default function MemberSearch({ organizationId, label = 'Member', variant
   const debouncedSearch = useDebounce(search, 500);
 
   React.useEffect(() => {
-    if (debouncedSearch) {
+    if (organizationId && debouncedSearch) {
       findMembers(organizationId, debouncedSearch).then((infos) => {
         setOptions(infos);
         setLoading(false);
@@ -48,7 +48,7 @@ export default function MemberSearch({ organizationId, label = 'Member', variant
       }}
       onChange={(event, value) => {
         if (value && typeof value !== 'string') {
-          onChange(value.id);
+          onChange(value ? options.find((f) => f.id === value.id) : undefined);
         }
       }}
       freeSolo={true}

--- a/src/components/organization/OrganizationSelect.tsx
+++ b/src/components/organization/OrganizationSelect.tsx
@@ -2,15 +2,16 @@ import { FormControl, InputLabel, MenuItem, Select, SelectChangeEvent } from '@m
 import * as React from 'react';
 
 import useOrganizations from '@respond/hooks/useOrganizations';
+import { Organization } from '@respond/types/organization';
 
-export default function OrganizationSelect({ onChange }: { onChange: (id: string) => void }) {
+export default function OrganizationSelect({ onChange }: { onChange: (id: Organization | undefined) => void }) {
   const { organizations } = useOrganizations();
 
   const [value, setValue] = React.useState('');
 
   const handleChange = (event: SelectChangeEvent<string>) => {
     setValue(event.target.value);
-    onChange(event.target.value);
+    onChange(event.target.value ? organizations?.find((f) => f.id === event.target.value) : undefined);
   };
 
   return (

--- a/src/components/organization/OrganizationSelect.tsx
+++ b/src/components/organization/OrganizationSelect.tsx
@@ -4,24 +4,31 @@ import * as React from 'react';
 import useOrganizations from '@respond/hooks/useOrganizations';
 import { Organization } from '@respond/types/organization';
 
-export default function OrganizationSelect({ onChange }: { onChange: (id: Organization | undefined) => void }) {
-  const { organizations } = useOrganizations();
+export default function OrganizationSelect({ onChange }: { onChange: (organization: Organization | undefined) => void }) {
+  const { organizations, isLoading, isError } = useOrganizations();
 
   const [value, setValue] = React.useState('');
 
-  const handleChange = (event: SelectChangeEvent<string>) => {
-    setValue(event.target.value);
-    onChange(event.target.value ? organizations?.find((f) => f.id === event.target.value) : undefined);
-  };
+  const handleChange = React.useCallback(
+    (event: SelectChangeEvent<string>) => {
+      setValue(event.target.value);
+      onChange(event.target.value ? organizations?.find((f) => f.id === event.target.value) : undefined);
+    },
+    [organizations, onChange],
+  );
 
   return (
     <FormControl fullWidth>
       <InputLabel>Organization</InputLabel>
       <Select value={value} label="Organization" onChange={handleChange}>
-        {organizations === null ? (
+        {isLoading ? (
           <MenuItem disabled>Loading organizations...</MenuItem>
+        ) : isError ? (
+          <MenuItem disabled>Error loading organizations</MenuItem>
+        ) : organizations?.length === 0 ? (
+          <MenuItem disabled>No organizations available</MenuItem>
         ) : (
-          organizations.map((org) => (
+          organizations?.map((org) => (
             <MenuItem key={org.id} value={org.id}>
               {org.title}
             </MenuItem>

--- a/src/components/organization/OrganizationSelect.tsx
+++ b/src/components/organization/OrganizationSelect.tsx
@@ -1,0 +1,32 @@
+import { FormControl, InputLabel, MenuItem, Select, SelectChangeEvent } from '@mui/material';
+import * as React from 'react';
+
+import useOrganizations from '@respond/hooks/useOrganizations';
+
+export default function OrganizationSelect({ onChange }: { onChange: (id: string) => void }) {
+  const { organizations } = useOrganizations();
+
+  const [value, setValue] = React.useState('');
+
+  const handleChange = (event: SelectChangeEvent<string>) => {
+    setValue(event.target.value);
+    onChange(event.target.value);
+  };
+
+  return (
+    <FormControl fullWidth>
+      <InputLabel>Organization</InputLabel>
+      <Select value={value} label="Organization" onChange={handleChange}>
+        {organizations === null ? (
+          <MenuItem disabled>Loading organizations...</MenuItem>
+        ) : (
+          organizations.map((org) => (
+            <MenuItem key={org.id} value={org.id}>
+              {org.title}
+            </MenuItem>
+          ))
+        )}
+      </Select>
+    </FormControl>
+  );
+}

--- a/src/hooks/useOrganizations.ts
+++ b/src/hooks/useOrganizations.ts
@@ -1,0 +1,40 @@
+import * as React from 'react';
+
+import { apiFetch } from '@respond/lib/api';
+import { OrganizationDoc } from '@respond/types/data/organizationDoc';
+
+type OrganizationOption = Pick<OrganizationDoc, 'id' | 'title'>;
+
+let cachedOrgs: OrganizationOption[] | null = null;
+
+export default function useOrganizations() {
+  const [organizations, setOrganizations] = React.useState<OrganizationOption[] | null>(cachedOrgs);
+  const [loading, setLoading] = React.useState<boolean>(!cachedOrgs);
+
+  const load = React.useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await apiFetch<{ data: OrganizationOption[] }>('/api/v1/organizations');
+      cachedOrgs = res.data;
+      setOrganizations(res.data);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    if (!cachedOrgs) {
+      load();
+    }
+  }, [load]);
+
+  const reload = React.useCallback(() => {
+    // clear cache and reload
+    cachedOrgs = null;
+    load();
+  }, [load]);
+
+  return { organizations, loading, reload } as const;
+}
+
+export type { OrganizationOption };

--- a/src/hooks/useOrganizations.ts
+++ b/src/hooks/useOrganizations.ts
@@ -1,20 +1,18 @@
 import * as React from 'react';
 
 import { apiFetch } from '@respond/lib/api';
-import { OrganizationDoc } from '@respond/types/data/organizationDoc';
+import { Organization } from '@respond/types/organization';
 
-type OrganizationOption = Pick<OrganizationDoc, 'id' | 'title'>;
-
-let cachedOrgs: OrganizationOption[] | null = null;
+let cachedOrgs: Organization[] | null = null;
 
 export default function useOrganizations() {
-  const [organizations, setOrganizations] = React.useState<OrganizationOption[] | null>(cachedOrgs);
+  const [organizations, setOrganizations] = React.useState<Organization[] | null>(cachedOrgs);
   const [loading, setLoading] = React.useState<boolean>(!cachedOrgs);
 
   const load = React.useCallback(async () => {
     setLoading(true);
     try {
-      const res = await apiFetch<{ data: OrganizationOption[] }>('/api/v1/organizations');
+      const res = await apiFetch<{ data: Organization[] }>('/api/v1/organizations');
       cachedOrgs = res.data;
       setOrganizations(res.data);
     } finally {
@@ -36,5 +34,3 @@ export default function useOrganizations() {
 
   return { organizations, loading, reload } as const;
 }
-
-export type { OrganizationOption };

--- a/src/hooks/useOrganizations.ts
+++ b/src/hooks/useOrganizations.ts
@@ -1,36 +1,18 @@
-import * as React from 'react';
+import { useQuery } from '@tanstack/react-query';
 
 import { apiFetch } from '@respond/lib/api';
 import { Organization } from '@respond/types/organization';
 
-let cachedOrgs: Organization[] | null = null;
+const ORGANIZATIONS_QUERY_KEY = ['organizations'] as const;
 
 export default function useOrganizations() {
-  const [organizations, setOrganizations] = React.useState<Organization[] | null>(cachedOrgs);
-  const [loading, setLoading] = React.useState<boolean>(!cachedOrgs);
-
-  const load = React.useCallback(async () => {
-    setLoading(true);
-    try {
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: ORGANIZATIONS_QUERY_KEY,
+    queryFn: async () => {
       const res = await apiFetch<{ data: Organization[] }>('/api/v1/organizations');
-      cachedOrgs = res.data;
-      setOrganizations(res.data);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+      return res.data;
+    },
+  });
 
-  React.useEffect(() => {
-    if (!cachedOrgs) {
-      load();
-    }
-  }, [load]);
-
-  const reload = React.useCallback(() => {
-    // clear cache and reload
-    cachedOrgs = null;
-    load();
-  }, [load]);
-
-  return { organizations, loading, reload } as const;
+  return { organizations: data ?? null, isLoading, isError, reload: refetch } as const;
 }

--- a/src/lib/server/memberProviders/d4hMembersProvider.ts
+++ b/src/lib/server/memberProviders/d4hMembersProvider.ts
@@ -1,6 +1,5 @@
 import mongoPromise from '@respond/lib/server/mongodb';
 import { MemberProviderConfig, OrganizationDoc, ORGS_COLLECTION } from '@respond/types/data/organizationDoc';
-import { ParticipantInfo } from '@respond/types/participant';
 
 import { MemberAuthInfo, MemberInfo, MemberProvider } from './memberProvider';
 
@@ -53,6 +52,20 @@ interface D4HCacheDoc extends FetchForTokenEntry {
   token: string;
 }
 
+function buildMemberInfo(member: D4HMemberResponse, groups: string[] = []): MemberInfo {
+  const [family_name, given_name] = member.name.split(', ');
+  return {
+    id: member.id.toString(),
+    label: `${member.name}${member.ref ? ' (' + member.ref + ')' : ''}`,
+    name: member.name,
+    given_name,
+    family_name,
+    groups,
+    email: member.email?.value,
+    mobilephone: member.mobile?.phone,
+  };
+}
+
 export default class D4HMembersProvider implements MemberProvider {
   initialized: boolean = false;
   fetching: boolean = false;
@@ -91,11 +104,7 @@ export default class D4HMembersProvider implements MemberProvider {
     for (const token in this.tokenFetchInfo) {
       const member = this.tokenFetchInfo[token].lookup[memberId].response;
       if (!member) continue;
-      const result: ParticipantInfo = {
-        email: member.email?.value,
-        mobilephone: member.mobile?.phone,
-      };
-      return result;
+      return buildMemberInfo(member);
     }
   }
 
@@ -156,14 +165,7 @@ export default class D4HMembersProvider implements MemberProvider {
     }
 
     const data = await response.json();
-    const results = (data.results || []).map((res: D4HMemberResponse) => {
-      return {
-        id: res.id,
-        label: `${res.name} (${res.ref})`,
-        name: res.name,
-        groups: [],
-      };
-    }) as MemberInfo[];
+    const results = (data.results || []).map((member: D4HMemberResponse) => buildMemberInfo(member)) as MemberInfo[];
 
     console.log(results);
     return results;
@@ -315,13 +317,13 @@ export default class D4HMembersProvider implements MemberProvider {
 
     const lookup = rows.reduce(
       (accum, cur) => {
-        const memberInfo: MemberInfo = {
-          id: cur.id + '',
-          groups: memberships
+        const memberInfo: MemberInfo = buildMemberInfo(
+          cur,
+          memberships
             .filter((f) => f.member.id === cur.id)
             .map((f) => groupLookup[f.group.id])
             .filter((f) => !!f),
-        };
+        );
 
         const member: D4HMember = {
           response: cur,

--- a/src/lib/server/memberProviders/d4hMembersProvider.ts
+++ b/src/lib/server/memberProviders/d4hMembersProvider.ts
@@ -7,6 +7,7 @@ import { MemberAuthInfo, MemberInfo, MemberProvider } from './memberProvider';
 const D4H_MEMBER_REFRESH_SECS = 15 * 60;
 const D4H_FETCH_LIMIT = 1000;
 const D4H_CACHE_COLLECTION = 'd4hCache';
+const D4H_STATUS_OPERATIONAL = 'OPERATIONAL';
 
 interface CustomFieldValue {
   customField: { id: number };
@@ -127,6 +128,45 @@ export default class D4HMembersProvider implements MemberProvider {
     } else {
       return undefined;
     }
+  }
+
+  async searchMembers(organizationId: string, query: string): Promise<MemberInfo[]> {
+    await this.initialize();
+
+    const mongo = await mongoPromise;
+    const organization = await mongo.db().collection<OrganizationDoc>(ORGS_COLLECTION).findOne({ id: organizationId });
+    if (!organization) {
+      throw new Error('Unknown Organization');
+    }
+
+    const config = organization?.memberProvider as MemberProviderConfig;
+    if (!config || !config.token) {
+      throw new Error('Invalid Configuration');
+    }
+
+    const [teamId, v3Token] = config.token.split(':');
+    const response = await fetch(`https://api.team-manager.us.d4h.com/v3/team/${teamId}/members?search=${encodeURIComponent(query)}&size=25&status=${D4H_STATUS_OPERATIONAL}`, {
+      headers: {
+        Authorization: `Bearer ${v3Token}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`D4H API error: ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    const results = (data.results || []).map((res: D4HMemberResponse) => {
+      return {
+        id: res.id,
+        label: `${res.name} (${res.ref})`,
+        name: res.name,
+        groups: [],
+      };
+    }) as MemberInfo[];
+
+    console.log(results);
+    return results;
   }
 
   private async initialize() {

--- a/src/lib/server/memberProviders/memberProvider.ts
+++ b/src/lib/server/memberProviders/memberProvider.ts
@@ -3,6 +3,8 @@ import { ParticipantInfo } from '@respond/types/participant';
 
 export interface MemberInfo {
   id: string;
+  label?: string;
+  name?: string;
   groups: string[];
   email?: string;
   mobilephone?: string;
@@ -18,6 +20,7 @@ export interface MemberProvider {
   getMemberInfoById(memberId: string): Promise<MemberInfo | undefined>;
   getMemberPhoto(memberId: string): Promise<ArrayBuffer | undefined>;
   getParticipantInfo(query: string): Promise<ParticipantInfo | undefined>;
+  searchMembers(organizationId: string, query: string): Promise<Array<MemberInfo>>;
   refresh(force?: boolean): Promise<{ ok: boolean; runtime: number; cached?: boolean }>;
 }
 

--- a/src/lib/server/memberProviders/memberProvider.ts
+++ b/src/lib/server/memberProviders/memberProvider.ts
@@ -1,10 +1,11 @@
 import { MemberProviderType } from '@respond/types/data/MemberProviderType';
-import { ParticipantInfo } from '@respond/types/participant';
 
 export interface MemberInfo {
   id: string;
   label?: string;
-  name?: string;
+  name: string;
+  given_name: string;
+  family_name: string;
   groups: string[];
   email?: string;
   mobilephone?: string;
@@ -19,7 +20,7 @@ export interface MemberProvider {
   getMemberInfo<TOptions = undefined>(organizationId: string, authPayload: MemberAuthInfo, providerOptions: TOptions): Promise<MemberInfo | undefined>;
   getMemberInfoById(memberId: string): Promise<MemberInfo | undefined>;
   getMemberPhoto(memberId: string): Promise<ArrayBuffer | undefined>;
-  getParticipantInfo(query: string): Promise<ParticipantInfo | undefined>;
+  getParticipantInfo(query: string): Promise<MemberInfo | undefined>;
   searchMembers(organizationId: string, query: string): Promise<Array<MemberInfo>>;
   refresh(force?: boolean): Promise<{ ok: boolean; runtime: number; cached?: boolean }>;
 }

--- a/src/lib/server/stateManager.ts
+++ b/src/lib/server/stateManager.ts
@@ -48,7 +48,7 @@ export class StateManager {
     this.locationsState = {
       list: allLocations,
     };
-    const allOrganizations = (await mongo.db().collection<Organization>(ORGS_COLLECTION).find().project({ id: 1, title: 1 }).toArray()) as Organization[];
+    const allOrganizations = (await mongo.db().collection<Organization>(ORGS_COLLECTION).find().project({ id: 1, title: 1, rosterName: 1 }).toArray()) as Organization[];
     this.organizationsState = {
       list: allOrganizations,
     };

--- a/src/lib/server/stateManager.ts
+++ b/src/lib/server/stateManager.ts
@@ -2,11 +2,12 @@ import { Action } from '@reduxjs/toolkit';
 import produce from 'immer';
 
 import mongoPromise, { getRelatedOrgIds } from '@respond/lib/server/mongodb';
-import type { ActivityState, LocationState } from '@respond/lib/state';
+import type { ActivityState, LocationState, OrganizationState } from '@respond/lib/state';
 import { BasicActivityReducers, BasicLocationReducers } from '@respond/lib/state';
 import type { Activity } from '@respond/types/activity';
 import { OrganizationDoc, ORGS_COLLECTION } from '@respond/types/data/organizationDoc';
 import { Location } from '@respond/types/location';
+import { Organization } from '@respond/types/organization';
 import type UserAuth from '@respond/types/userAuth';
 
 import { ActivityAction, ActivityActions, isActivityAction, ParticipantUpdateAction } from '../state/activityActions';
@@ -27,6 +28,7 @@ export class StateManager {
   private listeners: ActionListener[] = [];
   private activityState: ActivityState = { list: [] };
   private locationsState: LocationState = { list: [] };
+  private organizationsState: OrganizationState = { list: [] };
 
   addClient(listener: ActionListener) {
     this.listeners = [...this.listeners, listener];
@@ -46,6 +48,10 @@ export class StateManager {
     this.locationsState = {
       list: allLocations,
     };
+    const allOrganizations = (await mongo.db().collection<Organization>(ORGS_COLLECTION).find().project({ id: 1, title: 1 }).toArray()) as Organization[];
+    this.organizationsState = {
+      list: allOrganizations,
+    };
   }
 
   async getStateForUser(user: UserAuth) {
@@ -60,6 +66,10 @@ export class StateManager {
 
   getLocationState() {
     return this.locationsState;
+  }
+
+  async getAllOrganizations() {
+    return this.organizationsState.list;
   }
 
   async getAllActivities() {

--- a/src/lib/state/index.ts
+++ b/src/lib/state/index.ts
@@ -1,8 +1,13 @@
 import { Activity } from '@respond/types/activity';
 import { Location } from '@respond/types/location';
+import { Organization } from '@respond/types/organization';
 
 export interface ActivityState {
   list: Activity[];
+}
+
+export interface OrganizationState {
+  list: Organization[];
 }
 
 export interface LocationState {

--- a/src/types/organization.ts
+++ b/src/types/organization.ts
@@ -1,8 +1,11 @@
 import { MemberProviderType } from './data/MemberProviderType';
 
-export interface BaseOrganization {
+export interface Organization {
   id: string;
   title: string;
+}
+
+export interface BaseOrganization extends Organization {
   rosterName?: string;
   canCreateMissions: boolean;
   canCreateEvents: boolean;

--- a/src/types/organization.ts
+++ b/src/types/organization.ts
@@ -3,10 +3,10 @@ import { MemberProviderType } from './data/MemberProviderType';
 export interface Organization {
   id: string;
   title: string;
+  rosterName?: string;
 }
 
 export interface BaseOrganization extends Organization {
-  rosterName?: string;
   canCreateMissions: boolean;
   canCreateEvents: boolean;
 }

--- a/src/types/participant.ts
+++ b/src/types/participant.ts
@@ -1,4 +1,0 @@
-export interface ParticipantInfo {
-  email?: string;
-  mobilephone?: string;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1158,6 +1158,18 @@
   dependencies:
     tslib "^2.4.0"
 
+"@tanstack/query-core@5.90.20":
+  version "5.90.20"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.90.20.tgz#e12128e39210715d4ce4fb299c33498ac297771e"
+  integrity sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==
+
+"@tanstack/react-query@^5.90.21":
+  version "5.90.21"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.90.21.tgz#e0eb40831a76510be438109435b8807ef63ab1b9"
+  integrity sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==
+  dependencies:
+    "@tanstack/query-core" "5.90.20"
+
 "@tootallnate/once@2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"


### PR DESCRIPTION
# Summary
* **ADD**: "Add Responder/Participant" enables adding/updating other Participants.
* **UPDATE**: Modified the `StatusUpdater` so that it can take either `UserInfo` (the authenticated user) OR `MemberInfo` (a member from a `MemberProvider`) and `Organization` props, enabling it to act on Participants other than the logged-in user.
* **REMOVE**: The `ParticipantInfo` type has been deprecated; dependencies are refactored to use `MemberInfo`. This also helps disambiguate "Participant" (of an Activity) and "Member" (of a MemberProvider)

# Add Responder/Participant
An "Add Responder/Participant" button has been added to the Desktop view, next to "View Roster." The button opens a dialog that enables the addition/update of Participants other than the logged-in user.

<img width="748" height="119" alt="image" src="https://github.com/user-attachments/assets/f56ba0f3-bc04-494d-8101-421b43ef7a0e" />

The Dialog has a drop-down to select which organization to search/assign the member under. After selecting an organization, the member input enables searching for members by name or email; minimum 3 characters.

<img width="615" height="300" alt="image" src="https://github.com/user-attachments/assets/b2fd934c-163e-4c6c-964b-325a521f448c" />

<img width="622" height="457" alt="image" src="https://github.com/user-attachments/assets/769c9c29-7084-41c3-a93b-6c644a0f8f50" />

After selecting a member, the `StatusUpdater` component appears, and can be used to add/update the participant. The timeline entries are also reflected in the dialog.

<img width="612" height="484" alt="image" src="https://github.com/user-attachments/assets/38d8f86b-ef48-4f83-92d7-2dcaee499706" />

