### PR TITLE
Fix: Clear roster panel when closed

### DIFF
--- a/src/components/activities/RosterPanel.tsx
+++ b/src/components/activities/RosterPanel.tsx
@@ -122,13 +122,16 @@ export function ParticipantDialog({ open, participant, onClose }: { open: boolea
   const [memberInfo, setMemberInfo] = useState<MemberInfo | undefined>();
 
   useEffect(() => {
-    if (participant) getMemberInfo(participant);
-  }, [participant]);
+    if (!participant) return;
 
-  const getMemberInfo = async (participant: Participant) => {
-    const member = await findMember(participant.organizationId, participant.id);
-    setMemberInfo(member);
-  };
+    findMember(participant.organizationId, participant.id).then((member) => {
+      setMemberInfo(member);
+    });
+
+    return () => {
+      setMemberInfo(undefined);
+    };
+  }, [participant]);
 
   if (!participant) return <></>;
 


### PR DESCRIPTION
This PR fixes issue #154 by clearing the modal state when the modal is closed.
This is achieved by returning a `dispose` function from `useEffect` which is called when the modal dialog is closed.

### Validation
* locally with test data