### PR TITLE
Fix: Cache exceeding local storage quota causing stale UI

### DIFF
--- a/src/lib/client/sync.ts
+++ b/src/lib/client/sync.ts
@@ -4,7 +4,7 @@ import io, { Socket } from 'socket.io-client';
 import type { ClientToServerEvents, ServerToClientEvents } from '@respond/types/syncSocket';
 
 import { apiFetch } from '../api';
-import { ActivityActions } from '../state';
+import { ActivityActions, filterInitialActivities } from '../state';
 
 import { addAppListener, AppDispatch, AppStore } from './store';
 import { AuthActions } from './store/auth';
@@ -80,8 +80,19 @@ export class ClientSync {
       addAppListener({
         matcher: isAnyOf(ActivityActions.reload, ActivityActions.update),
         effect: (_action, listenerApi) => {
-          console.log('SHOULD SAVE TO LOCALSTORAGE', listenerApi.getState().activities);
-          localStorage.activities = JSON.stringify(listenerApi.getState().activities);
+          const activities = listenerApi.getState().activities;
+          const cachedActivities = { ...activities, list: filterInitialActivities(activities.list) };
+          console.log('SHOULD SAVE TO LOCALSTORAGE', cachedActivities);
+          try {
+            const serializedActivities = JSON.stringify(cachedActivities);
+
+            // remove activities from localStorage to then ...
+            localStorage.removeItem('activities');
+            // ... update with the fresh list
+            localStorage.setItem('activities', serializedActivities);
+          } catch (error) {
+            console.warn('Unable to save filtered activities cache', error);
+          }
         },
       }),
     );

--- a/src/lib/server/stateManager.ts
+++ b/src/lib/server/stateManager.ts
@@ -11,6 +11,7 @@ import { Organization } from '@respond/types/organization';
 import type UserAuth from '@respond/types/userAuth';
 
 import { ActivityAction, ActivityActions, isActivityAction, ParticipantUpdateAction } from '../state/activityActions';
+import { filterInitialActivities } from '../state/activityVisibility';
 import { isLocationAction, LocationAction } from '../state/locationActions';
 
 import { getServices } from './services';
@@ -60,7 +61,7 @@ export class StateManager {
     const myOrgIds = await getRelatedOrgIds(user.organizationId);
 
     return {
-      list: this.activityState.list.filter((a) => myOrgIds.includes(a.ownerOrgId)),
+      list: filterInitialActivities(this.activityState.list.filter((a) => myOrgIds.includes(a.ownerOrgId))),
     };
   }
 

--- a/src/lib/state/__tests__/activityVisibilityTests.ts
+++ b/src/lib/state/__tests__/activityVisibilityTests.ts
@@ -1,0 +1,51 @@
+import type { Activity } from '@respond/types/activity';
+
+const daysToMilliseconds = (days: number) => days * 24 * 60 * 60 * 1000;
+
+import { filterInitialActivities, isActivityIncludedInInitialState } from '../activityVisibility';
+
+function activity(id: string, startTime: number, endTime?: number): Activity {
+  return {
+    id,
+    forceStandbyOnly: false,
+    idNumber: '',
+    title: id,
+    description: '',
+    location: undefined,
+    mapId: '',
+    startTime,
+    endTime,
+    isMission: true,
+    asMission: false,
+    ownerOrgId: 'org-1',
+    participants: {},
+    organizations: {},
+  } as unknown as Activity;
+}
+
+describe('activity initial state visibility', () => {
+  const now = new Date('2026-05-28T12:00:00Z').getTime();
+  const historyMs = daysToMilliseconds(90);
+
+  it('includes active activities even when they started before the history window', () => {
+    expect(isActivityIncludedInInitialState(activity('active-old', now - daysToMilliseconds(180)), now, historyMs)).toBe(true);
+  });
+
+  it('includes future activities', () => {
+    expect(isActivityIncludedInInitialState(activity('future', now + daysToMilliseconds(30), now - daysToMilliseconds(100)), now, historyMs)).toBe(true);
+  });
+
+  it('includes recently completed activities', () => {
+    expect(isActivityIncludedInInitialState(activity('recent', now - daysToMilliseconds(10), now - daysToMilliseconds(5)), now, historyMs)).toBe(true);
+  });
+
+  it('excludes old completed activities', () => {
+    expect(isActivityIncludedInInitialState(activity('old', now - daysToMilliseconds(120), now - daysToMilliseconds(100)), now, historyMs)).toBe(false);
+  });
+
+  it('filters a mixed list', () => {
+    const visible = filterInitialActivities([activity('active-old', now - daysToMilliseconds(180)), activity('recent', now - daysToMilliseconds(10), now - daysToMilliseconds(5)), activity('old', now - daysToMilliseconds(120), now - daysToMilliseconds(100))], now, historyMs);
+
+    expect(visible.map((a) => a.id)).toEqual(['active-old', 'recent']);
+  });
+});

--- a/src/lib/state/activityVisibility.ts
+++ b/src/lib/state/activityVisibility.ts
@@ -1,0 +1,28 @@
+import type { Activity } from '@respond/types/activity';
+
+/**
+ * Filter activities by
+ * * Active activities (no end time) are always included.
+ * * Future activities (start time in the future) are always included.
+ * * Completed activities are included only when their latest activity time is inside the retention window.
+ *
+ * This is used to determine which activities should be included in the initial state when the app loads, and also to 
+ * filter activities before saving them to localStorage for caching purposes.
+ */
+export const INITIAL_ACTIVITY_HISTORY_DAYS = 90;
+export const INITIAL_ACTIVITY_HISTORY_MS = INITIAL_ACTIVITY_HISTORY_DAYS * 24 * 60 * 60 * 1000;
+
+export function isActivityIncludedInInitialState(activity: Activity, now = Date.now(), historyMs = INITIAL_ACTIVITY_HISTORY_MS) {
+  // Active activities must remain in the initial cache even if they started long ago.
+  if (!activity.endTime) return true;
+  // Future activities must remain visible before they begin.
+  if (activity.startTime > now) return true;
+
+  // Completed activities are included only when their latest activity time is inside the retention window.
+  const mostRecentActivityTime = Math.max(activity.startTime, activity.endTime);
+  return mostRecentActivityTime >= now - historyMs;
+}
+
+export function filterInitialActivities(activities: Activity[], now = Date.now(), historyMs = INITIAL_ACTIVITY_HISTORY_MS) {
+  return activities.filter((activity) => isActivityIncludedInInitialState(activity, now, historyMs));
+}

--- a/src/lib/state/index.ts
+++ b/src/lib/state/index.ts
@@ -21,4 +21,5 @@ export type { LocationAction } from './locationActions';
 export { LocationActions } from './locationActions';
 
 export { BasicReducers as BasicActivityReducers } from './activityReducers';
+export { filterInitialActivities } from './activityVisibility';
 export { BasicReducers as BasicLocationReducers } from './locationReducers';


### PR DESCRIPTION
The PR fixes #153 and #152 by doing two things:
* filtering the activities on the server to reduce payload as well as on the client to reduce localStorage size
* replace the localStorage cache with the filtered items on update and reload actions

### Filter logic
Only keep items that
* are active, which is asserted by checking if an item as an `endTime`
* if they are activities that are in the future
* if they are activities that have either started or ended within the last 90 days

### Validation
* The changes were validated locally with seed data exceeding local storage quota as well as exceeding events spanning back 2 years. 
* The bugs were reproducible in the local setup and are fixed with this change