### PR TITLE
Implement ETA Preferences

### DIFF
--- a/src/components/Preferences.tsx
+++ b/src/components/Preferences.tsx
@@ -1,4 +1,4 @@
-import { Button, Dialog, DialogContent, DialogTitle, FormControl, FormHelperText, InputLabel, MenuItem, Select, Stack } from '@mui/material';
+import { Button, Dialog, DialogContent, DialogTitle, FormControl, FormHelperText, InputLabel, MenuItem, Select, Stack, TextField } from '@mui/material';
 import { Controller, useForm } from 'react-hook-form';
 
 import { useAppDispatch, useAppSelector } from '@respond/lib/client/store';
@@ -39,7 +39,7 @@ function PreferencesForm({ onCancel, onSubmit }: { onCancel: () => void; onSubmi
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <Stack spacing={2} marginTop={2}>
+      <Stack spacing={2} marginTop={1}>
         <Controller
           name="defaultMobileView"
           control={control}
@@ -70,6 +70,68 @@ function PreferencesForm({ onCancel, onSubmit }: { onCancel: () => void; onSubmi
             </FormControl>
           )}
         />
+        <Stack spacing={2} direction={{ xs: 'column', sm: 'row' }}>
+          <Controller
+            name="etaIncrement"
+            control={control}
+            rules={{ required: true, min: 1, max: 999 }} // Add validation rules
+            render={({ field }) => (
+              <TextField
+                {...field}
+                label="ETA Increment"
+                type="number" // Ensure numeric input on mobile devices
+                fullWidth
+                error={!!errors.etaIncrement}
+                helperText={errors.etaIncrement ? 'Must be between 1 and 999 minutes' : ''}
+              />
+            )}
+          />
+          <Controller
+            name="etaPreset1"
+            control={control}
+            rules={{ required: true, min: 1, max: 999 }} // Add validation rules
+            render={({ field }) => (
+              <TextField
+                {...field}
+                label="ETA Preset 1"
+                type="number" // Ensure numeric input on mobile devices
+                fullWidth
+                error={!!errors.etaIncrement}
+                helperText={errors.etaIncrement ? 'Must be between 1 and 999 minutes' : ''}
+              />
+            )}
+          />
+          <Controller
+            name="etaPreset2"
+            control={control}
+            rules={{ required: true, min: 1, max: 999 }} // Add validation rules
+            render={({ field }) => (
+              <TextField
+                {...field}
+                label="ETA Preset 2"
+                type="number" // Ensure numeric input on mobile devices
+                fullWidth
+                error={!!errors.etaIncrement}
+                helperText={errors.etaIncrement ? 'Must be between 1 and 999 minutes' : ''}
+              />
+            )}
+          />
+          <Controller
+            name="etaPreset3"
+            control={control}
+            rules={{ required: true, min: 1, max: 999 }} // Add validation rules
+            render={({ field }) => (
+              <TextField
+                {...field}
+                label="ETA Preset 3"
+                type="number" // Ensure numeric input on mobile devices
+                fullWidth
+                error={!!errors.etaIncrement}
+                helperText={errors.etaIncrement ? 'must be between 1 and 999 minutes' : ''}
+              />
+            )}
+          />
+        </Stack>
         <Button disabled={!isDirty} type="submit" variant="contained">
           Save
         </Button>

--- a/src/components/participant/ParticipantEtaUpdater.tsx
+++ b/src/components/participant/ParticipantEtaUpdater.tsx
@@ -5,19 +5,18 @@ import { format as formatDate } from 'date-fns';
 import { useEffect, useState } from 'react';
 
 import { useDebounce } from '@respond/hooks/useDebounce';
-import { useAppDispatch } from '@respond/lib/client/store';
+import { useAppDispatch, useAppSelector } from '@respond/lib/client/store';
 import { ActivityActions } from '@respond/lib/state';
 
 import { InlineTimeEdit } from '../InlineTimeEdit';
 import { Button, IconButton, Stack, Typography } from '../Material';
 
-const ONE_MINUTE_MILLISECONDS = 60 * 1000;
-const FIFTEEN_MINUTES_MILLISECONDS = 15 * 60 * 1000;
-const THIRTY_MINUTES_MILLISECONDS = 30 * 60 * 1000;
-const SIXTY_MINUTES_MILLISECONDS = 60 * 60 * 1000;
+const toMilliseconds = (minutes: number) => minutes * 60 * 1000;
 
 export function ParticipantEtaUpdater({ activityId, participantId, participantEta }: { activityId: string; participantId: string; participantEta?: number }) {
   const dispatch = useAppDispatch();
+
+  const { etaIncrement, etaPreset1, etaPreset2, etaPreset3 } = useAppSelector((state) => state.preferences);
 
   const [eta, setEta] = useState<number | undefined | null>(participantEta);
   const [editing, setEditing] = useState(false);
@@ -45,10 +44,10 @@ export function ParticipantEtaUpdater({ activityId, participantId, participantEt
         <>
           <Typography variant="h6">ETA</Typography>
           <Typography variant="h6">{formatDate(eta, 'HHmm')}</Typography>
-          <IconButton onClick={() => setEta(eta - ONE_MINUTE_MILLISECONDS)}>
+          <IconButton onClick={() => setEta(eta - toMilliseconds(etaIncrement))}>
             <RemoveIcon />
           </IconButton>
-          <IconButton onClick={() => setEta(eta + ONE_MINUTE_MILLISECONDS)}>
+          <IconButton onClick={() => setEta(eta + toMilliseconds(etaIncrement))}>
             <AddIcon />
           </IconButton>
           <Button onClick={() => setEta(null)}>clear</Button>
@@ -58,9 +57,9 @@ export function ParticipantEtaUpdater({ activityId, participantId, participantEt
         <>
           <Typography variant="h6">ETA</Typography>
           <Stack direction={'row'} spacing={2} alignItems={'center'} justifyContent={'space-between'}>
-            <IconButton onClick={() => setEta(new Date().getTime() + FIFTEEN_MINUTES_MILLISECONDS)}>15</IconButton>
-            <IconButton onClick={() => setEta(new Date().getTime() + THIRTY_MINUTES_MILLISECONDS)}>30</IconButton>
-            <IconButton onClick={() => setEta(new Date().getTime() + SIXTY_MINUTES_MILLISECONDS)}>60</IconButton>
+            <IconButton onClick={() => setEta(new Date().getTime() + toMilliseconds(etaPreset1))}>{etaPreset1}</IconButton>
+            <IconButton onClick={() => setEta(new Date().getTime() + toMilliseconds(etaPreset2))}>{etaPreset2}</IconButton>
+            <IconButton onClick={() => setEta(new Date().getTime() + toMilliseconds(etaPreset3))}>{etaPreset3}</IconButton>
             <IconButton onClick={() => setEditing(true)}>
               <AccessTime />
             </IconButton>

--- a/src/lib/client/store/preferences.ts
+++ b/src/lib/client/store/preferences.ts
@@ -11,11 +11,19 @@ export enum NavigationApp {
 export interface PerferencesState {
   defaultMobileView: MobilePageId;
   navigationApp: NavigationApp;
+  etaIncrement: number;
+  etaPreset1: number;
+  etaPreset2: number;
+  etaPreset3: number;
 }
 
 const initialState: PerferencesState = {
   defaultMobileView: MobilePageId.Briefing,
   navigationApp: NavigationApp.Google,
+  etaIncrement: 5,
+  etaPreset1: 15,
+  etaPreset2: 30,
+  etaPreset3: 60,
 };
 
 const preferencesSlice = createSlice({


### PR DESCRIPTION
# Summary
* **ADD**: Users can manage ETA Increment and Presets via `PreferencesDialog`.
* **UPDATED**: The default ETA Increment is 5 minutes (previously it was 1 Minute.)

## Manage ETA Preferences
The `PreferencesDialog` component has new fields that allow the user to specify their preferred ETA Increment and assign custom values to the presets.

<img width="611" height="416" alt="image" src="https://github.com/user-attachments/assets/0ba44ad8-198f-41a4-9127-1b7736d0c3b1" />

<img width="357" height="630" alt="image" src="https://github.com/user-attachments/assets/f6efbb38-b99d-4c22-b336-c44604e2c8e9" />

