### PR TITLE
Enhanced Sort Functionality

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -15,7 +15,11 @@ import { Activity, isActive as isParticipantStatusActive } from '@respond/types/
 
 function filterActivitiesForDisplay(activities: Activity[], maxCompletedVisible: number, oldestVisible: number) {
   // Most recent first
-  const sort = (a: Activity, b: Activity) => (a.startTime > b.startTime ? -1 : 1);
+  const sort = (a: Activity, b: Activity) => {
+    // sort missions date descending. Other activities date ascending
+    const sign = a.isMission ? -1 : 1;
+    return a.startTime === b.startTime ? 0 : a.startTime > b.startTime ? sign : -sign;
+  };
 
   const active = activities.filter(isActive).sort(sort);
   const complete = activities

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -15,11 +15,7 @@ import { Activity, isActive as isParticipantStatusActive } from '@respond/types/
 
 function filterActivitiesForDisplay(activities: Activity[], maxCompletedVisible: number, oldestVisible: number) {
   // Most recent first
-  const sort = (a: Activity, b: Activity) => {
-    // sort missions date descending. Other activities date ascending
-    const sign = a.isMission ? -1 : 1;
-    return a.startTime === b.startTime ? 0 : a.startTime > b.startTime ? sign : -sign;
-  };
+  const sort = (a: Activity, b: Activity) => (a.startTime > b.startTime ? -1 : 1);
 
   const active = activities.filter(isActive).sort(sort);
   const complete = activities

--- a/src/components/activities/RosterPanel.tsx
+++ b/src/components/activities/RosterPanel.tsx
@@ -35,10 +35,14 @@ const STATUS_SORT_ORDER = [
   ParticipantStatus.NotResponding,
 ];
 
+const etaStatus = (status: ParticipantStatus) => {
+  return [ParticipantStatus.Standby, ParticipantStatus.SignedIn].includes(status) ? 1 : 0;
+};
+
 const sortByStatus = (a: Participant, b: Participant) => {
   const statusIndexA = STATUS_SORT_ORDER.indexOf(a.timeline[0].status);
   const statusIndexB = STATUS_SORT_ORDER.indexOf(b.timeline[0].status);
-  return statusIndexA - statusIndexB || (a.eta ?? Infinity) - (b.eta ?? Infinity);
+  return statusIndexA - statusIndexB || etaStatus(b.timeline[0].status) - etaStatus(a.timeline[0].status) || (a.eta ?? Infinity) - (b.eta ?? Infinity);
 };
 const sortAlphabetical = (a: Participant, b: Participant) => a.firstname.localeCompare(b.firstname);
 

--- a/src/components/activities/RosterPanel.tsx
+++ b/src/components/activities/RosterPanel.tsx
@@ -23,10 +23,23 @@ interface RosterPanelProps {
   onClick?: (participant: Participant) => void;
 }
 
-const etaStatus = (status: ParticipantStatus) => {
-  return [ParticipantStatus.Standby, ParticipantStatus.SignedIn].includes(status) ? 1 : 0;
+// eslint-disable-next-line prettier/prettier
+const STATUS_SORT_ORDER = [
+  ParticipantStatus.SignedIn,
+  ParticipantStatus.Available,
+  ParticipantStatus.Assigned,
+  ParticipantStatus.Demobilized,
+  ParticipantStatus.Remote,
+  ParticipantStatus.Standby,
+  ParticipantStatus.SignedOut,
+  ParticipantStatus.NotResponding,
+];
+
+const sortByStatus = (a: Participant, b: Participant) => {
+  const statusIndexA = STATUS_SORT_ORDER.indexOf(a.timeline[0].status);
+  const statusIndexB = STATUS_SORT_ORDER.indexOf(b.timeline[0].status);
+  return statusIndexA - statusIndexB || (a.eta ?? Infinity) - (b.eta ?? Infinity);
 };
-const sortArrivingNext = (a: Participant, b: Participant) => etaStatus(b.timeline[0].status) - etaStatus(a.timeline[0].status) || (a.eta ?? Infinity) - (b.eta ?? Infinity);
 const sortAlphabetical = (a: Participant, b: Participant) => a.firstname.localeCompare(b.firstname);
 
 const findMember = async (orgId: string, memberId: string) => {
@@ -45,15 +58,15 @@ const formatPhoneNumber = (phoneNumberString: string, includeIntlCode: boolean =
 
 export function RosterPanel({ filter, participantContainerComponent: Participants, participantRowComponent: Participant, onClick }: RosterPanelProps) {
   const activity = useActivityContext();
-  const [sortEta, setSortEta] = useState(false);
+  const [sortOnStatus, setSortOnStatus] = useState(false);
   const [participants, setParticipants] = useState<Array<Participant>>(Object.values(activity.participants));
 
   useEffect(() => {
     let list = Object.values(activity.participants);
     if (filter) list = list.filter((p) => p.organizationId === filter);
-    list.sort(sortEta ? sortArrivingNext : sortAlphabetical);
+    list.sort(sortOnStatus ? sortByStatus : sortAlphabetical);
     setParticipants(list);
-  }, [activity, filter, sortEta]);
+  }, [activity, filter, sortOnStatus]);
 
   let cards: ReactNode = participants.map((p) => <Participant key={p.id} orgs={activity.organizations} participant={p} onClick={() => onClick?.(p)} />);
   if (participants.length == 0) {
@@ -68,8 +81,8 @@ export function RosterPanel({ filter, participantContainerComponent: Participant
     <Box flex="1 1 auto">
       <Stack direction="row" spacing={1} alignItems="center" justifyContent={'right'}>
         <Typography>Sort By: Name</Typography>
-        <Switch value={sortEta} onChange={(event) => setSortEta(event.target.checked)} color="primary" />
-        <Typography>ETA</Typography>
+        <Switch value={sortOnStatus} onChange={(event) => setSortOnStatus(event.target.checked)} color="primary" />
+        <Typography>Status</Typography>
       </Stack>
       <Participants>{cards}</Participants>
     </Box>


### PR DESCRIPTION
# Summary
* **UPDATED**: "Sort By: ETA" changed to "Sort By: Status"

Previously, Sort By ETA would bubble all the responders with ETAs to the top, and leave the rest of the list alphabetical.

Now, Sort By Status applies a more-specific sort order by Status, _then_ sorts by ETA (bubbling responders with an ETA to the top of the respective status group)

Note: ETA is only applicable for responders in the `Standby` and `SignedIn` statuses; they will be bubbled to the top of these respective status groups.

The sort order pulls signed in responders (i.e. not arrived yet) to the top, and pushes demobilized and signed out responders to the bottom.

<img width="758" height="560" alt="image" src="https://github.com/user-attachments/assets/c641398c-c33e-47bd-bf93-7fccc71535bc" />
