### PR TITLE
Add option to change activity type after creation

### DIFF
--- a/src/components/activities/ActivityEditPage.tsx
+++ b/src/components/activities/ActivityEditPage.tsx
@@ -1,7 +1,7 @@
 'use client';
 import AddLocation from '@mui/icons-material/AddLocation';
 import Edit from '@mui/icons-material/Edit';
-import { Box, Button, FormControl, FormControlLabel, FormGroup, FormHelperText, FormLabel, Grid, IconButton, InputLabel, MenuItem, Paper, Radio, RadioGroup, Select, Stack, Switch, TextField } from '@mui/material';
+import { Box, Button, FormControl, FormControlLabel, FormGroup, FormHelperText, Grid, IconButton, InputLabel, MenuItem, Paper, Select, Stack, Switch, TextField } from '@mui/material';
 import { DateTimePicker } from '@mui/x-date-pickers';
 import { useRouter } from 'next/navigation';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -193,7 +193,7 @@ export const ActivityEditPage = ({ activityType, activityId }: { activityType: A
       <Paper>
         <form onSubmit={handleSubmit(onSubmit)}>
           <Grid container padding={2} spacing={2} alignItems="center">
-            <Grid item xs={12}>
+            <Grid item xs={12} sm={8}>
               <Controller
                 name="title"
                 control={control}
@@ -206,17 +206,17 @@ export const ActivityEditPage = ({ activityType, activityId }: { activityType: A
               />
             </Grid>
 
-            <Grid item xs={12} sm={6}>
+            <Grid item xs={12} sm={4}>
               <Controller
                 name="isMission"
                 control={control}
                 render={({ field }) => (
-                  <FormControl component="fieldset">
-                    <FormLabel>Type</FormLabel>
-                    <RadioGroup row value={field.value ? 'missions' : 'events'} onChange={(event) => field.onChange(event.target.value === 'missions')}>
-                      <FormControlLabel value="missions" control={<Radio />} label="Mission" />
-                      <FormControlLabel value="events" control={<Radio />} label="Event" />
-                    </RadioGroup>
+                  <FormControl fullWidth>
+                    <InputLabel id="activity-type-label">Type</InputLabel>
+                    <Select {...field} labelId="activity-type-label" label="Type" value={field.value ? 'missions' : 'events'} onChange={(event) => field.onChange(event.target.value === 'missions')}>
+                      <MenuItem value="missions">Mission</MenuItem>
+                      <MenuItem value="events">Event</MenuItem>
+                    </Select>
                   </FormControl>
                 )}
               />

--- a/src/components/activities/ActivityEditPage.tsx
+++ b/src/components/activities/ActivityEditPage.tsx
@@ -193,7 +193,7 @@ export const ActivityEditPage = ({ activityType, activityId }: { activityType: A
       <Paper>
         <form onSubmit={handleSubmit(onSubmit)}>
           <Grid container padding={2} spacing={2} alignItems="center">
-            <Grid item xs={12} sm={8}>
+            <Grid item xs={12} sm={6}>
               <Controller
                 name="title"
                 control={control}
@@ -206,7 +206,7 @@ export const ActivityEditPage = ({ activityType, activityId }: { activityType: A
               />
             </Grid>
 
-            <Grid item xs={12} sm={4}>
+            <Grid item xs={12} sm={6}>
               <Controller
                 name="isMission"
                 control={control}

--- a/src/components/activities/ActivityEditPage.tsx
+++ b/src/components/activities/ActivityEditPage.tsx
@@ -1,10 +1,10 @@
 'use client';
 import AddLocation from '@mui/icons-material/AddLocation';
 import Edit from '@mui/icons-material/Edit';
-import { Box, Button, FormControl, FormControlLabel, FormGroup, FormHelperText, Grid, IconButton, InputLabel, MenuItem, Paper, Select, Stack, Switch, TextField } from '@mui/material';
+import { Box, Button, FormControl, FormControlLabel, FormGroup, FormHelperText, FormLabel, Grid, IconButton, InputLabel, MenuItem, Paper, Radio, RadioGroup, Select, Stack, Switch, TextField } from '@mui/material';
 import { DateTimePicker } from '@mui/x-date-pickers';
 import { useRouter } from 'next/navigation';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Controller, Resolver, ResolverResult, SubmitHandler, useForm } from 'react-hook-form';
 
 import { ToolbarPage } from '@respond/components/ToolbarPage';
@@ -67,14 +67,14 @@ export const ActivityEditPage = ({ activityType, activityId }: { activityType: A
   const [showLocationEditDialog, setShowLocationEditDialog] = useState(false);
 
   const permProp = activityType === 'missions' ? 'canCreateMissions' : 'canCreateEvents';
-  const ownerOptions = [...(org?.[permProp] ? [org] : []), ...(org?.partners.filter((p) => p[permProp]) ?? [])];
+  const initialOwnerOptions = [...(org?.[permProp] ? [org] : []), ...(org?.partners.filter((p) => p[permProp]) ?? [])];
   const isNew = !selectedActivity;
 
   let activity: Activity;
   if (isNew) {
     activity = {
       ...createNewActivity(),
-      ownerOrgId: ownerOptions[0].id,
+      ownerOrgId: initialOwnerOptions[0]?.id ?? '',
       isMission: activityType === 'missions',
       asMission: activityType === 'missions',
     };
@@ -90,6 +90,9 @@ export const ActivityEditPage = ({ activityType, activityId }: { activityType: A
     defaultValues.earlySignInWindow = defaultEarlySigninWindow;
   }
 
+  const initialOwnerOrgId = useRef(defaultValues.ownerOrgId);
+  const initialSelectedType = useRef(defaultValues.isMission ? 'missions' : 'events');
+
   const {
     control,
     handleSubmit,
@@ -103,10 +106,36 @@ export const ActivityEditPage = ({ activityType, activityId }: { activityType: A
 
   const focusRef = useRef<HTMLInputElement>();
   const watchLocation = watch('location');
+  const selectedIsMission = watch('isMission');
+  const selectedType = selectedIsMission ? 'missions' : 'events';
+  const selectedOwnerOrgId = watch('ownerOrgId');
+
+  const permissionProp = selectedType === 'missions' ? 'canCreateMissions' : 'canCreateEvents';
+  const ownerOptions = useMemo(() => [...(org?.[permissionProp] ? [org] : []), ...(org?.partners.filter((p) => p[permissionProp]) ?? [])], [org, permissionProp]);
 
   useEffect(() => {
     focusRef.current?.focus();
   }, [focusRef]);
+
+  useEffect(() => {
+    if (!ownerOptions.length) {
+      return;
+    }
+
+    const currentOwnerIsValid = selectedOwnerOrgId && ownerOptions.some((o) => o.id === selectedOwnerOrgId);
+    if (currentOwnerIsValid) {
+      return;
+    }
+
+    const initialOwnerMatchesCurrentType = selectedType === initialSelectedType.current;
+    const initialOwnerIsAvailable = ownerOptions.some((o) => o.id === initialOwnerOrgId.current);
+    if (initialOwnerMatchesCurrentType && initialOwnerIsAvailable) {
+      setValue('ownerOrgId', initialOwnerOrgId.current);
+      return;
+    }
+
+    setValue('ownerOrgId', ownerOptions[0].id);
+  }, [ownerOptions, selectedOwnerOrgId, selectedType, setValue]);
 
   if (!org) {
     return <Box>Waiting for org...</Box>;
@@ -156,7 +185,7 @@ export const ActivityEditPage = ({ activityType, activityId }: { activityType: A
 
     // We're optimistic that the submitted event will be processed successfully. With partially offline clients,
     // we may not know of a conflict/etc. until later and will have to have UI for that anyways.
-    router.push(`/${activityType === 'missions' ? 'mission' : 'event'}/${updated.id}`);
+    router.push(`/${updated.isMission ? 'mission' : 'event'}/${updated.id}`);
   };
 
   return (
@@ -172,6 +201,22 @@ export const ActivityEditPage = ({ activityType, activityId }: { activityType: A
                   <FormControl fullWidth error={!!errors.title?.message}>
                     <TextField {...field} inputRef={focusRef} variant="outlined" label="Name" required />
                     <FormHelperText>{errors.title?.message}</FormHelperText>
+                  </FormControl>
+                )}
+              />
+            </Grid>
+
+            <Grid item xs={12} sm={6}>
+              <Controller
+                name="isMission"
+                control={control}
+                render={({ field }) => (
+                  <FormControl component="fieldset">
+                    <FormLabel>Type</FormLabel>
+                    <RadioGroup row value={field.value ? 'missions' : 'events'} onChange={(event) => field.onChange(event.target.value === 'missions')}>
+                      <FormControlLabel value="missions" control={<Radio />} label="Mission" />
+                      <FormControlLabel value="events" control={<Radio />} label="Event" />
+                    </RadioGroup>
                   </FormControl>
                 )}
               />
@@ -325,7 +370,7 @@ export const ActivityEditPage = ({ activityType, activityId }: { activityType: A
                 <Stack direction="row" justifyContent="flex-end" spacing={1}>
                   <Button onClick={() => router.back()}>Cancel</Button>
                   <Button type="submit" variant="contained">
-                    Save {activityType === 'missions' ? 'Mission' : 'Event'}
+                    Save {selectedType === 'missions' ? 'Mission' : 'Event'}
                   </Button>
                 </Stack>
               </Grid>

--- a/src/lib/state/__tests__/activityReducerTests.ts
+++ b/src/lib/state/__tests__/activityReducerTests.ts
@@ -1,6 +1,7 @@
 import produce from 'immer';
 
 import { defaultEarlySigninWindow } from '@respond/lib/client/store/activities';
+import { createNewLocation } from '@respond/types/location';
 
 import { ActivityState } from '..';
 import { ActivityActions } from '../activityActions';
@@ -15,10 +16,11 @@ describe('Activity Reducers', () => {
       list: [
         {
           id: activityId,
+          forceStandbyOnly: false,
           idNumber: '',
           title: 'sample event',
           description: '',
-          location: { title: 'home' },
+          location: createNewLocation(),
           mapId: '',
           startTime: 1699765740000,
           earlySignInWindow: defaultEarlySigninWindow,
@@ -45,5 +47,40 @@ describe('Activity Reducers', () => {
     const newState = produce(startState, (draft) => BasicReducers[ActivityActions.tagParticipant.type](draft, tagAction));
 
     expect(newState.list[0].participants[participantId].tags).toEqual(tags);
+  });
+
+  it('supports updating activity type via ActivityActions.update', () => {
+    const activityId = 'd5ce23b0-4a91-4f2d-ad34-b39166a1d5f4';
+    const startState: ActivityState = {
+      list: [
+        {
+          id: activityId,
+          forceStandbyOnly: false,
+          idNumber: '',
+          title: 'sample event',
+          description: '',
+          location: createNewLocation(),
+          mapId: '',
+          startTime: 1699765740000,
+          earlySignInWindow: defaultEarlySigninWindow,
+          isMission: false,
+          asMission: false,
+          ownerOrgId: '1',
+          participants: {},
+          organizations: {},
+        },
+      ],
+    };
+
+    const updatedActivity = {
+      ...startState.list[0],
+      isMission: true,
+      asMission: true,
+    };
+
+    const newState = produce(startState, (draft) => BasicReducers[ActivityActions.update.type](draft, ActivityActions.update(updatedActivity)));
+
+    expect(newState.list[0].isMission).toBe(true);
+    expect(newState.list[0].asMission).toBe(true);
   });
 });


### PR DESCRIPTION
ADD: Activity Type option in the `ActivityEditPage`

This update enables switching of Activity Type on `ActivityEditPage`.
* The type can be changed while creating or updating any activity.
* The Responsible Agency selection updates automatically to an appropriately-permissioned org; the initial selection is restored when toggling back to the original activity type.

<img width="867" height="618" alt="image" src="https://github.com/user-attachments/assets/661cc015-4bfd-49e0-a040-52cf6f5a65e7" />
