### PR TITLE
Fix dialog history cleanup on close

### DIFF
--- a/src/hooks/useDialogHistory.ts
+++ b/src/hooks/useDialogHistory.ts
@@ -63,6 +63,11 @@ export default function useDialogHistory(open: boolean, onClose: () => void) {
           window.removeEventListener('popstate', handlePop);
         } else {
           // Programmatic close: go back to remove the pushed history entry.
+          // React has already run the cleanup for the previous `open=true` effect,
+          // so re-register this effect's handler before calling `history.back()`.
+          // Otherwise the suppressing popstate can be missed, leaving pushedRef true
+          // and causing the next close to navigate back past the current page.
+          window.addEventListener('popstate', handlePop);
           suppressPopRef.current = true;
           history.back();
         }

--- a/src/hooks/useDialogHistory.ts
+++ b/src/hooks/useDialogHistory.ts
@@ -2,84 +2,65 @@
 import { useEffect, useRef } from 'react';
 
 // Hook: when `open` is true, push a history state so browser Back will trigger `onClose`.
-// When `open` becomes false the original history state is restored without firing popstate.
+// When `open` becomes false the pushed history entry is removed without firing popstate.
 export default function useDialogHistory(open: boolean, onClose: () => void) {
   const pushedRef = useRef(false);
-  const prevStateRef = useRef<any>(null);
   const idRef = useRef<string | null>(null);
   const onCloseRef = useRef(onClose);
   const suppressPopRef = useRef(false);
-  const popInitiatedRef = useRef(false);
 
   useEffect(() => {
     onCloseRef.current = onClose;
   }, [onClose]);
 
+  // Register a single popstate listener on mount. It consults refs to decide actions.
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
     const handlePop = (ev: PopStateEvent) => {
       if (!pushedRef.current) return;
-      const state = ev.state as any;
-      // If this pop was triggered by our programmatic `history.back()`, just clean up.
+
       if (suppressPopRef.current) {
+        // This pop was triggered by our programmatic history.back(); just clear flags.
         suppressPopRef.current = false;
         pushedRef.current = false;
         idRef.current = null;
-        prevStateRef.current = null;
-        window.removeEventListener('popstate', handlePop);
         return;
       }
 
-      // Close when the new state does NOT include our dialog id (i.e. user navigated back)
+      const state = ev.state as any;
+      // If the new state doesn't include our dialog id, treat it as user Back.
       if (!state || state.__respond_dialog_id !== idRef.current) {
-        // Mark that the pop initiated the close so we don't try to pop again.
-        popInitiatedRef.current = true;
+        pushedRef.current = false;
+        idRef.current = null;
         onCloseRef.current();
       }
     };
 
+    window.addEventListener('popstate', handlePop);
+    return () => window.removeEventListener('popstate', handlePop);
+  }, []);
+
+  // Push state when opened; on close, remove pushed entry via history.back().
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
     if (open && !pushedRef.current) {
       try {
-        prevStateRef.current = history.state;
         idRef.current = `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
         history.pushState({ ...(history.state || {}), __respond_dialog_id: idRef.current }, '');
         pushedRef.current = true;
-        window.addEventListener('popstate', handlePop);
       } catch (e) {
         console.error('useDialogHistory pushState error:', e);
       }
-    }
-
-    if (!open && pushedRef.current) {
+    } else if (!open && pushedRef.current) {
       try {
-        // If the dialog was closed because the user clicked Back, the pop handler
-        // already cleaned up. Avoid calling history.back() in that case.
-        if (popInitiatedRef.current) {
-          popInitiatedRef.current = false;
-          pushedRef.current = false;
-          idRef.current = null;
-          prevStateRef.current = null;
-          window.removeEventListener('popstate', handlePop);
-        } else {
-          // Programmatic close: go back to remove the pushed history entry.
-          // React has already run the cleanup for the previous `open=true` effect,
-          // so re-register this effect's handler before calling `history.back()`.
-          // Otherwise the suppressing popstate can be missed, leaving pushedRef true
-          // and causing the next close to navigate back past the current page.
-          window.addEventListener('popstate', handlePop);
-          suppressPopRef.current = true;
-          history.back();
-        }
+        // Programmatic close: suppress the resulting popstate and go back.
+        suppressPopRef.current = true;
+        history.back();
       } catch (e) {
         console.error('useDialogHistory cleanup error:', e);
       }
     }
-
-    return () => {
-      if (typeof window === 'undefined') return;
-      window.removeEventListener('popstate', handlePop);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 }


### PR DESCRIPTION
This fixes #163 where the app navigates back to the home screen when a user opens and closes multiple member profiles.

**Before**

https://github.com/user-attachments/assets/3629cde6-cbdd-4604-abbf-ecc6f370c2af

**After**

https://github.com/user-attachments/assets/af96c9f4-e5d3-4cc7-8485-ab3f9092a13e

