### PR TITLE
FIX: New Preference Attributes Not Initialized to Defaults

### DIFF
--- a/src/components/PreferencesProvider.tsx
+++ b/src/components/PreferencesProvider.tsx
@@ -15,7 +15,8 @@ export function PreferencesProvider({ children }: { children: React.ReactNode })
   const [preferences, setPreferencesState] = useState<PerferencesState>(() => {
     try {
       if (typeof window !== 'undefined' && window.localStorage && localStorage.preferences) {
-        return JSON.parse(localStorage.preferences) as PerferencesState;
+        const stored = JSON.parse(localStorage.preferences) as Partial<PerferencesState>;
+        return { ...defaultPreferences, ...stored };
       }
     } catch (e) {
       console.error('Failed to load saved preferences', e);


### PR DESCRIPTION
This commit fixes an issue where the new preferences attributes added for ETA Increment and Presets were only initialized to defaults if the client does not already have preferences in local storage.

This issue caused the ETA components to partially render, without the shortcut:

<img width="409" height="82" alt="image" src="https://github.com/user-attachments/assets/c9e300a1-6de6-4730-9059-ee35cc37414d" />  

<img width="322" height="340" alt="image" src="https://github.com/user-attachments/assets/427e50ef-dea3-417e-8b52-aa9ff69d46da" />
