### PR TITLE
Add Operations Dashboard

### DIFF
--- a/src/app/(main)/event/[eventId]/layout.tsx
+++ b/src/app/(main)/event/[eventId]/layout.tsx
@@ -1,0 +1,5 @@
+import ActivityLayout from '@respond/components/activities/ActivityLayout';
+
+export default function EventActivityLayout({ children, params }: { children: React.ReactNode; params: { eventId: string } }) {
+  return <ActivityLayout activityId={params.eventId}>{children}</ActivityLayout>;
+}

--- a/src/app/(main)/event/[eventId]/ops/page.tsx
+++ b/src/app/(main)/event/[eventId]/ops/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { OperationsDashboard } from '@respond/components/dashboard/OperationsDashboard';
+
+export default function EditEvent() {
+  return <OperationsDashboard />;
+}

--- a/src/app/(main)/event/[eventId]/page.tsx
+++ b/src/app/(main)/event/[eventId]/page.tsx
@@ -2,6 +2,6 @@
 
 import { ActivityPage } from '@respond/components/activities/ActivityPage';
 
-export default function ViewEvent({ params }: { params: { eventId: string } }) {
-  return <ActivityPage activityId={params.eventId} />;
+export default function ViewEvent() {
+  return <ActivityPage />;
 }

--- a/src/app/(main)/mission/[missionId]/layout.tsx
+++ b/src/app/(main)/mission/[missionId]/layout.tsx
@@ -1,0 +1,5 @@
+import ActivityLayout from '@respond/components/activities/ActivityLayout';
+
+export default function MissionActivityLayout({ children, params }: { children: React.ReactNode; params: { missionId: string } }) {
+  return <ActivityLayout activityId={params.missionId}>{children}</ActivityLayout>;
+}

--- a/src/app/(main)/mission/[missionId]/ops/page.tsx
+++ b/src/app/(main)/mission/[missionId]/ops/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { OperationsDashboard } from '@respond/components/dashboard/OperationsDashboard';
+
+export default function EditEvent() {
+  return <OperationsDashboard />;
+}

--- a/src/app/(main)/mission/[missionId]/page.tsx
+++ b/src/app/(main)/mission/[missionId]/page.tsx
@@ -2,6 +2,6 @@
 
 import { ActivityPage } from '@respond/components/activities/ActivityPage';
 
-export default function ViewMission({ params }: { params: { missionId: string } }) {
-  return <ActivityPage activityId={params.missionId} />;
+export default function ViewMission() {
+  return <ActivityPage />;
 }

--- a/src/components/CopyChip.tsx
+++ b/src/components/CopyChip.tsx
@@ -52,5 +52,3 @@ export const CopyChip: React.FC<CopyChipProps> = ({ value, label, timeoutDuratio
 
   return <Chip {...restProps} label={copied ? `${value} copied` : label ?? value} color={copied ? 'success' : color ?? 'default'} icon={copied ? <CheckIcon /> : <ContentCopyIcon />} onClick={handleClick} sx={[{ px: 1, mt: 1 }, ...(Array.isArray(sx) ? sx : [sx])]} clickable />;
 };
-
-export default CopyChip;

--- a/src/components/CopyChip.tsx
+++ b/src/components/CopyChip.tsx
@@ -1,0 +1,56 @@
+import CheckIcon from '@mui/icons-material/Check';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import Chip, { ChipProps } from '@mui/material/Chip';
+import React, { useEffect, useRef, useState } from 'react';
+
+export interface CopyChipProps extends Omit<ChipProps, 'label' | 'onClick'> {
+  /** The value to copy to the clipboard and display */
+  value: string;
+  /** Optional custom label to show when in the default state */
+  label?: React.ReactNode;
+  /** Duration in milliseconds to display the copied state (default: 3000) */
+  timeoutDuration?: number;
+  /** Optional callback after click */
+  onClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
+}
+
+export const CopyChip: React.FC<CopyChipProps> = ({ value, label, timeoutDuration = 3000, onClick, color, sx, ...restProps }) => {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clean up the timeout if the component unmounts
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  const handleClick = async (event: React.MouseEvent<HTMLDivElement>) => {
+    try {
+      await navigator.clipboard.writeText(value);
+
+      setCopied(true);
+
+      // Reset timer if clicked again while already in "copied" state
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+
+      timerRef.current = setTimeout(() => {
+        setCopied(false);
+      }, timeoutDuration);
+    } catch (err) {
+      console.error('Failed to copy text to clipboard:', err);
+    }
+
+    if (onClick) {
+      onClick(event);
+    }
+  };
+
+  return <Chip {...restProps} label={copied ? `${value} copied` : label ?? value} color={copied ? 'success' : color ?? 'default'} icon={copied ? <CheckIcon /> : <ContentCopyIcon />} onClick={handleClick} sx={[{ px: 1, mt: 1 }, ...(Array.isArray(sx) ? sx : [sx])]} clickable />;
+};
+
+export default CopyChip;

--- a/src/components/DragAndDrop/DnDComponents.tsx
+++ b/src/components/DragAndDrop/DnDComponents.tsx
@@ -6,7 +6,8 @@ import { DraggedItem, useDnD } from './DnDProvider';
 interface DraggableProps<T> {
   type: string;
   item: T;
-  callback?: () => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  callback?: (...args: any[]) => void;
   children: ReactNode;
 }
 

--- a/src/components/DragAndDrop/DnDComponents.tsx
+++ b/src/components/DragAndDrop/DnDComponents.tsx
@@ -1,0 +1,95 @@
+import React, { ReactNode, useEffect, useRef } from 'react';
+
+import { DraggedItem, useDnD } from './DnDProvider';
+
+// --- <Draggable /> ---
+interface DraggableProps<T> {
+  type: string;
+  item: T;
+  children: ReactNode;
+}
+
+export function Draggable<T>({ type, item, children }: DraggableProps<T>) {
+  const { startDrag, updateDrag, endDrag } = useDnD();
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    // Prevents text selection during drag
+    e.stopPropagation();
+    startDrag({ type, data: item, previewNode: children }, e);
+  };
+
+  const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+    endDrag(e, (targetElement) => {
+      // Finds closest droppable ancestor and dispatches a synthetic drop event
+      const droppable = targetElement.closest<HTMLElement>('[data-droppable]');
+      if (droppable) {
+        droppable.dispatchEvent(
+          new CustomEvent('custom-drop', {
+            bubbles: true,
+            detail: { type, data: item },
+          }),
+        );
+      }
+    });
+  };
+
+  return (
+    <div
+      onPointerDown={handlePointerDown}
+      onPointerMove={updateDrag}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerUp}
+      style={{
+        touchAction: 'none', // Critical: prevents mobile browser scrolling while dragging
+        cursor: 'grab',
+        userSelect: 'none',
+        WebkitUserSelect: 'none',
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+// --- <Droppable /> ---
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+interface DroppableProps {
+  accepts?: string | string[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onDrop: (draggedItem: any, type: string) => void; // Accepts any dropped payload
+  children: ReactNode;
+  grow?: boolean;
+}
+
+export function Droppable({ accepts, onDrop, children, grow }: DroppableProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) return;
+
+    const isAccepted = (type?: string): boolean => {
+      if (!accepts) return true;
+      if (!type) return false;
+      return Array.isArray(accepts) ? accepts.includes(type) : accepts === type;
+    };
+
+    const handleCustomDrop = (e: Event) => {
+      const customEvent = e as CustomEvent<DraggedItem>;
+      // Only handle the event if this element is the original target the event was dispatched on.
+      if (e.target !== element) return;
+      if (isAccepted(customEvent.detail.type)) {
+        onDrop(customEvent.detail.data, customEvent.detail.type);
+      }
+    };
+
+    element.addEventListener('custom-drop', handleCustomDrop);
+    return () => element.removeEventListener('custom-drop', handleCustomDrop);
+  }, [accepts, onDrop]);
+
+  return (
+    <div data-droppable ref={containerRef} style={grow ? { flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' } : undefined}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/DragAndDrop/DnDComponents.tsx
+++ b/src/components/DragAndDrop/DnDComponents.tsx
@@ -6,16 +6,17 @@ import { DraggedItem, useDnD } from './DnDProvider';
 interface DraggableProps<T> {
   type: string;
   item: T;
+  callback?: () => void;
   children: ReactNode;
 }
 
-export function Draggable<T>({ type, item, children }: DraggableProps<T>) {
+export function Draggable<T>({ type, item, callback, children }: DraggableProps<T>) {
   const { startDrag, updateDrag, endDrag } = useDnD();
 
   const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     // Prevents text selection during drag
     e.stopPropagation();
-    startDrag({ type, data: item, previewNode: children }, e);
+    startDrag({ type, data: item, callback, previewNode: children }, e);
   };
 
   const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
@@ -26,7 +27,7 @@ export function Draggable<T>({ type, item, children }: DraggableProps<T>) {
         droppable.dispatchEvent(
           new CustomEvent('custom-drop', {
             bubbles: true,
-            detail: { type, data: item },
+            detail: { type, data: item, callback },
           }),
         );
       }
@@ -56,7 +57,7 @@ export function Draggable<T>({ type, item, children }: DraggableProps<T>) {
 interface DroppableProps {
   accepts?: string | string[];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onDrop: (draggedItem: any, type: string) => void; // Accepts any dropped payload
+  onDrop: (draggedItem: any, type: string, callback?: () => void) => void; // Accepts any dropped payload
   children: ReactNode;
   grow?: boolean;
 }
@@ -79,7 +80,7 @@ export function Droppable({ accepts, onDrop, children, grow }: DroppableProps) {
       // Only handle the event if this element is the original target the event was dispatched on.
       if (e.target !== element) return;
       if (isAccepted(customEvent.detail.type)) {
-        onDrop(customEvent.detail.data, customEvent.detail.type);
+        onDrop(customEvent.detail.data, customEvent.detail.type, customEvent.detail.callback);
       }
     };
 

--- a/src/components/DragAndDrop/DnDProvider.tsx
+++ b/src/components/DragAndDrop/DnDProvider.tsx
@@ -4,7 +4,8 @@ import React, { createContext, ReactNode, useContext, useState } from 'react';
 export interface DraggedItem<T = any> {
   type: string;
   data: T;
-  callback?: () => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  callback?: (...args: any[]) => void;
   previewNode?: ReactNode;
 }
 

--- a/src/components/DragAndDrop/DnDProvider.tsx
+++ b/src/components/DragAndDrop/DnDProvider.tsx
@@ -4,6 +4,7 @@ import React, { createContext, ReactNode, useContext, useState } from 'react';
 export interface DraggedItem<T = any> {
   type: string;
   data: T;
+  callback?: () => void;
   previewNode?: ReactNode;
 }
 

--- a/src/components/DragAndDrop/DnDProvider.tsx
+++ b/src/components/DragAndDrop/DnDProvider.tsx
@@ -1,0 +1,85 @@
+import React, { createContext, ReactNode, useContext, useState } from 'react';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface DraggedItem<T = any> {
+  type: string;
+  data: T;
+  previewNode?: ReactNode;
+}
+
+export interface Position {
+  x: number;
+  y: number;
+}
+
+interface DnDContextType {
+  activeItem: DraggedItem | null;
+  position: Position;
+  startDrag: (item: DraggedItem, e: React.PointerEvent<HTMLElement>) => void;
+  updateDrag: (e: React.PointerEvent<HTMLElement>) => void;
+  endDrag: (e: React.PointerEvent<HTMLElement>, onDropTargetFound: (element: HTMLElement) => void) => void;
+}
+
+const DnDContext = createContext<DnDContextType | null>(null);
+
+export const DnDProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [activeItem, setActiveItem] = useState<DraggedItem | null>(null);
+  const [position, setPosition] = useState<Position>({ x: 0, y: 0 });
+
+  const startDrag = (item: DraggedItem, e: React.PointerEvent<HTMLElement>) => {
+    // Locks pointer events to this element even if pointer moves outside it
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+
+    setActiveItem(item);
+    setPosition({ x: e.clientX, y: e.clientY });
+  };
+
+  const updateDrag = (e: React.PointerEvent<HTMLElement>) => {
+    if (!activeItem) return;
+    setPosition({ x: e.clientX, y: e.clientY });
+  };
+
+  const endDrag = (e: React.PointerEvent<HTMLElement>, onDropTargetFound: (element: HTMLElement) => void) => {
+    if (!activeItem) return;
+
+    const targetElement = e.target as HTMLElement;
+    if (targetElement.hasPointerCapture(e.pointerId)) {
+      targetElement.releasePointerCapture(e.pointerId);
+    }
+
+    // Identifies the element directly under the finger or cursor on drop
+    const dropTarget = document.elementFromPoint(e.clientX, e.clientY) as HTMLElement | null;
+    if (dropTarget) {
+      onDropTargetFound(dropTarget);
+    }
+
+    setActiveItem(null);
+  };
+
+  return (
+    <DnDContext.Provider value={{ activeItem, position, startDrag, updateDrag, endDrag }}>
+      {children}
+      {activeItem?.previewNode ? (
+        <div
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            transform: `translate3d(${position.x - 20}px, ${position.y - 20}px, 0)`,
+            pointerEvents: 'none',
+            zIndex: 9999,
+            opacity: 0.9,
+          }}
+        >
+          {activeItem.previewNode}
+        </div>
+      ) : null}
+    </DnDContext.Provider>
+  );
+};
+
+export const useDnD = (): DnDContextType => {
+  const context = useContext(DnDContext);
+  if (!context) throw new Error('useDnD must be used within a DnDProvider');
+  return context;
+};

--- a/src/components/DragAndDrop/Example.tsx
+++ b/src/components/DragAndDrop/Example.tsx
@@ -1,0 +1,156 @@
+import React, { useState } from 'react';
+
+import { Draggable, Droppable } from './DnDComponents';
+import { DnDProvider } from './DnDProvider';
+
+interface Participant {
+  id: string;
+  name: string;
+  type: 'participant';
+}
+
+interface Equipment {
+  id: string;
+  title: string;
+  type: 'equipment';
+}
+
+type Resource = Participant | Equipment;
+
+interface Team {
+  id: string;
+  name: string;
+}
+
+export default function App() {
+  const [teams] = useState<Team[]>([
+    { id: 'team-alpha', name: 'Team Alpha' },
+    { id: 'team-beta', name: 'Team Beta' },
+  ]);
+
+  // Track which resource belongs to which team (or unassigned: null)
+  const [resourceAssignments, setResourceAssignments] = useState<Record<string, string | null>>({
+    p1: 'team-alpha',
+    p2: 'team-alpha',
+    p3: 'team-beta',
+    e1: 'team-beta',
+  });
+
+  const resources: Resource[] = [
+    { id: 'p1', name: 'Alex', type: 'participant' },
+    { id: 'p2', name: 'Sam', type: 'participant' },
+    { id: 'p3', name: 'Jordan', type: 'participant' },
+    { id: 'e1', title: 'Camera Rig', type: 'equipment' },
+  ];
+
+  const handleDropOnTeam = (resource: Resource, targetTeamId: string | null) => {
+    setResourceAssignments((prev) => ({
+      ...prev,
+      [resource.id]: targetTeamId,
+    }));
+  };
+
+  const getTeamResources = (teamId: string | null) => resources.filter((res) => resourceAssignments[res.id] === teamId);
+
+  return (
+    <DnDProvider>
+      <div style={{ padding: '32px', fontFamily: 'sans-serif' }}>
+        <h2>Multi-Team Drag & Drop Test</h2>
+        <p style={{ color: '#64748b' }}>Drag items between the two teams or move them back to the Unassigned pool (works on desktop mouse & mobile touch).</p>
+
+        {/* Unassigned Items Pool */}
+        <Droppable accepts={['participant', 'equipment']} onDrop={(item) => handleDropOnTeam(item, null)}>
+          <div
+            style={{
+              marginBottom: '24px',
+              padding: '16px',
+              border: '2px dashed #cbd5e1',
+              borderRadius: '8px',
+              backgroundColor: '#f8fafc',
+              minHeight: '80px',
+            }}
+          >
+            <h4 style={{ margin: '0 0 12px 0' }}>Unassigned Resources</h4>
+            <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
+              {getTeamResources(null).map((item) => (
+                <Draggable key={item.id} type={item.type} item={item}>
+                  <ResourceCard resource={item} />
+                </Draggable>
+              ))}
+              {getTeamResources(null).length === 0 && <span style={{ color: '#94a3b8', fontSize: '14px' }}>Drop items here to unassign them</span>}
+            </div>
+          </div>
+        </Droppable>
+
+        {/* Teams Container */}
+        <div style={{ display: 'flex', gap: '24px' }}>
+          {teams.map((team) => (
+            <Droppable key={team.id} accepts={['participant', 'equipment']} onDrop={(item) => handleDropOnTeam(item, team.id)}>
+              <div
+                style={{
+                  flex: 1,
+                  minWidth: '240px',
+                  minHeight: '260px',
+                  border: '2px dashed #94a3b8',
+                  borderRadius: '8px',
+                  padding: '16px',
+                  backgroundColor: '#ffffff',
+                  boxShadow: '0 1px 3px rgba(0,0,0,0.05)',
+                }}
+              >
+                <h3 style={{ margin: '0 0 16px 0' }}>
+                  {team.name} ({getTeamResources(team.id).length})
+                </h3>
+
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                  {getTeamResources(team.id).map((item) => (
+                    <Draggable key={item.id} type={item.type} item={item}>
+                      <ResourceCard resource={item} />
+                    </Draggable>
+                  ))}
+                  {getTeamResources(team.id).length === 0 && (
+                    <div
+                      style={{
+                        padding: '24px',
+                        textAlign: 'center',
+                        color: '#94a3b8',
+                        fontSize: '14px',
+                      }}
+                    >
+                      Drop participants or equipment here
+                    </div>
+                  )}
+                </div>
+              </div>
+            </Droppable>
+          ))}
+        </div>
+      </div>
+    </DnDProvider>
+  );
+}
+
+// Reusable card renderer
+const ResourceCard: React.FC<{ resource: Resource; isPreview?: boolean }> = ({ resource, isPreview }) => {
+  const isParticipant = resource.type === 'participant';
+
+  return (
+    <div
+      style={{
+        padding: '10px 14px',
+        backgroundColor: isPreview ? '#eff6ff' : '#ffffff',
+        border: `1px solid ${isPreview ? '#2563eb' : '#cbd5e1'}`,
+        borderRadius: '6px',
+        boxShadow: isPreview ? '0 10px 15px -3px rgba(0, 0, 0, 0.2)' : '0 1px 2px rgba(0,0,0,0.05)',
+        fontSize: '14px',
+        fontWeight: 500,
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '8px',
+      }}
+    >
+      <span>{isParticipant ? '👤' : '📷'}</span>
+      <span>{isParticipant ? resource.name : resource.title}</span>
+    </div>
+  );
+};

--- a/src/components/StatusContainer.tsx
+++ b/src/components/StatusContainer.tsx
@@ -1,0 +1,20 @@
+import { Box, Paper, Stack, SxProps, Theme } from '@mui/material';
+import { ReactNode } from 'react';
+
+export function StatusContainer({ color, children, sx }: { color: string; children: ReactNode; sx?: SxProps<Theme> }) {
+  return (
+    <Stack direction="row" sx={sx}>
+      <Paper
+        elevation={0}
+        sx={{
+          width: 8,
+          flexShrink: 0, // Prevents the color bar from shrinking if content expands
+          bgcolor: color ?? 'transparent',
+          borderBottomRightRadius: 0,
+          borderTopRightRadius: 0,
+        }}
+      />
+      <Box sx={{ flexGrow: 1, minWidth: 0 }}>{children}</Box>
+    </Stack>
+  );
+}

--- a/src/components/StatusUpdater/index.tsx
+++ b/src/components/StatusUpdater/index.tsx
@@ -158,6 +158,11 @@ const StatusUpdaterProtected = ({ fullWidth, user, thisOrg }: { user: UserInfo |
           <DialogTitle id="status-update-dialog-title">{confirmTitle}</DialogTitle>
           <DialogContent>
             <>
+              {current === ParticipantStatus.Assigned && (
+                <Alert sx={{ mb: 1 }} severity="error">
+                  You are currently assigned to a Team or Place on the Operations Dashboard. Changing your status may cause a discrepancy.
+                </Alert>
+              )}
               {!activity.organizations[thisOrg.id] && (
                 <Alert sx={{ mb: 1 }} severity="warning">
                   You are the first responder for {thisOrg.rosterName}. Make sure you are authorized to commit {thisOrg.rosterName} to this {activity.isMission ? 'mission' : 'event'}.

--- a/src/components/ToolbarPage.tsx
+++ b/src/components/ToolbarPage.tsx
@@ -24,7 +24,7 @@ export function ToolbarPage({ children, maxWidth }: { children: React.ReactNode;
   }
 
   return (
-    <Container maxWidth={maxWidth ?? 'md'} sx={{ display: 'flex', flexDirection: 'column', flex: '1 1 auto' }}>
+    <Container maxWidth={maxWidth ?? 'md'} sx={{ display: 'flex', flexDirection: 'column', flex: '1 1 auto', minHeight: 0 }}>
       <CssBaseline />
       <AppBar position="fixed" sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
         <Toolbar sx={{ display: 'flex', alignItems: 'center' }}>
@@ -48,8 +48,8 @@ export function ToolbarPage({ children, maxWidth }: { children: React.ReactNode;
           <AppMenu />
         </Toolbar>
       </AppBar>
-      <Box className="toolbar-filler" sx={{ height: { xs: 56, sm: 64 } }} />
-      <Box component="main" sx={{ py: 2 }} flex="1 1 auto" display="flex" flexDirection="column">
+      <Box className="toolbar-filler" sx={{ height: { xs: 56, sm: 64 }, flexShrink: 0 }} />
+      <Box component="main" sx={{ py: 2, flex: '1 1 auto', minHeight: 0 }} display="flex" flexDirection="column">
         {children}
       </Box>
     </Container>

--- a/src/components/activities/ActivityLayout.tsx
+++ b/src/components/activities/ActivityLayout.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { apiFetch } from '@respond/lib/api';
+import { useAppSelector } from '@respond/lib/client/store';
+import { buildActivitySelector } from '@respond/lib/client/store/activities';
+import type { Activity } from '@respond/types/activity';
+
+import { ActivityProvider } from './ActivityProvider';
+
+export default function ActivityLayout({ children, activityId }: { children: React.ReactNode; activityId: string }) {
+  const activity = useAppSelector(buildActivitySelector(activityId));
+  const [fetchedActivity, setFetchedActivity] = useState<Activity | null | undefined>(activity ?? undefined);
+  const displayActivity = activity ?? fetchedActivity;
+
+  useEffect(() => {
+    if (activity) return;
+
+    let cancelled = false;
+    setFetchedActivity(undefined);
+
+    apiFetch<{ data?: Activity }>(`/api/v1/activities/${activityId}`)
+      .then((response) => {
+        if (cancelled) return;
+        setFetchedActivity(response.data ?? null);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setFetchedActivity(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activity, activityId]);
+
+  if (displayActivity === undefined) return <div>Loading activity...</div>;
+  if (displayActivity === null) return <div>Activity not found</div>;
+
+  return <ActivityProvider activity={displayActivity}>{children}</ActivityProvider>;
+}

--- a/src/components/activities/ActivityPage.tsx
+++ b/src/components/activities/ActivityPage.tsx
@@ -5,54 +5,28 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
-import { Alert, Button, DialogActions, DialogContent, DialogContentText, DialogTitle, DialogWithHistory, IconButton, Stack } from '@respond/components/Material';
-import { apiFetch } from '@respond/lib/api';
+import { Button, DialogActions, DialogContent, DialogContentText, DialogTitle, DialogWithHistory, IconButton, Stack } from '@respond/components/Material';
 import { useAppDispatch, useAppSelector } from '@respond/lib/client/store';
-import { buildActivitySelector, isActive } from '@respond/lib/client/store/activities';
+import { isActive } from '@respond/lib/client/store/activities';
 import { ActivityActions } from '@respond/lib/state';
-import type { Activity } from '@respond/types/activity';
 
-import { ActivityProvider, useActivityContext } from './ActivityProvider';
+import { useActivityContext } from './ActivityProvider';
 import { DesktopActivityPage } from './DesktopActivityPage';
 import { MobileActivityPage } from './MobileActivityPage';
 
-export const ActivityPage = ({ activityId }: { activityId: string }) => {
-  const activity = useAppSelector(buildActivitySelector(activityId));
+export const ActivityPage = () => {
+  const activity = useActivityContext();
   const org = useAppSelector((state) => state.organization.mine);
-  const [fetchedActivity, setFetchedActivity] = useState<Activity | null>();
-  const displayActivity = activity ?? fetchedActivity;
 
   useEffect(() => {
-    document.title = `${displayActivity?.idNumber} ${displayActivity?.title}`;
-  }, [displayActivity?.idNumber, displayActivity?.title]);
-
-  useEffect(() => {
-    if (activity) return;
-
-    let cancelled = false;
-    setFetchedActivity(undefined);
-
-    apiFetch<{ data?: Activity }>(`/api/v1/activities/${activityId}`)
-      .then((response) => {
-        if (!cancelled) setFetchedActivity(response.data ?? null);
-      })
-      .catch(() => {
-        if (!cancelled) setFetchedActivity(null);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [activity, activityId]);
+    document.title = `${activity.idNumber} ${activity.title}`;
+  }, [activity.idNumber, activity.title]);
 
   const isMobile = useMediaQuery(useTheme().breakpoints.down('md'));
 
-  if (displayActivity === undefined) return <Alert severity="info">Loading activity...</Alert>;
-  if (displayActivity === null) return <Alert severity="error">Activity not found</Alert>;
-
   if (!org) return <div>Loading org...</div>;
 
-  return <ActivityProvider activity={displayActivity}>{isMobile ? <MobileActivityPage /> : <DesktopActivityPage />}</ActivityProvider>;
+  return isMobile ? <MobileActivityPage /> : <DesktopActivityPage />;
 };
 
 export function ActivityActionsBar() {

--- a/src/components/dashboard/DashboardActivityDetails.tsx
+++ b/src/components/dashboard/DashboardActivityDetails.tsx
@@ -2,7 +2,7 @@ import { Box, Typography } from '@mui/material';
 
 import { useActivityContext } from '../activities/ActivityProvider';
 
-export default function DashboardActivityDetails() {
+export function DashboardActivityDetails() {
   const activity = useActivityContext();
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', minWidth: 0 }}>

--- a/src/components/dashboard/DashboardActivityDetails.tsx
+++ b/src/components/dashboard/DashboardActivityDetails.tsx
@@ -1,0 +1,20 @@
+import { Box, Typography } from '@mui/material';
+
+import { useActivityContext } from '../activities/ActivityProvider';
+
+export default function DashboardActivityDetails() {
+  const activity = useActivityContext();
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', minWidth: 0 }}>
+      <Typography variant="h5" sx={{ fontWeight: 700, lineHeight: 1.2 }}>
+        {activity.title}
+      </Typography>
+      <Typography variant="subtitle1" sx={{ color: 'text.secondary', mt: 0.5 }}>
+        Activity ID {activity.idNumber || activity.id}
+      </Typography>
+      <Typography variant="body2" sx={{ color: 'text.secondary', mt: 0.5 }}>
+        {activity.isMission ? 'Mission' : 'Event'} • {activity.location?.title || 'Location pending'}
+      </Typography>
+    </Box>
+  );
+}

--- a/src/components/dashboard/DashboardActivityDetails.tsx
+++ b/src/components/dashboard/DashboardActivityDetails.tsx
@@ -10,7 +10,7 @@ export default function DashboardActivityDetails() {
         {activity.title}
       </Typography>
       <Typography variant="subtitle1" sx={{ color: 'text.secondary', mt: 0.5 }}>
-        Activity ID {activity.idNumber || activity.id}
+        {activity.idNumber || ''}
       </Typography>
       <Typography variant="body2" sx={{ color: 'text.secondary', mt: 0.5 }}>
         {activity.isMission ? 'Mission' : 'Event'} • {activity.location?.title || 'Location pending'}

--- a/src/components/dashboard/DashboardAvailableParticipants.tsx
+++ b/src/components/dashboard/DashboardAvailableParticipants.tsx
@@ -25,7 +25,6 @@ export function DashboardAvailableParticipants() {
     dispatch(ActivityActions.participantTimelineAdd(activity.id, participant.id, update));
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handleDrop = (participant: Participant, type: string, callback?: () => void) => {
     // If the participant is not in Assigned status, do not overwrite the current status.
     if (participant.timeline[0].status !== ParticipantStatus.Assigned) return;

--- a/src/components/dashboard/DashboardAvailableParticipants.tsx
+++ b/src/components/dashboard/DashboardAvailableParticipants.tsx
@@ -7,7 +7,7 @@ import { Participant } from '@respond/types/activity';
 import { ParticipantStatus } from '@respond/types/activity';
 
 import { useActivityContext } from '../activities/ActivityProvider';
-import { Droppable } from '../DragAndDrop/DnDComponents';
+import { Draggable, Droppable } from '../DragAndDrop/DnDComponents';
 
 import DashboardParticipantCard from './DashboardParticipantCard';
 
@@ -20,19 +20,18 @@ export function DashboardAvailableParticipants() {
     return Object.values(activity.participants).filter((participant) => participant.timeline[0].status === ParticipantStatus.Available);
   }, [activity]);
 
-  const handleDrop = (participant: Participant) => {
-    if (participant.timeline[0].status !== ParticipantStatus.Available) {
-      // Update the Participant Status to Available
-      const update = { time: Date.now(), status: ParticipantStatus.Available, organizationId: participant.organizationId };
-      dispatch(ActivityActions.participantTimelineAdd(activity.id, participant.id, update));
-    }
-    activity.teams.forEach((team) => {
-      if (team.assignedParticipants.includes(participant.id)) {
-        // Remove the participant from the team
-        const updatedTeam = { ...team, assignedParticipants: team.assignedParticipants.filter((id) => id !== participant.id) };
-        dispatch(ActivityActions.updateTeam(activity.id, updatedTeam));
-      }
-    });
+  const setAssigned = (participant: Participant) => {
+    const update = { time: Date.now(), status: ParticipantStatus.Assigned, organizationId: participant.organizationId };
+    dispatch(ActivityActions.participantTimelineAdd(activity.id, participant.id, update));
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handleDrop = (participant: Participant, type: string, callback?: () => void) => {
+    if (participant.timeline[0].status === ParticipantStatus.Available) return;
+    // Update the Participant Status to Available
+    const update = { time: Date.now(), status: ParticipantStatus.Available, organizationId: participant.organizationId };
+    dispatch(ActivityActions.participantTimelineAdd(activity.id, participant.id, update));
+    callback?.();
   };
 
   return (
@@ -45,7 +44,13 @@ export function DashboardAvailableParticipants() {
             </Typography>
           </Box>
         ) : (
-          availableParticipants.map((participant) => <DashboardParticipantCard key={participant.id} participant={participant} />)
+          availableParticipants.map((participant) => {
+            return (
+              <Draggable key={participant.id} type="participant" item={participant} callback={() => setAssigned(participant)}>
+                <DashboardParticipantCard key={participant.id} participant={participant} />
+              </Draggable>
+            );
+          })
         )}
       </Box>
     </Droppable>

--- a/src/components/dashboard/DashboardAvailableParticipants.tsx
+++ b/src/components/dashboard/DashboardAvailableParticipants.tsx
@@ -1,0 +1,53 @@
+import { Box, Typography } from '@mui/material';
+import { useMemo } from 'react';
+
+import { useAppDispatch } from '@respond/lib/client/store';
+import { ActivityActions } from '@respond/lib/state';
+import { Participant } from '@respond/types/activity';
+import { ParticipantStatus } from '@respond/types/activity';
+
+import { useActivityContext } from '../activities/ActivityProvider';
+import { Droppable } from '../DragAndDrop/DnDComponents';
+
+import DashboardParticipantCard from './DashboardParticipantCard';
+
+export function DashboardAvailableParticipants() {
+  const dispatch = useAppDispatch();
+
+  const activity = useActivityContext();
+
+  const availableParticipants = useMemo(() => {
+    return Object.values(activity.participants).filter((participant) => participant.timeline[0].status === ParticipantStatus.Available);
+  }, [activity]);
+
+  const handleDrop = (participant: Participant) => {
+    if (participant.timeline[0].status !== ParticipantStatus.Available) {
+      // Update the Participant Status to Available
+      const update = { time: Date.now(), status: ParticipantStatus.Available, organizationId: participant.organizationId };
+      dispatch(ActivityActions.participantTimelineAdd(activity.id, participant.id, update));
+    }
+    activity.teams.forEach((team) => {
+      if (team.assignedParticipants.includes(participant.id)) {
+        // Remove the participant from the team
+        const updatedTeam = { ...team, assignedParticipants: team.assignedParticipants.filter((id) => id !== participant.id) };
+        dispatch(ActivityActions.updateTeam(activity.id, updatedTeam));
+      }
+    });
+  };
+
+  return (
+    <Droppable accepts="participant" onDrop={handleDrop} grow>
+      <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 1 }}>
+        {availableParticipants.length === 0 ? (
+          <Box sx={{ flex: 1, minHeight: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Typography variant="body2" color="text.secondary" textAlign="center">
+              All responders are assigned.
+            </Typography>
+          </Box>
+        ) : (
+          availableParticipants.map((participant) => <DashboardParticipantCard key={participant.id} participant={participant} />)
+        )}
+      </Box>
+    </Droppable>
+  );
+}

--- a/src/components/dashboard/DashboardAvailableParticipants.tsx
+++ b/src/components/dashboard/DashboardAvailableParticipants.tsx
@@ -23,11 +23,12 @@ export function DashboardAvailableParticipants() {
   const setAssigned = (participant: Participant) => {
     const update = { time: Date.now(), status: ParticipantStatus.Assigned, organizationId: participant.organizationId };
     dispatch(ActivityActions.participantTimelineAdd(activity.id, participant.id, update));
-  }
+  };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handleDrop = (participant: Participant, type: string, callback?: () => void) => {
-    if (participant.timeline[0].status === ParticipantStatus.Available) return;
+    // If the participant is not in Assigned status, do not overwrite the current status.
+    if (participant.timeline[0].status !== ParticipantStatus.Assigned) return;
     // Update the Participant Status to Available
     const update = { time: Date.now(), status: ParticipantStatus.Available, organizationId: participant.organizationId };
     dispatch(ActivityActions.participantTimelineAdd(activity.id, participant.id, update));

--- a/src/components/dashboard/DashboardBoxWithTitle.tsx
+++ b/src/components/dashboard/DashboardBoxWithTitle.tsx
@@ -19,9 +19,12 @@ interface DashboardBoxWithTitleAction {
 
 export function DashboardBoxWithTitle({ title, actions = [], collapsible = false, children, sx }: DashboardBoxWithTitleProps): JSX.Element {
   const [collapsed, setCollapsed] = useState(false);
+  const [hovered, setHovered] = useState(false);
 
   return (
     <Box
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
       sx={[
         {
           border: '1px solid',
@@ -44,20 +47,22 @@ export function DashboardBoxWithTitle({ title, actions = [], collapsible = false
         sx={{ cursor: 'pointer', pb: collapsed ? 0 : 1 }}
       >
         <Typography sx={{ fontWeight: 700, whiteSpace: 'nowrap', textAlign: 'center' }}>{title}</Typography>
-        <Stack direction="row">
-          {actions.map((action) => (
-            <IconButton
-              key={action.id}
-              size="small"
-              sx={{ width: 24, height: 24 }}
-              onClick={(e) => {
-                e.stopPropagation();
-                action.onClick();
-              }}
-            >
-              {action.icon}
-            </IconButton>
-          ))}
+        <Stack direction="row" alignItems="center">
+          <Stack direction="row" sx={{ visibility: hovered ? 'visible' : 'hidden' }}>
+            {actions.map((action) => (
+              <IconButton
+                key={action.id}
+                size="small"
+                sx={{ width: 24, height: 24 }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  action.onClick();
+                }}
+              >
+                {action.icon}
+              </IconButton>
+            ))}
+          </Stack>
           {collapsible && (
             <IconButton size="small" sx={{ width: 24, height: 24 }}>
               {collapsed ? <ExpandMoreIcon /> : <ExpandLessIcon />}

--- a/src/components/dashboard/DashboardBoxWithTitle.tsx
+++ b/src/components/dashboard/DashboardBoxWithTitle.tsx
@@ -5,11 +5,12 @@ import React, { useState } from 'react';
 
 interface DashboardCollapsibleBoxProps {
   title: string;
+  collapsible?: boolean;
   children: React.ReactNode;
   sx?: SxProps<Theme>;
 }
 
-export function DashboardCollapsibleBox({ title, children, sx }: DashboardCollapsibleBoxProps): JSX.Element {
+export function DashboardBoxWithTitle({ title, collapsible = false, children, sx }: DashboardCollapsibleBoxProps): JSX.Element {
   const [collapsed, setCollapsed] = useState(false);
 
   return (
@@ -23,13 +24,23 @@ export function DashboardCollapsibleBox({ title, children, sx }: DashboardCollap
         },
         ...(Array.isArray(sx) ? sx : [sx]),
       ]}
-      onClick={() => setCollapsed((current) => !current)}
     >
-      <Stack direction="row" spacing={0.5} alignItems="center" justifyContent="space-between">
+      <Stack
+        direction="row"
+        alignItems="center"
+        justifyContent="space-between"
+        onClick={() => {
+          if (!collapsible) return;
+          setCollapsed((current) => !current);
+        }}
+        sx={{ cursor: 'pointer', pb: collapsed ? 0 : 1 }}
+      >
         <Typography sx={{ fontWeight: 700, whiteSpace: 'nowrap', textAlign: 'center' }}>{title}</Typography>
-        <IconButton size="small" sx={{ width: 32, height: 32 }}>
-          {collapsed ? <ExpandMoreIcon /> : <ExpandLessIcon />}
-        </IconButton>
+        {collapsible && (
+          <IconButton size="small" sx={{ width: 24, height: 24 }}>
+            {collapsed ? <ExpandMoreIcon /> : <ExpandLessIcon />}
+          </IconButton>
+        )}
       </Stack>
       {!collapsed && children}
     </Box>

--- a/src/components/dashboard/DashboardBoxWithTitle.tsx
+++ b/src/components/dashboard/DashboardBoxWithTitle.tsx
@@ -3,14 +3,21 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { Box, IconButton, Stack, SxProps, Theme, Typography } from '@mui/material';
 import React, { useState } from 'react';
 
-interface DashboardCollapsibleBoxProps {
+interface DashboardBoxWithTitleProps {
   title: string;
+  actions?: DashboardBoxWithTitleAction[];
   collapsible?: boolean;
   children: React.ReactNode;
   sx?: SxProps<Theme>;
 }
 
-export function DashboardBoxWithTitle({ title, collapsible = false, children, sx }: DashboardCollapsibleBoxProps): JSX.Element {
+interface DashboardBoxWithTitleAction {
+  icon: React.ReactNode;
+  id: string;
+  onClick: () => void;
+}
+
+export function DashboardBoxWithTitle({ title, actions = [], collapsible = false, children, sx }: DashboardBoxWithTitleProps): JSX.Element {
   const [collapsed, setCollapsed] = useState(false);
 
   return (
@@ -21,6 +28,7 @@ export function DashboardBoxWithTitle({ title, collapsible = false, children, sx
           borderColor: 'divider',
           borderRadius: 2,
           bgcolor: 'background.paper',
+          p: 1,
         },
         ...(Array.isArray(sx) ? sx : [sx]),
       ]}
@@ -36,11 +44,26 @@ export function DashboardBoxWithTitle({ title, collapsible = false, children, sx
         sx={{ cursor: 'pointer', pb: collapsed ? 0 : 1 }}
       >
         <Typography sx={{ fontWeight: 700, whiteSpace: 'nowrap', textAlign: 'center' }}>{title}</Typography>
-        {collapsible && (
-          <IconButton size="small" sx={{ width: 24, height: 24 }}>
-            {collapsed ? <ExpandMoreIcon /> : <ExpandLessIcon />}
-          </IconButton>
-        )}
+        <Stack direction="row">
+          {actions.map((action) => (
+            <IconButton
+              key={action.id}
+              size="small"
+              sx={{ width: 24, height: 24 }}
+              onClick={(e) => {
+                e.stopPropagation();
+                action.onClick();
+              }}
+            >
+              {action.icon}
+            </IconButton>
+          ))}
+          {collapsible && (
+            <IconButton size="small" sx={{ width: 24, height: 24 }}>
+              {collapsed ? <ExpandMoreIcon /> : <ExpandLessIcon />}
+            </IconButton>
+          )}
+        </Stack>
       </Stack>
       {!collapsed && children}
     </Box>

--- a/src/components/dashboard/DashboardClock.tsx
+++ b/src/components/dashboard/DashboardClock.tsx
@@ -1,7 +1,7 @@
 import { Box, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
 
-export default function DashboardClock() {
+export function DashboardClock() {
   const [clock, setClock] = useState(() => new Date());
 
   useEffect(() => {

--- a/src/components/dashboard/DashboardClock.tsx
+++ b/src/components/dashboard/DashboardClock.tsx
@@ -1,0 +1,22 @@
+import { Box, Typography } from '@mui/material';
+import { useEffect, useState } from 'react';
+
+export default function DashboardClock() {
+  const [clock, setClock] = useState(() => new Date());
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      setClock(new Date());
+    }, 1000);
+
+    return () => window.clearInterval(timer);
+  }, []);
+
+  return (
+    <Box sx={{ minWidth: 220, display: 'flex', alignItems: 'center', justifyContent: 'center', bgcolor: 'primary.main', color: 'primary.contrastText', borderRadius: 3, px: 3, py: 2 }}>
+      <Typography variant="h2" sx={{ fontWeight: 800, lineHeight: 1, letterSpacing: 1.5 }}>
+        {new Intl.DateTimeFormat('en-GB', { hour: '2-digit', minute: '2-digit', hour12: false }).format(clock)}
+      </Typography>
+    </Box>
+  );
+}

--- a/src/components/dashboard/DashboardCollapsibleBox.tsx
+++ b/src/components/dashboard/DashboardCollapsibleBox.tsx
@@ -1,0 +1,37 @@
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { Box, IconButton, Stack, SxProps, Theme, Typography } from '@mui/material';
+import React, { useState } from 'react';
+
+interface DashboardCollapsibleBoxProps {
+  title: string;
+  children: React.ReactNode;
+  sx?: SxProps<Theme>;
+}
+
+export function DashboardCollapsibleBox({ title, children, sx }: DashboardCollapsibleBoxProps): JSX.Element {
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <Box
+      sx={[
+        {
+          border: '1px solid',
+          borderColor: 'divider',
+          borderRadius: 2,
+          bgcolor: 'background.paper',
+        },
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
+      onClick={() => setCollapsed((current) => !current)}
+    >
+      <Stack direction="row" spacing={0.5} alignItems="center" justifyContent="space-between">
+        <Typography sx={{ fontWeight: 700, whiteSpace: 'nowrap', textAlign: 'center' }}>{title}</Typography>
+        <IconButton size="small" sx={{ width: 32, height: 32 }}>
+          {collapsed ? <ExpandMoreIcon /> : <ExpandLessIcon />}
+        </IconButton>
+      </Stack>
+      {!collapsed && children}
+    </Box>
+  );
+}

--- a/src/components/dashboard/DashboardCommsAutomatedToggleButton.tsx
+++ b/src/components/dashboard/DashboardCommsAutomatedToggleButton.tsx
@@ -1,0 +1,32 @@
+import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined';
+import { IconButton, Tooltip } from '@mui/material';
+import React, { useState } from 'react';
+
+export function CommsAutomatedToggleButton({ onChange }: { onChange: (isHidden: boolean) => void }): JSX.Element {
+  const [hidden, setHidden] = useState<boolean>(false);
+
+  const handleToggle = (): void => {
+    const next = !hidden;
+    setHidden(next);
+    onChange(next);
+  };
+
+  return (
+    <Tooltip title={hidden ? 'Show automated logs' : 'Hide automated logs'}>
+      <IconButton
+        color={hidden ? 'default' : 'primary'}
+        aria-label={hidden ? 'Show automated logs' : 'Hide automated logs'}
+        onClick={handleToggle}
+        sx={{
+          width: 32,
+          height: 32,
+          borderRadius: 1,
+          border: '1px solid',
+          borderColor: hidden ? 'divider' : 'primary.main',
+        }}
+      >
+        <SmartToyOutlinedIcon fontSize="small" />
+      </IconButton>
+    </Tooltip>
+  );
+}

--- a/src/components/dashboard/DashboardCommsComposer.tsx
+++ b/src/components/dashboard/DashboardCommsComposer.tsx
@@ -2,11 +2,10 @@ import { Box, Button, Stack, TextField } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import { useEffect, useRef } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
-import { v4 as uuid } from 'uuid';
 
 import { useAppDispatch } from '@respond/lib/client/store';
 import { ActivityActions } from '@respond/lib/state';
-import { CommunicationsLogEntry } from '@respond/types/operations';
+import { CommunicationsLogEntry, createNewCommsEntry } from '@respond/types/operations';
 
 import { useActivityContext } from '../activities/ActivityProvider';
 
@@ -37,24 +36,20 @@ export function DashboardCommsComposer({ entry, onSave, onCancel }: { entry?: Co
 
   const submit: SubmitHandler<FormValues> = (values) => {
     if (entry && entry.id) {
-      // update existing comm: only send changed fields as updates
       const updates: Partial<CommunicationsLogEntry> = {
         from: values.from,
         to: values.to,
         message: values.message,
+        isAutomated: false, // Automated messages are toggled to false when edited
       };
       dispatch(ActivityActions.updateComm(activity.id, entry.id, updates));
       onSave?.();
     } else {
-      const comm: CommunicationsLogEntry = {
-        id: uuid(),
+      const comm: CommunicationsLogEntry = createNewCommsEntry({
         from: values.from,
         to: values.to,
         message: values.message,
-        timestamp: Date.now(),
-        isAutomated: false,
-        isDeleted: false,
-      };
+      });
       dispatch(ActivityActions.addComm(activity.id, comm));
       onSave?.();
     }

--- a/src/components/dashboard/DashboardCommsComposer.tsx
+++ b/src/components/dashboard/DashboardCommsComposer.tsx
@@ -1,0 +1,86 @@
+import { Box, Button, Stack, TextField } from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { v4 as uuid } from 'uuid';
+
+import { useAppDispatch } from '@respond/lib/client/store';
+import { ActivityActions } from '@respond/lib/state';
+import { CommunicationsLogEntry } from '@respond/types/activity';
+
+import { useActivityContext } from '../activities/ActivityProvider';
+
+type FormValues = {
+  from: string;
+  to: string;
+  message: string;
+};
+
+export function DashboardCommsComposer({ entry, onSave, onCancel }: { entry?: CommunicationsLogEntry | null; onSave?: () => void; onCancel?: () => void }) {
+  const dispatch = useAppDispatch();
+  const activity = useActivityContext();
+
+  const { register, handleSubmit, reset, formState } = useForm<FormValues>({
+    defaultValues: {
+      from: entry?.from ?? '',
+      to: entry?.to ?? '',
+      message: entry?.message ?? '',
+    },
+  });
+
+  const submit: SubmitHandler<FormValues> = (values) => {
+    if (entry && entry.id) {
+      // update existing comm: only send changed fields as updates
+      const updates: Partial<CommunicationsLogEntry> = {
+        from: values.from,
+        to: values.to,
+        message: values.message,
+      };
+      dispatch(ActivityActions.updateComm(activity.id, entry.id, updates));
+      onSave?.();
+    } else {
+      const comm: CommunicationsLogEntry = {
+        id: uuid(),
+        from: values.from,
+        to: values.to,
+        message: values.message,
+        timestamp: Date.now(),
+        isAutomated: false,
+        isDeleted: false,
+      };
+      dispatch(ActivityActions.addComm(activity.id, comm));
+      onSave?.();
+    }
+
+    reset({ from: 'Ops', to: 'All Teams', message: '' });
+  };
+
+  return (
+    <Box sx={{ borderColor: 'divider', p: entry ? 2 : 1, mt: entry ? 0 : 2, flexShrink: 0, bgcolor: entry ? (theme) => alpha(theme.palette.info.main, 0.08) : undefined }}>
+      <form onSubmit={handleSubmit(submit)}>
+        <Stack spacing={2}>
+          <Stack direction={{ xl: 'row' }} alignItems={{ xs: 'stretch', xl: 'center' }} gap={2}>
+            <TextField label="From" size="small" {...register('from')} />
+            <TextField label="To" size="small" {...register('to')} />
+          </Stack>
+          <TextField label="Message" size="small" multiline minRows={2} {...register('message', { required: true })} error={!!formState.errors.message} helperText={formState.errors.message ? 'Message is required' : ''} />
+          <Stack direction="row" spacing={1} alignItems="center" justifyContent="flex-end">
+            {entry && (
+              <Button
+                onClick={() => {
+                  reset();
+                  onCancel?.();
+                }}
+                size="small"
+              >
+                Cancel
+              </Button>
+            )}
+            <Button type="submit" size="small" variant="contained">
+              Save
+            </Button>
+          </Stack>
+        </Stack>
+      </form>
+    </Box>
+  );
+}

--- a/src/components/dashboard/DashboardCommsComposer.tsx
+++ b/src/components/dashboard/DashboardCommsComposer.tsx
@@ -6,7 +6,7 @@ import { v4 as uuid } from 'uuid';
 
 import { useAppDispatch } from '@respond/lib/client/store';
 import { ActivityActions } from '@respond/lib/state';
-import { CommunicationsLogEntry } from '@respond/types/activity';
+import { CommunicationsLogEntry } from '@respond/types/operations';
 
 import { useActivityContext } from '../activities/ActivityProvider';
 

--- a/src/components/dashboard/DashboardCommsComposer.tsx
+++ b/src/components/dashboard/DashboardCommsComposer.tsx
@@ -1,5 +1,6 @@
 import { Box, Button, Stack, TextField } from '@mui/material';
 import { alpha } from '@mui/material/styles';
+import { useEffect, useRef } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { v4 as uuid } from 'uuid';
 
@@ -18,6 +19,7 @@ type FormValues = {
 export function DashboardCommsComposer({ entry, onSave, onCancel }: { entry?: CommunicationsLogEntry | null; onSave?: () => void; onCancel?: () => void }) {
   const dispatch = useAppDispatch();
   const activity = useActivityContext();
+  const fromRef = useRef<HTMLInputElement | null>(null);
 
   const { register, handleSubmit, reset, formState } = useForm<FormValues>({
     defaultValues: {
@@ -26,6 +28,12 @@ export function DashboardCommsComposer({ entry, onSave, onCancel }: { entry?: Co
       message: entry?.message ?? '',
     },
   });
+
+  useEffect(() => {
+    if (!entry) {
+      fromRef.current?.focus();
+    }
+  }, [entry]);
 
   const submit: SubmitHandler<FormValues> = (values) => {
     if (entry && entry.id) {
@@ -51,7 +59,11 @@ export function DashboardCommsComposer({ entry, onSave, onCancel }: { entry?: Co
       onSave?.();
     }
 
-    reset({ from: 'Ops', to: 'All Teams', message: '' });
+    reset({ from: '', to: '', message: '' });
+
+    if (!entry) {
+      fromRef.current?.focus();
+    }
   };
 
   return (
@@ -59,10 +71,24 @@ export function DashboardCommsComposer({ entry, onSave, onCancel }: { entry?: Co
       <form onSubmit={handleSubmit(submit)}>
         <Stack spacing={2}>
           <Stack direction={{ xl: 'row' }} alignItems={{ xs: 'stretch', xl: 'center' }} gap={2}>
-            <TextField label="From" size="small" {...register('from')} />
+            <TextField label="From" size="small" inputRef={fromRef} {...register('from')} />
             <TextField label="To" size="small" {...register('to')} />
           </Stack>
-          <TextField label="Message" size="small" multiline minRows={2} {...register('message', { required: true })} error={!!formState.errors.message} helperText={formState.errors.message ? 'Message is required' : ''} />
+          <TextField
+            label="Message"
+            size="small"
+            multiline
+            minRows={2}
+            {...register('message', { required: true })}
+            error={!!formState.errors.message}
+            helperText={formState.errors.message ? 'Message is required' : ''}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' && !event.shiftKey) {
+                event.preventDefault();
+                handleSubmit(submit)();
+              }
+            }}
+          />
           <Stack direction="row" spacing={1} alignItems="center" justifyContent="flex-end">
             {entry && (
               <Button

--- a/src/components/dashboard/DashboardCommsFavoriteToggleButton.tsx
+++ b/src/components/dashboard/DashboardCommsFavoriteToggleButton.tsx
@@ -1,0 +1,32 @@
+import StarIcon from '@mui/icons-material/Star';
+import { IconButton, Tooltip } from '@mui/material';
+import React, { useState } from 'react';
+
+export function CommsFavoriteToggleButton({ onChange }: { onChange: (isSelected: boolean) => void }): JSX.Element {
+  const [selected, setSelected] = useState<boolean>(false);
+
+  const handleToggle = (): void => {
+    const nextState = !selected;
+    setSelected(nextState);
+    onChange(nextState);
+  };
+
+  return (
+    <Tooltip title={selected ? 'Show all messages' : 'Show favorites only'}>
+      <IconButton
+        color={selected ? 'primary' : 'default'}
+        aria-label={selected ? 'Show all messages' : 'Show favorites only'}
+        onClick={handleToggle}
+        sx={{
+          width: 32,
+          height: 32,
+          borderRadius: 1,
+          border: '1px solid',
+          borderColor: selected ? 'primary.main' : 'divider',
+        }}
+      >
+        <StarIcon fontSize="small" />
+      </IconButton>
+    </Tooltip>
+  );
+}

--- a/src/components/dashboard/DashboardCommsManager.tsx
+++ b/src/components/dashboard/DashboardCommsManager.tsx
@@ -1,0 +1,133 @@
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import EditIcon from '@mui/icons-material/Edit';
+import StarIcon from '@mui/icons-material/Star';
+import StarBorderIcon from '@mui/icons-material/StarBorder';
+import { Box, IconButton, Paper, Typography } from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import { useMemo, useState } from 'react';
+
+import { useAppDispatch } from '@respond/lib/client/store';
+import { ActivityActions } from '@respond/lib/state';
+import { CommunicationsLogEntry } from '@respond/types/activity';
+
+import { useActivityContext } from '../activities/ActivityProvider';
+import CopyChip from '../CopyChip';
+import { Stack } from '../Material';
+
+import { DashboardCommsComposer } from './DashboardCommsComposer';
+import { DashboardSearchBox } from './DashboardSearchBox';
+
+function format24HourTime(value: number) {
+  return new Intl.DateTimeFormat('en-GB', { hour: '2-digit', minute: '2-digit', hour12: false }).format(value);
+}
+
+const decimalDegrees = new RegExp('(\\d){1,3}\\.(\\d)*\\s*[,]?\\s*[+-]?(\\d){1,3}\\.(\\d)*', 'g');
+const utmCoordinates = new RegExp('(\\d){1,2}([a-zA-Z]){1}\\s(\\d)*([EW])?\\s(\\d)*([NS])?', 'g');
+
+const parseValues = (value: string): string[] => {
+  const matches = new Set<string>();
+
+  for (const regex of [decimalDegrees, utmCoordinates]) {
+    regex.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(value)) !== null) {
+      matches.add(match[0]);
+    }
+  }
+
+  return Array.from(matches);
+};
+
+export function DashboardCommsManager() {
+  const dispatch = useAppDispatch();
+  const activity = useActivityContext();
+
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  const visibleCommunications = useMemo(() => (activity.comms ?? []).filter((entry) => !entry.isDeleted), [activity]);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const filteredCommunications = useMemo(() => {
+    const q = (searchQuery || '').trim().toLowerCase();
+    if (!q) return visibleCommunications;
+    return visibleCommunications.filter((entry) => {
+      const msg = (entry.message || '').toLowerCase();
+      const from = (entry.from || '').toLowerCase();
+      const to = (entry.to || '').toLowerCase();
+      return msg.includes(q) || from.includes(q) || to.includes(q);
+    });
+  }, [visibleCommunications, searchQuery]);
+
+  const toggleFavorite = (entry: CommunicationsLogEntry) => {
+    const updates: Partial<CommunicationsLogEntry> = {
+      isFavorite: !entry.isFavorite,
+    };
+    dispatch(ActivityActions.updateComm(activity.id, entry.id, updates));
+  };
+
+  const deleteEntry = (id: string) => {
+    const updates: Partial<CommunicationsLogEntry> = {
+      isDeleted: true,
+    };
+    dispatch(ActivityActions.updateComm(activity.id, id, updates));
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, width: '100%' }}>
+      <DashboardSearchBox onChange={setSearchQuery} sx={{ mb: 2 }} />
+      <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2, p: 0.5, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 1, minHeight: 0, width: '100%' }}>
+        {filteredCommunications.length === 0 ? (
+          <Box sx={{ flex: 1, minHeight: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Typography variant="body2" color="text.secondary" textAlign="center">
+              No communications logged yet.
+            </Typography>
+          </Box>
+        ) : (
+          filteredCommunications.map((entry) => (
+            <Paper key={entry.id} variant="outlined" sx={{ p: 1, bgcolor: entry.isFavorite ? (theme) => alpha(theme.palette.info.main, 0.08) : undefined }}>
+              {editingId === entry.id ? <DashboardCommsComposer entry={entry} onSave={() => setEditingId(null)} onCancel={() => setEditingId(null)} /> : <DashboardCommsEntry entry={entry} onEdit={() => setEditingId(entry.id)} onFavorite={() => toggleFavorite(entry)} onDelete={() => deleteEntry(entry.id)} />}
+            </Paper>
+          ))
+        )}
+      </Box>
+      <DashboardCommsComposer />
+    </Box>
+  );
+}
+
+function DashboardCommsEntry({ entry, onEdit, onFavorite, onDelete }: { entry: CommunicationsLogEntry; onEdit: () => void; onFavorite: () => void; onDelete: () => void }) {
+  const copyValues = parseValues(entry.message);
+  return (
+    <Box sx={{ '&:hover .comm-action': { opacity: 1, visibility: 'visible' } }}>
+      <Stack direction="row" justifyContent="space-between" alignItems="center">
+        <Typography variant="subtitle2">
+          {entry.from} → {entry.to}
+        </Typography>
+        <Stack direction="row" alignItems="center" spacing={1}>
+          {entry.isFavorite ? (
+            <IconButton className="comm-action" onClick={onFavorite} size="small" aria-label="edit communication" sx={{ opacity: 0, visibility: 'hidden', transition: 'opacity 180ms ease' }}>
+              <StarIcon sx={{ fontSize: 16, color: '#d89e00' }} />
+            </IconButton>
+          ) : (
+            <IconButton className="comm-action" onClick={onFavorite} size="small" aria-label="edit communication" sx={{ opacity: 0, visibility: 'hidden', transition: 'opacity 180ms ease' }}>
+              <StarBorderIcon sx={{ fontSize: 16 }} />
+            </IconButton>
+          )}
+          <IconButton className="comm-action" onClick={onEdit} size="small" aria-label="edit communication" sx={{ opacity: 0, visibility: 'hidden', transition: 'opacity 180ms ease' }}>
+            <EditIcon sx={{ fontSize: 16 }} />
+          </IconButton>
+          <IconButton className="comm-action" onClick={onDelete} size="small" aria-label="delete communication" sx={{ opacity: 0, visibility: 'hidden', transition: 'opacity 180ms ease' }}>
+            <DeleteOutlineIcon sx={{ fontSize: 16, color: 'darkred' }} />
+          </IconButton>
+          <Typography variant="caption" color="text.secondary" sx={{ px: 0.5 }}>
+            {format24HourTime(entry.timestamp)}
+          </Typography>
+        </Stack>
+      </Stack>
+      <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+        {entry.message}
+      </Typography>
+      {!!copyValues.length && copyValues.map((value) => <CopyChip key={value} value={value} size="small" variant="outlined" sx={{ mt: 1 }} />)}
+    </Box>
+  );
+}

--- a/src/components/dashboard/DashboardCommsManager.tsx
+++ b/src/components/dashboard/DashboardCommsManager.tsx
@@ -8,7 +8,7 @@ import { useMemo, useState } from 'react';
 
 import { useAppDispatch } from '@respond/lib/client/store';
 import { ActivityActions } from '@respond/lib/state';
-import { CommunicationsLogEntry } from '@respond/types/activity';
+import { CommunicationsLogEntry } from '@respond/types/operations';
 
 import { useActivityContext } from '../activities/ActivityProvider';
 import CopyChip from '../CopyChip';

--- a/src/components/dashboard/DashboardCommsManager.tsx
+++ b/src/components/dashboard/DashboardCommsManager.tsx
@@ -15,6 +15,7 @@ import CopyChip from '../CopyChip';
 import { Stack } from '../Material';
 
 import { DashboardCommsComposer } from './DashboardCommsComposer';
+import { CommsFavoriteToggleButton } from './DashboardCommsFavoriteToggleButton';
 import { DashboardSearchBox } from './DashboardSearchBox';
 
 function format24HourTime(value: number) {
@@ -44,8 +45,10 @@ export function DashboardCommsManager() {
 
   const [editingId, setEditingId] = useState<string | null>(null);
 
-  const visibleCommunications = useMemo(() => (activity.comms ?? []).filter((entry) => !entry.isDeleted), [activity]);
   const [searchQuery, setSearchQuery] = useState('');
+  const [showFavorites, setShowFavorites] = useState(false);
+
+  const visibleCommunications = useMemo(() => (activity.comms ?? []).filter((entry) => !entry.isDeleted && (!showFavorites || entry.isFavorite)), [activity, showFavorites]);
 
   const filteredCommunications = useMemo(() => {
     const q = (searchQuery || '').trim().toLowerCase();
@@ -74,7 +77,10 @@ export function DashboardCommsManager() {
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, width: '100%' }}>
-      <DashboardSearchBox onChange={setSearchQuery} placeholder="Search messages, to, or from..." sx={{ mb: 2 }} />
+      <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
+        <DashboardSearchBox onChange={setSearchQuery} placeholder="Search messages, to, or from..." sx={{ flex: 1 }} />
+        <CommsFavoriteToggleButton onChange={(isSelected) => setShowFavorites(isSelected)} />
+      </Stack>
       <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2, p: 0.5, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 1, minHeight: 0, width: '100%' }}>
         {filteredCommunications.length === 0 ? (
           <Box sx={{ flex: 1, minHeight: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>

--- a/src/components/dashboard/DashboardCommsManager.tsx
+++ b/src/components/dashboard/DashboardCommsManager.tsx
@@ -74,7 +74,7 @@ export function DashboardCommsManager() {
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, width: '100%' }}>
-      <DashboardSearchBox onChange={setSearchQuery} sx={{ mb: 2 }} />
+      <DashboardSearchBox onChange={setSearchQuery} placeholder="Search messages, to, or from..." sx={{ mb: 2 }} />
       <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2, p: 0.5, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 1, minHeight: 0, width: '100%' }}>
         {filteredCommunications.length === 0 ? (
           <Box sx={{ flex: 1, minHeight: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>

--- a/src/components/dashboard/DashboardCommsManager.tsx
+++ b/src/components/dashboard/DashboardCommsManager.tsx
@@ -14,6 +14,7 @@ import { useActivityContext } from '../activities/ActivityProvider';
 import { CopyChip } from '../CopyChip';
 import { Stack } from '../Material';
 
+import { CommsAutomatedToggleButton } from './DashboardCommsAutomatedToggleButton';
 import { DashboardCommsComposer } from './DashboardCommsComposer';
 import { CommsFavoriteToggleButton } from './DashboardCommsFavoriteToggleButton';
 import { DashboardSearchBox } from './DashboardSearchBox';
@@ -47,8 +48,9 @@ export function DashboardCommsManager() {
 
   const [searchQuery, setSearchQuery] = useState('');
   const [showFavorites, setShowFavorites] = useState(false);
+  const [hideAutomated, setHideAutomated] = useState(false);
 
-  const visibleCommunications = useMemo(() => (activity.comms ?? []).filter((entry) => !entry.isDeleted && (!showFavorites || entry.isFavorite)), [activity, showFavorites]);
+  const visibleCommunications = useMemo(() => (activity.comms ?? []).filter((entry) => !entry.isDeleted && (!showFavorites || entry.isFavorite) && (!hideAutomated || !entry.isAutomated)), [activity, showFavorites, hideAutomated]);
 
   const filteredCommunications = useMemo(() => {
     const q = (searchQuery || '').trim().toLowerCase();
@@ -79,6 +81,7 @@ export function DashboardCommsManager() {
     <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, width: '100%' }}>
       <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
         <DashboardSearchBox onChange={setSearchQuery} placeholder="Search messages, to, or from..." sx={{ flex: 1 }} />
+        <CommsAutomatedToggleButton onChange={setHideAutomated} />
         <CommsFavoriteToggleButton onChange={(isSelected) => setShowFavorites(isSelected)} />
       </Stack>
       <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2, p: 0.5, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 1, minHeight: 0, width: '100%' }}>

--- a/src/components/dashboard/DashboardCommsManager.tsx
+++ b/src/components/dashboard/DashboardCommsManager.tsx
@@ -11,7 +11,7 @@ import { ActivityActions } from '@respond/lib/state';
 import { CommunicationsLogEntry } from '@respond/types/operations';
 
 import { useActivityContext } from '../activities/ActivityProvider';
-import CopyChip from '../CopyChip';
+import { CopyChip } from '../CopyChip';
 import { Stack } from '../Material';
 
 import { DashboardCommsComposer } from './DashboardCommsComposer';

--- a/src/components/dashboard/DashboardCommsManager.tsx
+++ b/src/components/dashboard/DashboardCommsManager.tsx
@@ -11,12 +11,12 @@ import { ActivityActions } from '@respond/lib/state';
 import { CommunicationsLogEntry } from '@respond/types/operations';
 
 import { useActivityContext } from '../activities/ActivityProvider';
-import { CopyChip } from '../CopyChip';
 import { Stack } from '../Material';
 
 import { CommsAutomatedToggleButton } from './DashboardCommsAutomatedToggleButton';
 import { DashboardCommsComposer } from './DashboardCommsComposer';
 import { CommsFavoriteToggleButton } from './DashboardCommsFavoriteToggleButton';
+import { DashboardCopyChip } from './DashboardCopyChip';
 import { DashboardSearchBox } from './DashboardSearchBox';
 
 function format24HourTime(value: number) {
@@ -136,7 +136,7 @@ function DashboardCommsEntry({ entry, onEdit, onFavorite, onDelete }: { entry: C
       <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
         {entry.message}
       </Typography>
-      {!!copyValues.length && copyValues.map((value) => <CopyChip key={value} value={value} size="small" variant="outlined" sx={{ mt: 1 }} />)}
+      {!!copyValues.length && copyValues.map((value) => <DashboardCopyChip key={value} value={value} />)}
     </Box>
   );
 }

--- a/src/components/dashboard/DashboardCopyChip.tsx
+++ b/src/components/dashboard/DashboardCopyChip.tsx
@@ -1,0 +1,24 @@
+import { CopyChip } from '../CopyChip';
+
+export function DashboardCopyChip({ value }: { value: string }) {
+  return (
+    <CopyChip
+      value={value}
+      size="small"
+      variant="outlined"
+      sx={{
+        mt: 1,
+        boxShadow: '0 1px 2px rgba(16,24,40,0.06)',
+        transition: 'transform 120ms ease, box-shadow 120ms ease, border-color 120ms ease, background-color 120ms ease',
+        ':hover': {
+          bgcolor: 'grey.50',
+          borderColor: 'primary.light',
+          boxShadow: '0 6px 14px rgba(16,24,40,0.12)',
+          '& .drag-handle': {
+            opacity: 0.9,
+          },
+        },
+      }}
+    />
+  );
+}

--- a/src/components/dashboard/DashboardDividedSection.tsx
+++ b/src/components/dashboard/DashboardDividedSection.tsx
@@ -1,0 +1,12 @@
+import { Stack, Typography } from '@mui/material';
+
+export function DashboardDividedSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <Stack spacing={0.75} sx={{ mt: 1, pt: 1, borderTop: '1px solid', borderColor: 'divider' }}>
+      <Typography variant="caption" color="text.secondary">
+        {title}
+      </Typography>
+      {children}
+    </Stack>
+  );
+}

--- a/src/components/dashboard/DashboardDraggableContainer.tsx
+++ b/src/components/dashboard/DashboardDraggableContainer.tsx
@@ -1,0 +1,50 @@
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
+import { Box, SxProps, Theme } from '@mui/material';
+import { ReactNode } from 'react';
+
+type DashboardDraggableContainerProps = {
+  children: ReactNode;
+  sx?: SxProps<Theme>;
+  showHandle?: boolean;
+  variant?: 'standard' | 'compact';
+};
+
+export function DashboardDraggableContainer({ children, sx, showHandle = true, variant = 'standard' }: DashboardDraggableContainerProps) {
+  const isCompact = variant === 'compact';
+
+  return (
+    <Box
+      sx={[
+        {
+          position: 'relative',
+          border: '1px solid',
+          borderColor: 'divider',
+          borderRadius: 2,
+          py: isCompact ? 0.75 : 1,
+          pr: 1,
+          pl: showHandle ? (isCompact ? 3 : 3.25) : 1,
+          cursor: 'grab',
+          bgcolor: 'background.paper',
+          boxShadow: '0 1px 2px rgba(16,24,40,0.06)',
+          transition: 'transform 120ms ease, box-shadow 120ms ease, border-color 120ms ease, background-color 120ms ease',
+          ':hover': {
+            bgcolor: 'grey.50',
+            borderColor: 'primary.light',
+            boxShadow: '0 6px 14px rgba(16,24,40,0.12)',
+            '& .drag-handle': {
+              opacity: 0.9,
+            },
+          },
+          ':active': {
+            cursor: 'grabbing',
+            transform: 'scale(0.995)',
+          },
+        },
+        ...(Array.isArray(sx) ? sx : sx ? [sx] : []),
+      ]}
+    >
+      {showHandle && <DragIndicatorIcon className="drag-handle" sx={{ position: 'absolute', left: 8, top: '50%', transform: 'translateY(-50%)', fontSize: isCompact ? 14 : 16, color: 'text.secondary', opacity: 0.55 }} />}
+      {children}
+    </Box>
+  );
+}

--- a/src/components/dashboard/DashboardEquipmentCreateDialog.tsx
+++ b/src/components/dashboard/DashboardEquipmentCreateDialog.tsx
@@ -1,0 +1,61 @@
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Stack, TextField } from '@mui/material';
+import { Controller, useForm } from 'react-hook-form';
+
+type FormValues = {
+  name: string;
+};
+
+export function DashboardEquipmentCreateDialog({ onSave, onCancel }: { onSave: (name: string) => void; onCancel: () => void }) {
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    defaultValues: { name: '' },
+    mode: 'onSubmit',
+  });
+
+  const onSubmit = ({ name }: FormValues) => {
+    onSave(name.trim());
+  };
+
+  return (
+    <Dialog open onClose={onCancel} maxWidth="sm" fullWidth>
+      <DialogTitle>Add Custom Equipment</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <Controller
+            name="name"
+            control={control}
+            rules={{ required: 'Name is required' }}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                label="Equipment Name"
+                fullWidth
+                required
+                autoFocus
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault();
+                    handleSubmit(onSubmit)();
+                  }
+                }}
+                error={!!errors.name}
+                helperText={errors.name?.message}
+              />
+            )}
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onCancel} color="primary">
+          Cancel
+        </Button>
+        <Button onClick={handleSubmit(onSubmit)} color="primary" variant="contained">
+          Add
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/dashboard/DashboardEquipmentGroupByMenu.tsx
+++ b/src/components/dashboard/DashboardEquipmentGroupByMenu.tsx
@@ -1,0 +1,34 @@
+import CategoryIcon from '@mui/icons-material/Category';
+import { IconButton, Tooltip } from '@mui/material';
+import React, { useState } from 'react';
+
+export type EquipmentGrouping = 'All' | 'Type';
+
+export default function GroupToggleButton({ onChange }: { onChange: (grouping: EquipmentGrouping) => void }): JSX.Element {
+  const [selected, setSelected] = useState<EquipmentGrouping>('All');
+
+  const handleToggle = (): void => {
+    const nextValue: EquipmentGrouping = selected === 'All' ? 'Type' : 'All';
+    setSelected(nextValue);
+    onChange(nextValue);
+  };
+
+  return (
+    <Tooltip title={`Group by: ${selected}`}>
+      <IconButton
+        color={selected === 'Type' ? 'primary' : 'default'}
+        aria-label={`Group by ${selected === 'All' ? 'Type' : 'All'}`}
+        onClick={handleToggle}
+        sx={{
+          width: 32,
+          height: 32,
+          borderRadius: 1, // Change to 0 for completely sharp 90° corners
+          border: '1px solid',
+          borderColor: selected === 'Type' ? 'primary.main' : 'divider',
+        }}
+      >
+        <CategoryIcon fontSize="small" />
+      </IconButton>
+    </Tooltip>
+  );
+}

--- a/src/components/dashboard/DashboardEquipmentGroupToggleButton.tsx
+++ b/src/components/dashboard/DashboardEquipmentGroupToggleButton.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 
 export type EquipmentGrouping = 'All' | 'Type';
 
-export default function GroupToggleButton({ onChange }: { onChange: (grouping: EquipmentGrouping) => void }): JSX.Element {
+export function EquipmentGroupToggleButton({ onChange }: { onChange: (grouping: EquipmentGrouping) => void }): JSX.Element {
   const [selected, setSelected] = useState<EquipmentGrouping>('All');
 
   const handleToggle = (): void => {

--- a/src/components/dashboard/DashboardEquipmentGroupToggleButton.tsx
+++ b/src/components/dashboard/DashboardEquipmentGroupToggleButton.tsx
@@ -5,7 +5,7 @@ import React, { useState } from 'react';
 export type EquipmentGrouping = 'All' | 'Type';
 
 export function EquipmentGroupToggleButton({ onChange }: { onChange: (grouping: EquipmentGrouping) => void }): JSX.Element {
-  const [selected, setSelected] = useState<EquipmentGrouping>('All');
+  const [selected, setSelected] = useState<EquipmentGrouping>('Type');
 
   const handleToggle = (): void => {
     const nextValue: EquipmentGrouping = selected === 'All' ? 'Type' : 'All';

--- a/src/components/dashboard/DashboardEquipmentManager.tsx
+++ b/src/components/dashboard/DashboardEquipmentManager.tsx
@@ -7,6 +7,7 @@ import { EquipmentItem } from '@respond/types/operations';
 import { Draggable, Droppable } from '../DragAndDrop/DnDComponents';
 
 import { DashboardBoxWithTitle } from './DashboardBoxWithTitle';
+import { DashboardDraggableContainer } from './DashboardDraggableContainer';
 import { EquipmentGrouping, EquipmentGroupToggleButton } from './DashboardEquipmentGroupToggleButton';
 import { DashboardSearchBox } from './DashboardSearchBox';
 
@@ -98,31 +99,14 @@ export function DashboardEquipmentManager() {
 
 function EquipmentTile({ item }: { item: EquipmentItem }) {
   return (
-    <Box
-      sx={{
-        border: '1px solid',
-        borderColor: 'divider',
-        borderRadius: 2,
-        p: 1,
-        cursor: 'grab',
-        bgcolor: 'background.paper',
-        ':hover': {
-          bgcolor: 'grey.100',
-          // Targets the child element with class 'promote-button' when Stack is hovered
-          '& .promote-button': {
-            opacity: 1,
-            visibility: 'visible',
-          },
-        },
-      }}
-    >
+    <DashboardDraggableContainer variant="compact">
       <Stack direction="row" justifyContent="space-between">
         <Typography variant="subtitle2">{item.name}</Typography>
         <Typography variant="caption" color="text.secondary">
           {item.type}
         </Typography>
       </Stack>
-    </Box>
+    </DashboardDraggableContainer>
   );
 }
 

--- a/src/components/dashboard/DashboardEquipmentManager.tsx
+++ b/src/components/dashboard/DashboardEquipmentManager.tsx
@@ -78,20 +78,13 @@ export function DashboardEquipmentManager() {
     }, {});
   }, [filteredEquipment]);
 
-  const returnEquipment = (equipment: EquipmentItem) => {
-    // Remove from the previous team, if any
-    // TODO: need actions to club these updates into a single activity transaction
-    activity.teams.forEach((team) => {
-      if (team.assignedEquipment.some((item) => item.uuid === equipment.uuid)) {
-        // Remove the participant from the team
-        const updatedTeam = { ...team, assignedEquipment: team.assignedEquipment.filter((item) => item.uuid !== equipment.uuid) };
-        dispatch(ActivityActions.updateTeam(activity.id, updatedTeam));
-      }
-    });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handleDrop = (item: any, type: string, callback?: () => void) => {
+    callback?.();
   };
 
   return (
-    <Droppable accepts="equipment" onDrop={returnEquipment} grow>
+    <Droppable accepts="equipment" onDrop={handleDrop} grow>
       <Stack spacing={2} sx={{ overflow: 'auto' }}>
         <Stack direction="row" spacing={1}>
           <DashboardSearchBox onChange={setSearchQuery} />
@@ -105,33 +98,31 @@ export function DashboardEquipmentManager() {
 
 function EquipmentTile({ item }: { item: EquipmentItem }) {
   return (
-    <Draggable type="equipment" item={checkOutEquipmentItem(item)}>
-      <Box
-        sx={{
-          border: '1px solid',
-          borderColor: 'divider',
-          borderRadius: 2,
-          p: 1,
-          cursor: 'grab',
-          bgcolor: 'background.paper',
-          ':hover': {
-            bgcolor: 'grey.100',
-            // Targets the child element with class 'promote-button' when Stack is hovered
-            '& .promote-button': {
-              opacity: 1,
-              visibility: 'visible',
-            },
+    <Box
+      sx={{
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 2,
+        p: 1,
+        cursor: 'grab',
+        bgcolor: 'background.paper',
+        ':hover': {
+          bgcolor: 'grey.100',
+          // Targets the child element with class 'promote-button' when Stack is hovered
+          '& .promote-button': {
+            opacity: 1,
+            visibility: 'visible',
           },
-        }}
-      >
-        <Stack direction="row" justifyContent="space-between">
-          <Typography variant="subtitle2">{item.name}</Typography>
-          <Typography variant="caption" color="text.secondary">
-            {item.type}
-          </Typography>
-        </Stack>
-      </Box>
-    </Draggable>
+        },
+      }}
+    >
+      <Stack direction="row" justifyContent="space-between">
+        <Typography variant="subtitle2">{item.name}</Typography>
+        <Typography variant="caption" color="text.secondary">
+          {item.type}
+        </Typography>
+      </Stack>
+    </Box>
   );
 }
 
@@ -139,7 +130,9 @@ function EquipmentAphabetical({ items }: { items: EquipmentItem[] }) {
   return (
     <>
       {items.map((item) => (
-        <EquipmentTile key={item.id} item={item} />
+        <Draggable type="equipment" item={checkOutEquipmentItem(item)}>
+          <EquipmentTile key={item.id} item={item} />
+        </Draggable>
       ))}
     </>
   );
@@ -149,10 +142,12 @@ function EquipmentGroups({ groups }: { groups: GroupedInventory }) {
   return (
     <>
       {Object.entries(groups).map(([groupName, list]) => (
-        <DashboardBoxWithTitle key={groupName} title={groupName} sx={{ p: 1 }} collapsible>
+        <DashboardBoxWithTitle key={groupName} title={groupName} collapsible>
           <Stack spacing={0.5}>
             {list.map((item) => (
-              <EquipmentTile key={item.id} item={item} />
+              <Draggable type="equipment" item={checkOutEquipmentItem(item)}>
+                <EquipmentTile key={item.id} item={item} />
+              </Draggable>
             ))}
           </Stack>
         </DashboardBoxWithTitle>

--- a/src/components/dashboard/DashboardEquipmentManager.tsx
+++ b/src/components/dashboard/DashboardEquipmentManager.tsx
@@ -4,7 +4,7 @@ import { v4 as uuid } from 'uuid';
 
 import { useAppDispatch } from '@respond/lib/client/store';
 import { ActivityActions } from '@respond/lib/state';
-import { EquipmentItem } from '@respond/types/team';
+import { EquipmentItem } from '@respond/types/operations';
 
 import { useActivityContext } from '../activities/ActivityProvider';
 import { Draggable, Droppable } from '../DragAndDrop/DnDComponents';

--- a/src/components/dashboard/DashboardEquipmentManager.tsx
+++ b/src/components/dashboard/DashboardEquipmentManager.tsx
@@ -9,7 +9,7 @@ import { EquipmentItem } from '@respond/types/team';
 import { useActivityContext } from '../activities/ActivityProvider';
 import { Draggable, Droppable } from '../DragAndDrop/DnDComponents';
 
-import SortMenuButton, { EquipmentGrouping } from './DashboardEquipmentGroupByMenu';
+import { EquipmentGrouping, EquipmentGroupToggleButton } from './DashboardEquipmentGroupToggleButton';
 import { DashboardSearchBox } from './DashboardSearchBox';
 
 const inventory = [
@@ -92,9 +92,9 @@ export function DashboardEquipmentManager() {
   return (
     <Droppable accepts="equipment" onDrop={returnEquipment} grow>
       <Stack spacing={2} sx={{ overflow: 'auto' }}>
-        <Stack direction="row" spacing={2}>
+        <Stack direction="row" spacing={1}>
           <DashboardSearchBox onChange={setSearchQuery} />
-          <SortMenuButton onChange={(value) => setGroupBy(value)} />
+          <EquipmentGroupToggleButton onChange={(value) => setGroupBy(value)} />
         </Stack>
         <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 1, pr: 0.5 }}>{groupBy === 'All' ? <EquipmentAphabetical items={filteredEquipment} /> : <EquipmentGroups groups={groupedEquipment} />}</Box>
       </Stack>

--- a/src/components/dashboard/DashboardEquipmentManager.tsx
+++ b/src/components/dashboard/DashboardEquipmentManager.tsx
@@ -48,6 +48,7 @@ const inventory = [
   { id: 'inventory-34', type: 'Medical', name: 'A.E.D - Basic' },
   { id: 'inventory-35', type: 'Medical', name: 'A.E.D - EMT' },
   { id: 'inventory-36', type: 'Medical', name: 'Backboard' },
+  { id: 'inventory-37', type: 'Rigging', name: 'Bolt Kit' },
 ].sort((a, b) => a.name.localeCompare(b.name));
 
 const checkOutEquipmentItem = (item: EquipmentItem): EquipmentItem => {
@@ -58,7 +59,7 @@ type GroupedInventory = Record<string, EquipmentItem[]>;
 
 export function DashboardEquipmentManager() {
   const [searchQuery, setSearchQuery] = useState('');
-  const [groupBy, setGroupBy] = useState<EquipmentGrouping>('All');
+  const [groupBy, setGroupBy] = useState<EquipmentGrouping>('Type');
 
   const filteredEquipment = useMemo(() => {
     const q = (searchQuery || '').trim().toLowerCase();

--- a/src/components/dashboard/DashboardEquipmentManager.tsx
+++ b/src/components/dashboard/DashboardEquipmentManager.tsx
@@ -74,8 +74,8 @@ export function DashboardEquipmentManager() {
 
   return (
     <Droppable accepts="equipment" onDrop={returnEquipment} grow>
+      <DashboardSearchBox onChange={setSearchQuery} sx={{ mb: 2 }} />
       <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 1 }}>
-        <DashboardSearchBox onChange={setSearchQuery} sx={{ mb: 1 }} />
         {filteredEquipment.map((item) => (
           <Draggable key={item.id} type="equipment" item={checkOutEquipmentItem(item)}>
             <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2, p: 1, cursor: 'grab', bgcolor: 'background.paper' }}>

--- a/src/components/dashboard/DashboardEquipmentManager.tsx
+++ b/src/components/dashboard/DashboardEquipmentManager.tsx
@@ -46,7 +46,8 @@ const inventory = [
   { id: 'inventory-32', type: 'Medical', name: 'SAM Splint' },
   { id: 'inventory-33', type: 'General', name: 'Webbing' },
   { id: 'inventory-34', type: 'Medical', name: 'A.E.D - Basic' },
-  { id: 'inventory-34', type: 'Medical', name: 'A.E.D - EMT' },
+  { id: 'inventory-35', type: 'Medical', name: 'A.E.D - EMT' },
+  { id: 'inventory-36', type: 'Medical', name: 'Backboard' },
 ].sort((a, b) => a.name.localeCompare(b.name));
 
 const checkOutEquipmentItem = (item: EquipmentItem): EquipmentItem => {

--- a/src/components/dashboard/DashboardEquipmentManager.tsx
+++ b/src/components/dashboard/DashboardEquipmentManager.tsx
@@ -9,6 +9,7 @@ import { EquipmentItem } from '@respond/types/team';
 import { useActivityContext } from '../activities/ActivityProvider';
 import { Draggable, Droppable } from '../DragAndDrop/DnDComponents';
 
+import { DashboardBoxWithTitle } from './DashboardBoxWithTitle';
 import { EquipmentGrouping, EquipmentGroupToggleButton } from './DashboardEquipmentGroupToggleButton';
 import { DashboardSearchBox } from './DashboardSearchBox';
 
@@ -148,14 +149,13 @@ function EquipmentGroups({ groups }: { groups: GroupedInventory }) {
   return (
     <>
       {Object.entries(groups).map(([groupName, list]) => (
-        <Stack key={groupName} spacing={0.5}>
-          <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
-            {groupName}
-          </Typography>
-          {list.map((item) => (
-            <EquipmentTile key={item.id} item={item} />
-          ))}
-        </Stack>
+        <DashboardBoxWithTitle key={groupName} title={groupName} sx={{ p: 1 }} collapsible>
+          <Stack spacing={0.5}>
+            {list.map((item) => (
+              <EquipmentTile key={item.id} item={item} />
+            ))}
+          </Stack>
+        </DashboardBoxWithTitle>
       ))}
     </>
   );

--- a/src/components/dashboard/DashboardEquipmentManager.tsx
+++ b/src/components/dashboard/DashboardEquipmentManager.tsx
@@ -124,7 +124,7 @@ function EquipmentAphabetical({ items }: { items: EquipmentItem[] }) {
   return (
     <>
       {items.map((item) => (
-        <Draggable key={item.uuid} type="equipment" item={checkOutEquipmentItem(item)}>
+        <Draggable key={item.id} type="equipment" item={checkOutEquipmentItem(item)}>
           <EquipmentTile item={item} />
         </Draggable>
       ))}
@@ -139,7 +139,7 @@ function EquipmentGroups({ groups }: { groups: GroupedInventory }) {
         <DashboardBoxWithTitle key={groupName} title={groupName} collapsible>
           <Stack spacing={0.5}>
             {list.map((item) => (
-              <Draggable key={item.uuid} type="equipment" item={checkOutEquipmentItem(item)}>
+              <Draggable key={item.id} type="equipment" item={checkOutEquipmentItem(item)}>
                 <EquipmentTile item={item} />
               </Draggable>
             ))}

--- a/src/components/dashboard/DashboardEquipmentManager.tsx
+++ b/src/components/dashboard/DashboardEquipmentManager.tsx
@@ -2,11 +2,8 @@ import { Box, Stack, Typography } from '@mui/material';
 import { useMemo, useState } from 'react';
 import { v4 as uuid } from 'uuid';
 
-import { useAppDispatch } from '@respond/lib/client/store';
-import { ActivityActions } from '@respond/lib/state';
 import { EquipmentItem } from '@respond/types/operations';
 
-import { useActivityContext } from '../activities/ActivityProvider';
 import { Draggable, Droppable } from '../DragAndDrop/DnDComponents';
 
 import { DashboardBoxWithTitle } from './DashboardBoxWithTitle';
@@ -52,11 +49,8 @@ const checkOutEquipmentItem = (item: EquipmentItem): EquipmentItem => {
 type GroupedInventory = Record<string, EquipmentItem[]>;
 
 export function DashboardEquipmentManager() {
-  const dispatch = useAppDispatch();
   const [searchQuery, setSearchQuery] = useState('');
   const [groupBy, setGroupBy] = useState<EquipmentGrouping>('All');
-
-  const activity = useActivityContext();
 
   const filteredEquipment = useMemo(() => {
     const q = (searchQuery || '').trim().toLowerCase();
@@ -130,8 +124,8 @@ function EquipmentAphabetical({ items }: { items: EquipmentItem[] }) {
   return (
     <>
       {items.map((item) => (
-        <Draggable type="equipment" item={checkOutEquipmentItem(item)}>
-          <EquipmentTile key={item.id} item={item} />
+        <Draggable key={item.uuid} type="equipment" item={checkOutEquipmentItem(item)}>
+          <EquipmentTile item={item} />
         </Draggable>
       ))}
     </>
@@ -145,8 +139,8 @@ function EquipmentGroups({ groups }: { groups: GroupedInventory }) {
         <DashboardBoxWithTitle key={groupName} title={groupName} collapsible>
           <Stack spacing={0.5}>
             {list.map((item) => (
-              <Draggable type="equipment" item={checkOutEquipmentItem(item)}>
-                <EquipmentTile key={item.id} item={item} />
+              <Draggable key={item.uuid} type="equipment" item={checkOutEquipmentItem(item)}>
+                <EquipmentTile item={item} />
               </Draggable>
             ))}
           </Stack>

--- a/src/components/dashboard/DashboardEquipmentManager.tsx
+++ b/src/components/dashboard/DashboardEquipmentManager.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography } from '@mui/material';
+import { Box, Stack, Typography } from '@mui/material';
 import { useMemo, useState } from 'react';
 import { v4 as uuid } from 'uuid';
 
@@ -9,45 +9,51 @@ import { EquipmentItem } from '@respond/types/team';
 import { useActivityContext } from '../activities/ActivityProvider';
 import { Draggable, Droppable } from '../DragAndDrop/DnDComponents';
 
+import SortMenuButton, { EquipmentGrouping } from './DashboardEquipmentGroupByMenu';
 import { DashboardSearchBox } from './DashboardSearchBox';
 
 const inventory = [
-  { id: 'inventory-1', name: 'Anchor Rope (150)' },
-  { id: 'inventory-2', name: 'Body Bag' },
-  { id: 'inventory-3', name: 'Climbing Rack' },
-  { id: 'inventory-4', name: 'Climbing Rope' },
-  { id: 'inventory-5', name: 'Dog Rescue Kit' },
-  { id: 'inventory-6', name: 'Drone' },
-  { id: 'inventory-7', name: 'EMT Kit' },
-  { id: 'inventory-8', name: 'First Aid Kit' },
-  { id: 'inventory-9', name: 'Helmet' },
-  { id: 'inventory-10', name: 'Ice Pack' },
-  { id: 'inventory-11', name: 'Litter' },
-  { id: 'inventory-12', name: 'Oxygen' },
-  { id: 'inventory-13', name: 'Packaging' },
-  { id: 'inventory-14', name: 'Patient Harness' },
-  { id: 'inventory-15', name: 'Rigging Kit' },
-  { id: 'inventory-16', name: 'Rope (300)' },
-  { id: 'inventory-17', name: 'Rope (600)' },
-  { id: 'inventory-18', name: 'Warming Blanket' },
-  { id: 'inventory-19', name: 'Wheel' },
-  { id: 'inventory-20', name: 'Water' },
-  { id: 'inventory-21', name: 'Snacks' },
-  { id: 'inventory-22', name: 'Stove' },
-  { id: 'inventory-23', name: 'Tarp' },
-  { id: 'inventory-24', name: 'Saw' },
-  { id: 'inventory-25', name: 'Traction' },
-  { id: 'inventory-26', name: 'Snowshoes' },
-  { id: 'inventory-27', name: 'Mega Mover' },
+  { id: 'inventory-1', type: 'Rigging', name: 'Anchor Rope (150)' },
+  { id: 'inventory-2', type: 'Medical', name: 'Body Bag' },
+  { id: 'inventory-3', type: 'Rigging', name: 'Climbing Rack' },
+  { id: 'inventory-4', type: 'Rigging', name: 'Climbing Rope' },
+  { id: 'inventory-5', type: 'General', name: 'Dog Rescue Kit' },
+  { id: 'inventory-6', type: 'General', name: 'Drone' },
+  { id: 'inventory-7', type: 'Medical', name: 'EMT Kit' },
+  { id: 'inventory-8', type: 'Medical', name: 'First Aid Kit' },
+  { id: 'inventory-9', type: 'Rigging', name: 'Helmet' },
+  { id: 'inventory-10', type: 'Medical', name: 'Ice Pack' },
+  { id: 'inventory-11', type: 'Packaging', name: 'Litter' },
+  { id: 'inventory-12', type: 'Medical', name: 'Oxygen' },
+  { id: 'inventory-13', type: 'Packaging', name: 'Sleeping Bag' },
+  { id: 'inventory-14', type: 'Rigging', name: 'Patient Harness' },
+  { id: 'inventory-15', type: 'Rigging', name: 'Rigging Kit' },
+  { id: 'inventory-16', type: 'Rigging', name: 'Rope (300)' },
+  { id: 'inventory-17', type: 'Rigging', name: 'Rope (600)' },
+  { id: 'inventory-18', type: 'Medical', name: 'Warming Blanket' },
+  { id: 'inventory-19', type: 'Packaging', name: 'Wheel' },
+  { id: 'inventory-20', type: 'General', name: 'Water' },
+  { id: 'inventory-21', type: 'General', name: 'Snacks' },
+  { id: 'inventory-22', type: 'General', name: 'Stove' },
+  { id: 'inventory-23', type: 'Packaging', name: 'Tarp' },
+  { id: 'inventory-24', type: 'General', name: 'Saw' },
+  { id: 'inventory-25', type: 'General', name: 'Traction' },
+  { id: 'inventory-26', type: 'General', name: 'Snowshoes' },
+  { id: 'inventory-27', type: 'Packaging', name: 'Mega Mover' },
+  { id: 'inventory-28', type: 'Packaging', name: 'Foam Pad' },
+  { id: 'inventory-29', type: 'Packaging', name: 'Padding' },
 ].sort((a, b) => a.name.localeCompare(b.name));
 
 const checkOutEquipmentItem = (item: EquipmentItem): EquipmentItem => {
   return { ...item, uuid: uuid() };
 };
 
+type GroupedInventory = Record<string, EquipmentItem[]>;
+
 export function DashboardEquipmentManager() {
   const dispatch = useAppDispatch();
   const [searchQuery, setSearchQuery] = useState('');
+  const [groupBy, setGroupBy] = useState<EquipmentGrouping>('All');
 
   const activity = useActivityContext();
 
@@ -59,6 +65,17 @@ export function DashboardEquipmentManager() {
       return name.includes(q);
     });
   }, [searchQuery]);
+
+  const groupedEquipment = useMemo<GroupedInventory>(() => {
+    return filteredEquipment.reduce<GroupedInventory>((acc, item) => {
+      const typeKey = item.type;
+      if (!acc[typeKey]) {
+        acc[typeKey] = [];
+      }
+      acc[typeKey].push(item);
+      return acc;
+    }, {});
+  }, [filteredEquipment]);
 
   const returnEquipment = (equipment: EquipmentItem) => {
     // Remove from the previous team, if any
@@ -74,16 +91,55 @@ export function DashboardEquipmentManager() {
 
   return (
     <Droppable accepts="equipment" onDrop={returnEquipment} grow>
-      <DashboardSearchBox onChange={setSearchQuery} sx={{ mb: 2 }} />
-      <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 1 }}>
-        {filteredEquipment.map((item) => (
-          <Draggable key={item.id} type="equipment" item={checkOutEquipmentItem(item)}>
-            <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2, p: 1, cursor: 'grab', bgcolor: 'background.paper' }}>
-              <Typography variant="subtitle2">{item.name}</Typography>
-            </Box>
-          </Draggable>
-        ))}
-      </Box>
+      <Stack spacing={2} sx={{ overflow: 'auto' }}>
+        <Stack direction="row" spacing={2}>
+          <DashboardSearchBox onChange={setSearchQuery} />
+          <SortMenuButton onChange={(value) => setGroupBy(value)} />
+        </Stack>
+        <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 1, pr: 0.5 }}>{groupBy === 'All' ? <EquipmentAphabetical items={filteredEquipment} /> : <EquipmentGroups groups={groupedEquipment} />}</Box>
+      </Stack>
     </Droppable>
+  );
+}
+
+function EquipmentTile({ item }: { item: EquipmentItem }) {
+  return (
+    <Draggable type="equipment" item={checkOutEquipmentItem(item)}>
+      <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2, p: 1, cursor: 'grab', bgcolor: 'background.paper' }}>
+        <Stack direction="row" justifyContent="space-between">
+          <Typography variant="subtitle2">{item.name}</Typography>
+          <Typography variant="caption" color="text.secondary">
+            {item.type}
+          </Typography>
+        </Stack>
+      </Box>
+    </Draggable>
+  );
+}
+
+function EquipmentAphabetical({ items }: { items: EquipmentItem[] }) {
+  return (
+    <>
+      {items.map((item) => (
+        <EquipmentTile key={item.id} item={item} />
+      ))}
+    </>
+  );
+}
+
+function EquipmentGroups({ groups }: { groups: GroupedInventory }) {
+  return (
+    <>
+      {Object.entries(groups).map(([groupName, list]) => (
+        <Stack key={groupName} spacing={0.5}>
+          <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+            {groupName}
+          </Typography>
+          {list.map((item) => (
+            <EquipmentTile key={item.id} item={item} />
+          ))}
+        </Stack>
+      ))}
+    </>
   );
 }

--- a/src/components/dashboard/DashboardEquipmentManager.tsx
+++ b/src/components/dashboard/DashboardEquipmentManager.tsx
@@ -8,10 +8,12 @@ import { Draggable, Droppable } from '../DragAndDrop/DnDComponents';
 
 import { DashboardBoxWithTitle } from './DashboardBoxWithTitle';
 import { DashboardDraggableContainer } from './DashboardDraggableContainer';
+import { DashboardEquipmentCreateDialog } from './DashboardEquipmentCreateDialog';
 import { EquipmentGrouping, EquipmentGroupToggleButton } from './DashboardEquipmentGroupToggleButton';
 import { DashboardSearchBox } from './DashboardSearchBox';
 
 const inventory = [
+  { id: 'inventory-0', type: 'Custom', name: 'Custom Item' },
   { id: 'inventory-1', type: 'Rigging', name: 'Anchor Rope (150)' },
   { id: 'inventory-2', type: 'Medical', name: 'Body Bag' },
   { id: 'inventory-3', type: 'Rigging', name: 'Climbing Rack' },
@@ -57,9 +59,15 @@ const checkOutEquipmentItem = (item: EquipmentItem): EquipmentItem => {
 
 type GroupedInventory = Record<string, EquipmentItem[]>;
 
+type EditingState = {
+  item: EquipmentItem;
+  onSave: (item: EquipmentItem) => void;
+};
+
 export function DashboardEquipmentManager() {
   const [searchQuery, setSearchQuery] = useState('');
   const [groupBy, setGroupBy] = useState<EquipmentGrouping>('Type');
+  const [editingState, setEditingState] = useState<EditingState | null>(null);
 
   const filteredEquipment = useMemo(() => {
     const q = (searchQuery || '').trim().toLowerCase();
@@ -86,16 +94,65 @@ export function DashboardEquipmentManager() {
     callback?.();
   };
 
+  const initializeCustomItem = (editingState: EditingState | undefined) => {
+    if (!editingState) return;
+    setEditingState(editingState);
+  };
+
+  const handleSaveEdit = (name: string) => {
+    editingState?.onSave({ ...editingState.item, name });
+    setEditingState(null);
+  };
+
+  const handleCancelEdit = () => {
+    setEditingState(null);
+  };
+
+  function EquipmentAphabetical({ items }: { items: EquipmentItem[] }) {
+    return (
+      <>
+        {items.map((item) => (
+          <Draggable key={item.id} type="equipment" item={checkOutEquipmentItem(item)} callback={initializeCustomItem}>
+            <EquipmentTile item={item} />
+          </Draggable>
+        ))}
+      </>
+    );
+  }
+
+  function EquipmentGroups({ groups }: { groups: GroupedInventory }) {
+    return (
+      <>
+        {Object.entries(groups)
+          .sort(([leftGroupName], [rightGroupName]) => leftGroupName.localeCompare(rightGroupName))
+          .map(([groupName, list]) => (
+            <DashboardBoxWithTitle key={groupName} title={groupName} collapsible>
+              <Stack spacing={0.5}>
+                {list.map((item) => (
+                  <Draggable key={item.id} type="equipment" item={checkOutEquipmentItem(item)} callback={initializeCustomItem}>
+                    <EquipmentTile item={item} />
+                  </Draggable>
+                ))}
+              </Stack>
+            </DashboardBoxWithTitle>
+          ))}
+      </>
+    );
+  }
+
   return (
-    <Droppable accepts="equipment" onDrop={handleDrop} grow>
-      <Stack spacing={2} sx={{ overflow: 'auto' }}>
-        <Stack direction="row" spacing={1}>
-          <DashboardSearchBox onChange={setSearchQuery} />
-          <EquipmentGroupToggleButton onChange={(value) => setGroupBy(value)} />
+    <>
+      <Droppable accepts="equipment" onDrop={handleDrop} grow>
+        <Stack spacing={2} sx={{ overflow: 'auto' }}>
+          <Stack direction="row" spacing={1}>
+            <DashboardSearchBox onChange={setSearchQuery} />
+            <EquipmentGroupToggleButton onChange={(value) => setGroupBy(value)} />
+          </Stack>
+          <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 1, pr: 0.5 }}>{groupBy === 'All' ? <EquipmentAphabetical items={filteredEquipment} /> : <EquipmentGroups groups={groupedEquipment} />}</Box>
         </Stack>
-        <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 1, pr: 0.5 }}>{groupBy === 'All' ? <EquipmentAphabetical items={filteredEquipment} /> : <EquipmentGroups groups={groupedEquipment} />}</Box>
-      </Stack>
-    </Droppable>
+      </Droppable>
+      {!!editingState?.item && <DashboardEquipmentCreateDialog onSave={handleSaveEdit} onCancel={handleCancelEdit} />}
+    </>
   );
 }
 
@@ -109,35 +166,5 @@ function EquipmentTile({ item }: { item: EquipmentItem }) {
         </Typography>
       </Stack>
     </DashboardDraggableContainer>
-  );
-}
-
-function EquipmentAphabetical({ items }: { items: EquipmentItem[] }) {
-  return (
-    <>
-      {items.map((item) => (
-        <Draggable key={item.id} type="equipment" item={checkOutEquipmentItem(item)}>
-          <EquipmentTile item={item} />
-        </Draggable>
-      ))}
-    </>
-  );
-}
-
-function EquipmentGroups({ groups }: { groups: GroupedInventory }) {
-  return (
-    <>
-      {Object.entries(groups).map(([groupName, list]) => (
-        <DashboardBoxWithTitle key={groupName} title={groupName} collapsible>
-          <Stack spacing={0.5}>
-            {list.map((item) => (
-              <Draggable key={item.id} type="equipment" item={checkOutEquipmentItem(item)}>
-                <EquipmentTile item={item} />
-              </Draggable>
-            ))}
-          </Stack>
-        </DashboardBoxWithTitle>
-      ))}
-    </>
   );
 }

--- a/src/components/dashboard/DashboardEquipmentManager.tsx
+++ b/src/components/dashboard/DashboardEquipmentManager.tsx
@@ -44,6 +44,8 @@ const inventory = [
   { id: 'inventory-31', type: 'Medical', name: 'Vacuum Splint: Extremity' },
   { id: 'inventory-32', type: 'Medical', name: 'SAM Splint' },
   { id: 'inventory-33', type: 'General', name: 'Webbing' },
+  { id: 'inventory-34', type: 'Medical', name: 'A.E.D - Basic' },
+  { id: 'inventory-34', type: 'Medical', name: 'A.E.D - EMT' },
 ].sort((a, b) => a.name.localeCompare(b.name));
 
 const checkOutEquipmentItem = (item: EquipmentItem): EquipmentItem => {

--- a/src/components/dashboard/DashboardEquipmentManager.tsx
+++ b/src/components/dashboard/DashboardEquipmentManager.tsx
@@ -105,7 +105,24 @@ export function DashboardEquipmentManager() {
 function EquipmentTile({ item }: { item: EquipmentItem }) {
   return (
     <Draggable type="equipment" item={checkOutEquipmentItem(item)}>
-      <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2, p: 1, cursor: 'grab', bgcolor: 'background.paper' }}>
+      <Box
+        sx={{
+          border: '1px solid',
+          borderColor: 'divider',
+          borderRadius: 2,
+          p: 1,
+          cursor: 'grab',
+          bgcolor: 'background.paper',
+          ':hover': {
+            bgcolor: 'grey.100',
+            // Targets the child element with class 'promote-button' when Stack is hovered
+            '& .promote-button': {
+              opacity: 1,
+              visibility: 'visible',
+            },
+          },
+        }}
+      >
         <Stack direction="row" justifyContent="space-between">
           <Typography variant="subtitle2">{item.name}</Typography>
           <Typography variant="caption" color="text.secondary">

--- a/src/components/dashboard/DashboardEquipmentManager.tsx
+++ b/src/components/dashboard/DashboardEquipmentManager.tsx
@@ -40,6 +40,10 @@ const inventory = [
   { id: 'inventory-27', type: 'Packaging', name: 'Mega Mover' },
   { id: 'inventory-28', type: 'Packaging', name: 'Foam Pad' },
   { id: 'inventory-29', type: 'Packaging', name: 'Padding' },
+  { id: 'inventory-30', type: 'Medical', name: 'Vacuum Splint: Full Body' },
+  { id: 'inventory-31', type: 'Medical', name: 'Vacuum Splint: Extremity' },
+  { id: 'inventory-32', type: 'Medical', name: 'SAM Splint' },
+  { id: 'inventory-33', type: 'General', name: 'Webbing' },
 ].sort((a, b) => a.name.localeCompare(b.name));
 
 const checkOutEquipmentItem = (item: EquipmentItem): EquipmentItem => {

--- a/src/components/dashboard/DashboardEquipmentManager.tsx
+++ b/src/components/dashboard/DashboardEquipmentManager.tsx
@@ -1,0 +1,89 @@
+import { Box, Typography } from '@mui/material';
+import { useMemo, useState } from 'react';
+import { v4 as uuid } from 'uuid';
+
+import { useAppDispatch } from '@respond/lib/client/store';
+import { ActivityActions } from '@respond/lib/state';
+import { EquipmentItem } from '@respond/types/team';
+
+import { useActivityContext } from '../activities/ActivityProvider';
+import { Draggable, Droppable } from '../DragAndDrop/DnDComponents';
+
+import { DashboardSearchBox } from './DashboardSearchBox';
+
+const inventory = [
+  { id: 'inventory-1', name: 'Anchor Rope (150)' },
+  { id: 'inventory-2', name: 'Body Bag' },
+  { id: 'inventory-3', name: 'Climbing Rack' },
+  { id: 'inventory-4', name: 'Climbing Rope' },
+  { id: 'inventory-5', name: 'Dog Rescue Kit' },
+  { id: 'inventory-6', name: 'Drone' },
+  { id: 'inventory-7', name: 'EMT Kit' },
+  { id: 'inventory-8', name: 'First Aid Kit' },
+  { id: 'inventory-9', name: 'Helmet' },
+  { id: 'inventory-10', name: 'Ice Pack' },
+  { id: 'inventory-11', name: 'Litter' },
+  { id: 'inventory-12', name: 'Oxygen' },
+  { id: 'inventory-13', name: 'Packaging' },
+  { id: 'inventory-14', name: 'Patient Harness' },
+  { id: 'inventory-15', name: 'Rigging Kit' },
+  { id: 'inventory-16', name: 'Rope (300)' },
+  { id: 'inventory-17', name: 'Rope (600)' },
+  { id: 'inventory-18', name: 'Warming Blanket' },
+  { id: 'inventory-19', name: 'Wheel' },
+  { id: 'inventory-20', name: 'Water' },
+  { id: 'inventory-21', name: 'Snacks' },
+  { id: 'inventory-22', name: 'Stove' },
+  { id: 'inventory-23', name: 'Tarp' },
+  { id: 'inventory-24', name: 'Saw' },
+  { id: 'inventory-25', name: 'Traction' },
+  { id: 'inventory-26', name: 'Snowshoes' },
+  { id: 'inventory-27', name: 'Mega Mover' },
+].sort((a, b) => a.name.localeCompare(b.name));
+
+const checkOutEquipmentItem = (item: EquipmentItem): EquipmentItem => {
+  return { ...item, uuid: uuid() };
+};
+
+export function DashboardEquipmentManager() {
+  const dispatch = useAppDispatch();
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const activity = useActivityContext();
+
+  const filteredEquipment = useMemo(() => {
+    const q = (searchQuery || '').trim().toLowerCase();
+    if (!q) return inventory;
+    return inventory.filter((entry) => {
+      const name = (entry.name || '').toLowerCase();
+      return name.includes(q);
+    });
+  }, [searchQuery]);
+
+  const returnEquipment = (equipment: EquipmentItem) => {
+    // Remove from the previous team, if any
+    // TODO: need actions to club these updates into a single activity transaction
+    activity.teams.forEach((team) => {
+      if (team.assignedEquipment.some((item) => item.uuid === equipment.uuid)) {
+        // Remove the participant from the team
+        const updatedTeam = { ...team, assignedEquipment: team.assignedEquipment.filter((item) => item.uuid !== equipment.uuid) };
+        dispatch(ActivityActions.updateTeam(activity.id, updatedTeam));
+      }
+    });
+  };
+
+  return (
+    <Droppable accepts="equipment" onDrop={returnEquipment} grow>
+      <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 1 }}>
+        <DashboardSearchBox onChange={setSearchQuery} sx={{ mb: 1 }} />
+        {filteredEquipment.map((item) => (
+          <Draggable key={item.id} type="equipment" item={checkOutEquipmentItem(item)}>
+            <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2, p: 1, cursor: 'grab', bgcolor: 'background.paper' }}>
+              <Typography variant="subtitle2">{item.name}</Typography>
+            </Box>
+          </Draggable>
+        ))}
+      </Box>
+    </Droppable>
+  );
+}

--- a/src/components/dashboard/DashboardEquipmentSummary.tsx
+++ b/src/components/dashboard/DashboardEquipmentSummary.tsx
@@ -1,0 +1,36 @@
+import { Box, Typography } from '@mui/material';
+
+import { useActivityContext } from '../activities/ActivityProvider';
+
+export function DashboardEquipmentSummary() {
+  const activity = useActivityContext();
+  const teams = activity?.teams ?? [];
+
+  const equipmentCounts = teams
+    .flatMap((team) => team.assignedEquipment ?? [])
+    .reduce<Record<string, number>>((counts, item) => {
+      counts[item.name] = (counts[item.name] ?? 0) + 1;
+      return counts;
+    }, {});
+
+  const equipmentEntries = Object.entries(equipmentCounts).sort(([leftName], [rightName]) => leftName.localeCompare(rightName));
+
+  return (
+    <Box sx={{ px: 1 }}>
+      <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+        Equipment
+      </Typography>
+      {equipmentEntries.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          No equipment assigned.
+        </Typography>
+      ) : (
+        equipmentEntries.map(([name, count]) => (
+          <Typography key={name} variant="subtitle1" sx={{ whiteSpace: 'pre-line' }}>
+            {`(${count}) ${name}`}
+          </Typography>
+        ))
+      )}
+    </Box>
+  );
+}

--- a/src/components/dashboard/DashboardEquipmentSummary.tsx
+++ b/src/components/dashboard/DashboardEquipmentSummary.tsx
@@ -16,19 +16,14 @@ export function DashboardEquipmentSummary() {
       return counts;
     }, {});
 
-  const placeEquipmentCounts = places
-    .flatMap((place) => place.assignedEquipment ?? [])
-    .reduce<Record<string, number>>((counts, item) => {
-      counts[item.name] = (counts[item.name] ?? 0) + 1;
-      return counts;
-    }, {});
-
   const teamEntries = Object.entries(equipmentCounts).sort(([leftName], [rightName]) => leftName.localeCompare(rightName));
-  const placeEntries = Object.entries(placeEquipmentCounts).sort(([leftName], [rightName]) => leftName.localeCompare(rightName));
+  const placesWithEquipment = places.filter((place) => place.assignedEquipment?.length > 0);
 
   return (
     <DashboardBoxWithTitle title="Equipment" collapsible>
-      <Typography variant="subtitle1">Assigned</Typography>
+      <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+        Assigned
+      </Typography>
       {teamEntries.length === 0 ? (
         <Typography variant="body2" color="text.secondary">
           No equipment assigned.
@@ -40,17 +35,33 @@ export function DashboardEquipmentSummary() {
           </Typography>
         ))
       )}
-      <Typography variant="subtitle1">Staged</Typography>
-      {placeEntries.length === 0 ? (
+      <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+        Staged
+      </Typography>
+      {placesWithEquipment.length === 0 ? (
         <Typography variant="body2" color="text.secondary">
-          No equipment assigned.
+          No equipment staged.
         </Typography>
       ) : (
-        placeEntries.map(([name, count]) => (
-          <Typography key={name} variant="subtitle1" sx={{ whiteSpace: 'pre-line' }}>
-            {`(${count}) ${name}`}
-          </Typography>
-        ))
+        placesWithEquipment.map((place) => {
+          const counts = place.assignedEquipment.reduce<Record<string, number>>((acc, item) => {
+            acc[item.name] = (acc[item.name] ?? 0) + 1;
+            return acc;
+          }, {});
+          const entries = Object.entries(counts).sort(([a], [b]) => a.localeCompare(b));
+          return (
+            <div key={place.id}>
+              <Typography variant="subtitle2" color="text.secondary" sx={{ mt: 0.5 }}>
+                {place.name}
+              </Typography>
+              {entries.map(([name, count]) => (
+                <Typography key={name} variant="subtitle1" sx={{ whiteSpace: 'pre-line' }}>
+                  {`(${count}) ${name}`}
+                </Typography>
+              ))}
+            </div>
+          );
+        })
       )}
     </DashboardBoxWithTitle>
   );

--- a/src/components/dashboard/DashboardEquipmentSummary.tsx
+++ b/src/components/dashboard/DashboardEquipmentSummary.tsx
@@ -1,6 +1,7 @@
 import { Typography } from '@mui/material';
 
 import { useActivityContext } from '../activities/ActivityProvider';
+import { Stack } from '../Material';
 
 import { DashboardBoxWithTitle } from './DashboardBoxWithTitle';
 
@@ -9,60 +10,79 @@ export function DashboardEquipmentSummary() {
   const teams = activity?.teams ?? [];
   const places = activity?.places ?? [];
 
-  const equipmentCounts = teams
-    .flatMap((team) => team.assignedEquipment ?? [])
-    .reduce<Record<string, number>>((counts, item) => {
-      counts[item.name] = (counts[item.name] ?? 0) + 1;
-      return counts;
-    }, {});
+  const countTeamEquipment = (filteredTeams: typeof teams) =>
+    filteredTeams
+      .flatMap((team) => team.assignedEquipment ?? [])
+      .reduce<Record<string, number>>((counts, item) => {
+        counts[item.name] = (counts[item.name] ?? 0) + 1;
+        return counts;
+      }, {});
 
-  const teamEntries = Object.entries(equipmentCounts).sort(([leftName], [rightName]) => leftName.localeCompare(rightName));
+  const onSceneEquipmentCounts = countTeamEquipment(teams.filter((team) => team.status === 'On Scene'));
+  const assignedEquipmentCounts = countTeamEquipment(teams.filter((team) => team.status !== 'On Scene'));
+
+  const onSceneEntries = Object.entries(onSceneEquipmentCounts).sort(([leftName], [rightName]) => leftName.localeCompare(rightName));
+  const assignedEntries = Object.entries(assignedEquipmentCounts).sort(([leftName], [rightName]) => leftName.localeCompare(rightName));
+
   const placesWithEquipment = places.filter((place) => place.assignedEquipment?.length > 0);
 
   return (
     <DashboardBoxWithTitle title="Equipment" collapsible>
-      <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
-        Assigned
-      </Typography>
-      {teamEntries.length === 0 ? (
-        <Typography variant="body2" color="text.secondary">
-          No equipment assigned.
-        </Typography>
-      ) : (
-        teamEntries.map(([name, count]) => (
-          <Typography key={name} variant="subtitle1" sx={{ whiteSpace: 'pre-line' }}>
-            {`(${count}) ${name}`}
-          </Typography>
-        ))
-      )}
-      <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
-        Staged
-      </Typography>
-      {placesWithEquipment.length === 0 ? (
-        <Typography variant="body2" color="text.secondary">
-          No equipment staged.
-        </Typography>
-      ) : (
-        placesWithEquipment.map((place) => {
-          const counts = place.assignedEquipment.reduce<Record<string, number>>((acc, item) => {
-            acc[item.name] = (acc[item.name] ?? 0) + 1;
-            return acc;
-          }, {});
-          const entries = Object.entries(counts).sort(([a], [b]) => a.localeCompare(b));
-          return (
-            <div key={place.id}>
-              <Typography variant="subtitle2" color="text.secondary" sx={{ mt: 0.5 }}>
-                {place.name}
+      <Stack spacing={1}>
+        <DashboardBoxWithTitle title="On Scene" collapsible>
+          {onSceneEntries.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              No equipment on scene.
+            </Typography>
+          ) : (
+            onSceneEntries.map(([name, count]) => (
+              <Typography key={name} variant="subtitle1" sx={{ whiteSpace: 'pre-line' }}>
+                {`${count} - ${name}`}
               </Typography>
-              {entries.map(([name, count]) => (
-                <Typography key={name} variant="subtitle1" sx={{ whiteSpace: 'pre-line' }}>
-                  {`(${count}) ${name}`}
-                </Typography>
-              ))}
-            </div>
-          );
-        })
-      )}
+            ))
+          )}
+        </DashboardBoxWithTitle>
+        <DashboardBoxWithTitle title="Assigned" collapsible>
+          {assignedEntries.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              No equipment assigned.
+            </Typography>
+          ) : (
+            assignedEntries.map(([name, count]) => (
+              <Typography key={name} variant="subtitle1" sx={{ whiteSpace: 'pre-line' }}>
+                {`${count} - ${name}`}
+              </Typography>
+            ))
+          )}
+        </DashboardBoxWithTitle>
+        <DashboardBoxWithTitle title="Staged" collapsible>
+          {placesWithEquipment.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              No equipment staged.
+            </Typography>
+          ) : (
+            placesWithEquipment.map((place) => {
+              const counts = place.assignedEquipment.reduce<Record<string, number>>((acc, item) => {
+                acc[item.name] = (acc[item.name] ?? 0) + 1;
+                return acc;
+              }, {});
+              const entries = Object.entries(counts).sort(([a], [b]) => a.localeCompare(b));
+              return (
+                <div key={place.id}>
+                  <Typography variant="subtitle2" color="text.secondary" sx={{ mt: 0.5 }}>
+                    {place.name}
+                  </Typography>
+                  {entries.map(([name, count]) => (
+                    <Typography key={name} variant="subtitle1" sx={{ whiteSpace: 'pre-line' }}>
+                      {`${count} - ${name}`}
+                    </Typography>
+                  ))}
+                </div>
+              );
+            })
+          )}
+        </DashboardBoxWithTitle>
+      </Stack>
     </DashboardBoxWithTitle>
   );
 }

--- a/src/components/dashboard/DashboardEquipmentSummary.tsx
+++ b/src/components/dashboard/DashboardEquipmentSummary.tsx
@@ -2,7 +2,7 @@ import { Typography } from '@mui/material';
 
 import { useActivityContext } from '../activities/ActivityProvider';
 
-import { DashboardCollapsibleBox } from './DashboardCollapsibleBox';
+import { DashboardBoxWithTitle } from './DashboardBoxWithTitle';
 
 export function DashboardEquipmentSummary() {
   const activity = useActivityContext();
@@ -18,7 +18,7 @@ export function DashboardEquipmentSummary() {
   const equipmentEntries = Object.entries(equipmentCounts).sort(([leftName], [rightName]) => leftName.localeCompare(rightName));
 
   return (
-    <DashboardCollapsibleBox title="Equipment" sx={{ p: 1 }}>
+    <DashboardBoxWithTitle title="Equipment" sx={{ p: 1 }} collapsible>
       {equipmentEntries.length === 0 ? (
         <Typography variant="body2" color="text.secondary">
           No equipment assigned.
@@ -30,6 +30,6 @@ export function DashboardEquipmentSummary() {
           </Typography>
         ))
       )}
-    </DashboardCollapsibleBox>
+    </DashboardBoxWithTitle>
   );
 }

--- a/src/components/dashboard/DashboardEquipmentSummary.tsx
+++ b/src/components/dashboard/DashboardEquipmentSummary.tsx
@@ -1,6 +1,8 @@
-import { Box, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 
 import { useActivityContext } from '../activities/ActivityProvider';
+
+import { DashboardCollapsibleBox } from './DashboardCollapsibleBox';
 
 export function DashboardEquipmentSummary() {
   const activity = useActivityContext();
@@ -16,10 +18,7 @@ export function DashboardEquipmentSummary() {
   const equipmentEntries = Object.entries(equipmentCounts).sort(([leftName], [rightName]) => leftName.localeCompare(rightName));
 
   return (
-    <Box sx={{ px: 1 }}>
-      <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
-        Equipment
-      </Typography>
+    <DashboardCollapsibleBox title="Equipment" sx={{ p: 1 }}>
       {equipmentEntries.length === 0 ? (
         <Typography variant="body2" color="text.secondary">
           No equipment assigned.
@@ -31,6 +30,6 @@ export function DashboardEquipmentSummary() {
           </Typography>
         ))
       )}
-    </Box>
+    </DashboardCollapsibleBox>
   );
 }

--- a/src/components/dashboard/DashboardEquipmentSummary.tsx
+++ b/src/components/dashboard/DashboardEquipmentSummary.tsx
@@ -7,6 +7,7 @@ import { DashboardBoxWithTitle } from './DashboardBoxWithTitle';
 export function DashboardEquipmentSummary() {
   const activity = useActivityContext();
   const teams = activity?.teams ?? [];
+  const places = activity?.places ?? [];
 
   const equipmentCounts = teams
     .flatMap((team) => team.assignedEquipment ?? [])
@@ -15,16 +16,41 @@ export function DashboardEquipmentSummary() {
       return counts;
     }, {});
 
-  const equipmentEntries = Object.entries(equipmentCounts).sort(([leftName], [rightName]) => leftName.localeCompare(rightName));
+  const placeEquipmentCounts = places
+    .flatMap((place) => place.assignedEquipment ?? [])
+    .reduce<Record<string, number>>((counts, item) => {
+      counts[item.name] = (counts[item.name] ?? 0) + 1;
+      return counts;
+    }, {});
+
+  const teamEntries = Object.entries(equipmentCounts).sort(([leftName], [rightName]) => leftName.localeCompare(rightName));
+  const placeEntries = Object.entries(placeEquipmentCounts).sort(([leftName], [rightName]) => leftName.localeCompare(rightName));
 
   return (
     <DashboardBoxWithTitle title="Equipment" collapsible>
-      {equipmentEntries.length === 0 ? (
+      <Typography variant="subtitle1">
+        Assigned
+      </Typography>
+      {teamEntries.length === 0 ? (
         <Typography variant="body2" color="text.secondary">
           No equipment assigned.
         </Typography>
       ) : (
-        equipmentEntries.map(([name, count]) => (
+        teamEntries.map(([name, count]) => (
+          <Typography key={name} variant="subtitle1" sx={{ whiteSpace: 'pre-line' }}>
+            {`(${count}) ${name}`}
+          </Typography>
+        ))
+      )}
+      <Typography variant="subtitle1">
+        Staged
+      </Typography>
+      {placeEntries.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          No equipment assigned.
+        </Typography>
+      ) : (
+        placeEntries.map(([name, count]) => (
           <Typography key={name} variant="subtitle1" sx={{ whiteSpace: 'pre-line' }}>
             {`(${count}) ${name}`}
           </Typography>

--- a/src/components/dashboard/DashboardEquipmentSummary.tsx
+++ b/src/components/dashboard/DashboardEquipmentSummary.tsx
@@ -18,7 +18,7 @@ export function DashboardEquipmentSummary() {
   const equipmentEntries = Object.entries(equipmentCounts).sort(([leftName], [rightName]) => leftName.localeCompare(rightName));
 
   return (
-    <DashboardBoxWithTitle title="Equipment" sx={{ p: 1 }} collapsible>
+    <DashboardBoxWithTitle title="Equipment" collapsible>
       {equipmentEntries.length === 0 ? (
         <Typography variant="body2" color="text.secondary">
           No equipment assigned.

--- a/src/components/dashboard/DashboardEquipmentSummary.tsx
+++ b/src/components/dashboard/DashboardEquipmentSummary.tsx
@@ -28,9 +28,7 @@ export function DashboardEquipmentSummary() {
 
   return (
     <DashboardBoxWithTitle title="Equipment" collapsible>
-      <Typography variant="subtitle1">
-        Assigned
-      </Typography>
+      <Typography variant="subtitle1">Assigned</Typography>
       {teamEntries.length === 0 ? (
         <Typography variant="body2" color="text.secondary">
           No equipment assigned.
@@ -42,9 +40,7 @@ export function DashboardEquipmentSummary() {
           </Typography>
         ))
       )}
-      <Typography variant="subtitle1">
-        Staged
-      </Typography>
+      <Typography variant="subtitle1">Staged</Typography>
       {placeEntries.length === 0 ? (
         <Typography variant="body2" color="text.secondary">
           No equipment assigned.

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -1,12 +1,13 @@
 import { Box, Paper, Stack } from '@mui/material';
 
 import { useActivityContext } from '../activities/ActivityProvider';
-import DashboardActivityDetails from '../dashboard/DashboardActivityDetails';
-import DashboardClock from '../dashboard/DashboardClock';
+import { DashboardActivityDetails } from '../dashboard/DashboardActivityDetails';
+import { DashboardClock } from '../dashboard/DashboardClock';
 import { DashboardWeather } from '../dashboard/DashboardWeather';
 
 export function DashboardHeader() {
   const activity = useActivityContext();
+  const hasLocation = activity.location?.lat && activity.location?.lon;
   return (
     <Paper elevation={2} sx={{ p: 2, display: 'flex', alignItems: 'stretch', justifyContent: 'space-between', gap: 2, borderRadius: 3, minHeight: 120 }}>
       <Box
@@ -22,9 +23,7 @@ export function DashboardHeader() {
           <DashboardClock />
           <DashboardActivityDetails />
         </Stack>
-        <Box sx={{ justifySelf: 'right', display: 'flex', alignItems: 'stretch' }}>
-          <DashboardWeather lat={activity.location?.lat ?? 0} lon={activity.location?.lon ?? 0} />
-        </Box>
+        <Box sx={{ justifySelf: 'right', display: 'flex', alignItems: 'stretch' }}>{hasLocation && <DashboardWeather lat={activity.location.lat} lon={activity.location.lon} />}</Box>
       </Box>
     </Paper>
   );

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -1,0 +1,31 @@
+import { Box, Paper, Stack } from '@mui/material';
+
+import { useActivityContext } from '../activities/ActivityProvider';
+import DashboardActivityDetails from '../dashboard/DashboardActivityDetails';
+import DashboardClock from '../dashboard/DashboardClock';
+import { DashboardWeather } from '../dashboard/DashboardWeather';
+
+export function DashboardHeader() {
+  const activity = useActivityContext();
+  return (
+    <Paper elevation={2} sx={{ p: 2, display: 'flex', alignItems: 'stretch', justifyContent: 'space-between', gap: 2, borderRadius: 3, minHeight: 120 }}>
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: 'auto 1fr',
+          alignItems: 'stretch',
+          gap: 2,
+          width: '100%',
+        }}
+      >
+        <Stack direction="row" alignItems="stretch" spacing={2}>
+          <DashboardClock />
+          <DashboardActivityDetails />
+        </Stack>
+        <Box sx={{ justifySelf: 'right', display: 'flex', alignItems: 'stretch' }}>
+          <DashboardWeather lat={activity.location?.lat ?? 0} lon={activity.location?.lon ?? 0} />
+        </Box>
+      </Box>
+    </Paper>
+  );
+}

--- a/src/components/dashboard/DashboardPanel.tsx
+++ b/src/components/dashboard/DashboardPanel.tsx
@@ -1,0 +1,86 @@
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import { Box, IconButton, Paper, Stack, Typography } from '@mui/material';
+import { useState } from 'react';
+
+const COLLAPSE_WIDTH = 56;
+
+export function DashboardPanel({ title, icon, collapse = 'left', grow = false, children }: { title: string; icon?: React.ReactNode; collapse: 'left' | 'right'; grow?: boolean; children: React.ReactNode }) {
+  const [collapsed, setCollapsed] = useState(false);
+  const toggle = () => {
+    setCollapsed((current) => !current);
+  };
+  return (
+    <Paper
+      elevation={2}
+      sx={{
+        width: collapsed ? COLLAPSE_WIDTH : grow ? '100%' : 280,
+        minWidth: collapsed ? COLLAPSE_WIDTH : 280,
+        flex: collapsed ? 'none' : grow ? 1 : 'none',
+        transition: 'width 180ms ease',
+        display: 'flex',
+        flexDirection: 'column',
+        p: 1,
+        borderRadius: 3,
+      }}
+    >
+      {collapse === 'left' ? <LeftPanelHeader title={title} icon={icon} collapsed={collapsed} onToggle={toggle} /> : <RightPanelHeader title={title} icon={icon} collapsed={collapsed} onToggle={toggle} />}
+      {!collapsed && children}
+    </Paper>
+  );
+}
+
+function LeftPanelHeader({ title, icon, collapsed, onToggle }: { title: string; icon?: React.ReactNode; collapsed: boolean; onToggle: () => void }) {
+  const open = (
+    <Stack direction="row" alignItems="center" sx={{ mb: 1, gap: 1, width: '100%' }} justifyContent="space-between">
+      <Box sx={{ width: 32, height: 32 }} /> {/* Placeholder to balance the layout when the button is on the right */}
+      <DashboardPanelTitle title={title} icon={icon} />
+      <IconButton onClick={onToggle} size="small" sx={{ width: 32, height: 32 }}>
+        {collapsed ? <ChevronRightIcon /> : <ChevronLeftIcon />}
+      </IconButton>
+    </Stack>
+  );
+
+  const closed = (
+    <Stack direction="column" alignItems="center" sx={{ gap: 2, width: '100%' }} justifyContent="flex-start">
+      <IconButton onClick={onToggle} size="small" sx={{ width: 32, height: 32 }}>
+        {collapsed ? <ChevronRightIcon /> : <ChevronLeftIcon />}
+      </IconButton>
+      <DashboardPanelTitle title={title} icon={icon} rotate />
+    </Stack>
+  );
+
+  return collapsed ? closed : open;
+}
+
+function RightPanelHeader({ title, icon, collapsed, onToggle }: { title: string; icon?: React.ReactNode; collapsed: boolean; onToggle: () => void }) {
+  const open = (
+    <Stack direction="row" alignItems="center" sx={{ mb: 1, gap: 1, width: '100%' }} justifyContent="space-between">
+      <IconButton onClick={onToggle} size="small" sx={{ width: 32, height: 32 }}>
+        {collapsed ? <ChevronLeftIcon /> : <ChevronRightIcon />}
+      </IconButton>
+      <DashboardPanelTitle title={title} icon={icon} />
+      <Box sx={{ width: 32, height: 32 }} /> {/* Placeholder to balance the layout when the button is on the left */}
+    </Stack>
+  );
+
+  const closed = (
+    <Stack direction="column" alignItems="center" sx={{ gap: 2, width: '100%' }} justifyContent="flex-start">
+      <IconButton onClick={onToggle} size="small" sx={{ width: 32, height: 32 }}>
+        {collapsed ? <ChevronLeftIcon /> : <ChevronRightIcon />}
+      </IconButton>
+      <DashboardPanelTitle title={title} icon={icon} rotate />
+    </Stack>
+  );
+
+  return collapsed ? closed : open;
+}
+
+function DashboardPanelTitle({ title, rotate = false, icon }: { title: string; rotate?: boolean; icon?: React.ReactNode }) {
+  return (
+    <Stack direction={rotate ? 'column' : 'row'} spacing={1} alignItems="center">
+      {icon}
+      <Typography sx={{ fontWeight: 700, whiteSpace: 'nowrap', textAlign: 'center', writingMode: rotate ? 'vertical-rl' : 'unset' }}>{title}</Typography>
+    </Stack>
+  );
+}

--- a/src/components/dashboard/DashboardPanel.tsx
+++ b/src/components/dashboard/DashboardPanel.tsx
@@ -1,11 +1,11 @@
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
-import { Box, IconButton, Paper, Stack, Typography } from '@mui/material';
+import { Box, IconButton, Paper, Stack, SxProps, Theme, Typography } from '@mui/material';
 import { useState } from 'react';
 
 const COLLAPSE_WIDTH = 56;
 
-export function DashboardPanel({ title, icon, collapse = 'left', grow = false, children }: { title: string; icon?: React.ReactNode; collapse: 'left' | 'right'; grow?: boolean; children: React.ReactNode }) {
+export function DashboardPanel({ title, icon, collapse = 'left', grow = false, children, sx }: { title: string; icon?: React.ReactNode; collapse: 'left' | 'right'; grow?: boolean; children: React.ReactNode; sx?: SxProps<Theme> }) {
   const [collapsed, setCollapsed] = useState(false);
   const toggle = () => {
     setCollapsed((current) => !current);
@@ -13,16 +13,19 @@ export function DashboardPanel({ title, icon, collapse = 'left', grow = false, c
   return (
     <Paper
       elevation={2}
-      sx={{
-        width: collapsed ? COLLAPSE_WIDTH : grow ? '100%' : 280,
-        minWidth: collapsed ? COLLAPSE_WIDTH : 280,
-        flex: collapsed ? 'none' : grow ? 1 : 'none',
-        transition: 'width 180ms ease',
-        display: 'flex',
-        flexDirection: 'column',
-        p: 1,
-        borderRadius: 3,
-      }}
+      sx={[
+        {
+          width: collapsed ? COLLAPSE_WIDTH : grow ? '100%' : 300,
+          minWidth: collapsed ? COLLAPSE_WIDTH : 300,
+          flex: collapsed ? 'none' : grow ? 1 : 'none',
+          transition: 'width 180ms ease',
+          display: 'flex',
+          flexDirection: 'column',
+          p: 1,
+          borderRadius: 3,
+        },
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
     >
       {collapse === 'left' ? <LeftPanelHeader title={title} icon={icon} collapsed={collapsed} onToggle={toggle} /> : <RightPanelHeader title={title} icon={icon} collapsed={collapsed} onToggle={toggle} />}
       {!collapsed && children}

--- a/src/components/dashboard/DashboardParticipantCard.tsx
+++ b/src/components/dashboard/DashboardParticipantCard.tsx
@@ -1,0 +1,23 @@
+import { Box, Typography } from '@mui/material';
+
+import { getOrganizationName, Participant } from '@respond/types/activity';
+
+import { useActivityContext } from '../activities/ActivityProvider';
+import { Draggable } from '../DragAndDrop/DnDComponents';
+
+export default function DashboardParticipantCard({ participant }: { participant: Participant }) {
+  const activity = useActivityContext();
+  const organizationName = getOrganizationName(activity, participant.organizationId);
+  return (
+    <Draggable key={participant.id} type="participant" item={participant}>
+      <Box key={participant.id} sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2, p: 1, cursor: 'grab', bgcolor: 'background.paper' }}>
+        <Typography variant="subtitle2">
+          {participant.firstname} {participant.lastname}
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          {organizationName} {participant.tags?.join(', ')}
+        </Typography>
+      </Box>
+    </Draggable>
+  );
+}

--- a/src/components/dashboard/DashboardParticipantCard.tsx
+++ b/src/components/dashboard/DashboardParticipantCard.tsx
@@ -3,39 +3,36 @@ import { Box, Typography } from '@mui/material';
 import { getOrganizationName, Participant } from '@respond/types/activity';
 
 import { useActivityContext } from '../activities/ActivityProvider';
-import { Draggable } from '../DragAndDrop/DnDComponents';
 
 export default function DashboardParticipantCard({ participant }: { participant: Participant }) {
   const activity = useActivityContext();
   const organizationName = getOrganizationName(activity, participant.organizationId);
   return (
-    <Draggable key={participant.id} type="participant" item={participant}>
-      <Box
-        key={participant.id}
-        sx={{
-          border: '1px solid',
-          borderColor: 'divider',
-          borderRadius: 2,
-          p: 1,
-          cursor: 'grab',
-          bgcolor: 'background.paper',
-          ':hover': {
-            bgcolor: 'grey.100',
-            // Targets the child element with class 'promote-button' when Stack is hovered
-            '& .promote-button': {
-              opacity: 1,
-              visibility: 'visible',
-            },
+    <Box
+      key={participant.id}
+      sx={{
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 2,
+        p: 1,
+        cursor: 'grab',
+        bgcolor: 'background.paper',
+        ':hover': {
+          bgcolor: 'grey.100',
+          // Targets the child element with class 'promote-button' when Stack is hovered
+          '& .promote-button': {
+            opacity: 1,
+            visibility: 'visible',
           },
-        }}
-      >
-        <Typography variant="subtitle2">
-          {participant.firstname} {participant.lastname}
-        </Typography>
-        <Typography variant="caption" color="text.secondary">
-          {organizationName} {participant.tags?.join(', ')}
-        </Typography>
-      </Box>
-    </Draggable>
+        },
+      }}
+    >
+      <Typography variant="subtitle2">
+        {participant.firstname} {participant.lastname}
+      </Typography>
+      <Typography variant="caption" color="text.secondary">
+        {organizationName} {participant.tags?.join(', ')}
+      </Typography>
+    </Box>
   );
 }

--- a/src/components/dashboard/DashboardParticipantCard.tsx
+++ b/src/components/dashboard/DashboardParticipantCard.tsx
@@ -1,38 +1,22 @@
-import { Box, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 
 import { getOrganizationName, Participant } from '@respond/types/activity';
 
 import { useActivityContext } from '../activities/ActivityProvider';
 
+import { DashboardDraggableContainer } from './DashboardDraggableContainer';
+
 export default function DashboardParticipantCard({ participant }: { participant: Participant }) {
   const activity = useActivityContext();
   const organizationName = getOrganizationName(activity, participant.organizationId);
   return (
-    <Box
-      key={participant.id}
-      sx={{
-        border: '1px solid',
-        borderColor: 'divider',
-        borderRadius: 2,
-        p: 1,
-        cursor: 'grab',
-        bgcolor: 'background.paper',
-        ':hover': {
-          bgcolor: 'grey.100',
-          // Targets the child element with class 'promote-button' when Stack is hovered
-          '& .promote-button': {
-            opacity: 1,
-            visibility: 'visible',
-          },
-        },
-      }}
-    >
+    <DashboardDraggableContainer>
       <Typography variant="subtitle2">
         {participant.firstname} {participant.lastname}
       </Typography>
       <Typography variant="caption" color="text.secondary">
         {organizationName} {participant.tags?.join(', ')}
       </Typography>
-    </Box>
+    </DashboardDraggableContainer>
   );
 }

--- a/src/components/dashboard/DashboardParticipantCard.tsx
+++ b/src/components/dashboard/DashboardParticipantCard.tsx
@@ -10,7 +10,25 @@ export default function DashboardParticipantCard({ participant }: { participant:
   const organizationName = getOrganizationName(activity, participant.organizationId);
   return (
     <Draggable key={participant.id} type="participant" item={participant}>
-      <Box key={participant.id} sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2, p: 1, cursor: 'grab', bgcolor: 'background.paper' }}>
+      <Box
+        key={participant.id}
+        sx={{
+          border: '1px solid',
+          borderColor: 'divider',
+          borderRadius: 2,
+          p: 1,
+          cursor: 'grab',
+          bgcolor: 'background.paper',
+          ':hover': {
+            bgcolor: 'grey.100',
+            // Targets the child element with class 'promote-button' when Stack is hovered
+            '& .promote-button': {
+              opacity: 1,
+              visibility: 'visible',
+            },
+          },
+        }}
+      >
         <Typography variant="subtitle2">
           {participant.firstname} {participant.lastname}
         </Typography>

--- a/src/components/dashboard/DashboardPlaceEditDialog.tsx
+++ b/src/components/dashboard/DashboardPlaceEditDialog.tsx
@@ -1,0 +1,120 @@
+import { Button, DialogActions, DialogContent, DialogTitle, TextField } from '@mui/material';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+
+import { Activity } from '@respond/types/activity';
+
+import { isDefaultPlace, Place } from '../../types/operations';
+import { useActivityContext } from '../activities/ActivityProvider';
+import DialogWithHistory from '../DialogWithHistory';
+import { Stack } from '../Material';
+
+type DashboardPlaceEditDialogProps = {
+  place: Place | null;
+  onSave: (place: Place) => void;
+  onClose: () => void;
+};
+
+type FormValues = {
+  name: string;
+  lat: string;
+  lon: string;
+  notes: string;
+};
+
+export function validatePlaceName(activity: Activity, placeId: string, name: string): { isValid: boolean; error?: string } {
+  const trimmedName = name.trim();
+
+  if (!trimmedName) {
+    return { isValid: false, error: 'Place name is required.' };
+  }
+
+  const hasDuplicate = activity.places.some((place) => place.id !== placeId && place.name.trim().toLowerCase() === trimmedName.toLowerCase());
+
+  if (hasDuplicate) {
+    return { isValid: false, error: 'Place name already exists.' };
+  }
+
+  return { isValid: true };
+}
+
+export function DashboardPlaceEditDialog({ place, onSave, onClose }: DashboardPlaceEditDialogProps) {
+  const activity = useActivityContext();
+
+  const isDefault = !!place && isDefaultPlace(place);
+
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors },
+    reset,
+  } = useForm<FormValues>({
+    // Use `values` instead of `defaultValues` to keep the form synced when `place` changes or finishes loading
+    values: {
+      name: place?.name ?? '',
+      lat: place?.lat ?? '',
+      lon: place?.lon ?? '',
+      notes: place?.notes ?? '',
+    },
+  });
+
+  useEffect(() => {
+    reset({
+      name: place?.name ?? '',
+      lat: place?.lat ?? '',
+      lon: place?.lon ?? '',
+      notes: place?.notes ?? '',
+    });
+  }, [place, reset]);
+
+  const handleSave = (data: FormValues) => {
+    // Safety check in case the form is somehow submitted while place is undefined
+    if (!place) return;
+
+    const validation = validatePlaceName(activity, place.id, data.name);
+
+    if (!validation.isValid) {
+      setError('name', {
+        type: 'manual',
+        message: validation.error ?? 'Please enter a place name.',
+      });
+      return;
+    }
+
+    onSave({
+      ...place,
+      name: data.name.trim(),
+      lat: data.lat?.trim(),
+      lon: data.lon?.trim(),
+      notes: data.notes?.trim(),
+    });
+  };
+
+  // Prevent rendering dialog contents if place is null/undefined
+  if (!place) return null;
+
+  return (
+    <DialogWithHistory fullWidth={true} open={Boolean(place)} onClose={onClose}>
+      <DialogTitle>Edit Place</DialogTitle>
+
+      <form onSubmit={handleSubmit(handleSave)}>
+        <DialogContent>
+          <Stack spacing={2} sx={{ pt: 1 }}>
+            <TextField autoFocus label="Place Name" disabled={isDefault} fullWidth {...register('name')} error={Boolean(errors.name)} helperText={errors.name?.message ?? 'Choose a unique name for this place.'} />
+            <TextField label="Latitude" fullWidth multiline minRows={3} {...register('lat')} />
+            <TextField label="Longitude" fullWidth multiline minRows={3} {...register('lon')} />
+            <TextField label="Notes" fullWidth multiline minRows={3} {...register('notes')} />
+          </Stack>
+        </DialogContent>
+
+        <DialogActions>
+          <Button onClick={onClose}>Cancel</Button>
+          <Button type="submit" variant="contained">
+            Save
+          </Button>
+        </DialogActions>
+      </form>
+    </DialogWithHistory>
+  );
+}

--- a/src/components/dashboard/DashboardPlaceEditDialog.tsx
+++ b/src/components/dashboard/DashboardPlaceEditDialog.tsx
@@ -73,6 +73,7 @@ export function DashboardPlaceEditDialog({ place, onSave, onClose }: DashboardPl
     if (!place) return;
 
     const validation = validatePlaceName(activity, place.id, data.name);
+    // TODO: Validate Coordinates Inputs (see LocationEditForm form)
 
     if (!validation.isValid) {
       setError('name', {
@@ -102,8 +103,8 @@ export function DashboardPlaceEditDialog({ place, onSave, onClose }: DashboardPl
         <DialogContent>
           <Stack spacing={2} sx={{ pt: 1 }}>
             <TextField autoFocus label="Place Name" disabled={isDefault} fullWidth {...register('name')} error={Boolean(errors.name)} helperText={errors.name?.message ?? 'Choose a unique name for this place.'} />
-            <TextField label="Latitude" fullWidth multiline minRows={3} {...register('lat')} />
-            <TextField label="Longitude" fullWidth multiline minRows={3} {...register('lon')} />
+            <TextField label="Latitude" fullWidth multiline {...register('lat')} />
+            <TextField label="Longitude" fullWidth multiline {...register('lon')} />
             <TextField label="Notes" fullWidth multiline minRows={3} {...register('notes')} />
           </Stack>
         </DialogContent>

--- a/src/components/dashboard/DashboardPlaceEditDialog.tsx
+++ b/src/components/dashboard/DashboardPlaceEditDialog.tsx
@@ -1,6 +1,6 @@
 import { Button, DialogActions, DialogContent, DialogTitle, TextField } from '@mui/material';
-import { useEffect } from 'react';
-import { useForm } from 'react-hook-form';
+import { useEffect, useMemo } from 'react';
+import { FieldErrors, Resolver, useForm } from 'react-hook-form';
 
 import { Activity } from '@respond/types/activity';
 
@@ -15,41 +15,87 @@ type DashboardPlaceEditDialogProps = {
   onClose: () => void;
 };
 
-type FormValues = {
-  name: string;
-  lat: string;
-  lon: string;
-  notes: string;
+type FormValues = Pick<Place, 'name' | 'lat' | 'lon' | 'notes'>;
+
+/**
+ * Builds a resolver scoped to the current activity and place.
+ */
+const createResolver = (activity: Activity, placeId: string): Resolver<FormValues> => {
+  return async (values) => {
+    const normalizedValues: FormValues = {
+      name: values.name?.trim() ?? '',
+      lat: values.lat?.trim() ?? '',
+      lon: values.lon?.trim() ?? '',
+      notes: values.notes?.trim() ?? '',
+    };
+
+    const errors: FieldErrors<FormValues> = {};
+
+    if (!normalizedValues.name) {
+      errors.name = { type: 'required', message: 'Name is required' };
+    }
+
+    const hasDuplicate = activity.places.some((place) => place.id !== placeId && place.name.trim().toLowerCase() === normalizedValues.name.toLowerCase());
+    if (hasDuplicate) {
+      errors.name = { type: 'duplicate', message: 'Place name already exists' };
+    }
+
+    const hasLat = !!normalizedValues.lat;
+    const hasLon = !!normalizedValues.lon;
+
+    if (hasLat && !hasLon) {
+      errors.lon = { type: 'required', message: 'Longitude is required when latitude is provided' };
+    }
+
+    if (hasLon && !hasLat) {
+      errors.lat = { type: 'required', message: 'Latitude is required when longitude is provided' };
+    }
+
+    if (hasLat) {
+      const parsedLat = Number(normalizedValues.lat);
+      if (!Number.isFinite(parsedLat)) {
+        errors.lat = { type: 'format', message: 'Latitude must be a valid decimal number' };
+      } else if (parsedLat < -90 || parsedLat > 90) {
+        errors.lat = { type: 'range', message: 'Latitude must be between -90 and 90' };
+      }
+    }
+
+    if (hasLon) {
+      const parsedLon = Number(normalizedValues.lon);
+      if (!Number.isFinite(parsedLon)) {
+        errors.lon = { type: 'format', message: 'Longitude must be a valid decimal number' };
+      } else if (parsedLon < -180 || parsedLon > 180) {
+        errors.lon = { type: 'range', message: 'Longitude must be between -180 and 180' };
+      }
+    }
+
+    if (Object.keys(errors).length > 0) {
+      return {
+        values: {} as FormValues,
+        errors,
+      };
+    }
+
+    return {
+      values: normalizedValues,
+      errors: {},
+    };
+  };
 };
-
-export function validatePlaceName(activity: Activity, placeId: string, name: string): { isValid: boolean; error?: string } {
-  const trimmedName = name.trim();
-
-  if (!trimmedName) {
-    return { isValid: false, error: 'Place name is required.' };
-  }
-
-  const hasDuplicate = activity.places.some((place) => place.id !== placeId && place.name.trim().toLowerCase() === trimmedName.toLowerCase());
-
-  if (hasDuplicate) {
-    return { isValid: false, error: 'Place name already exists.' };
-  }
-
-  return { isValid: true };
-}
 
 export function DashboardPlaceEditDialog({ place, onSave, onClose }: DashboardPlaceEditDialogProps) {
   const activity = useActivityContext();
 
   const isDefault = !!place && isDefaultPlace(place);
+  const resolver = useMemo(() => createResolver(activity, place?.id ?? ''), [activity, place?.id]);
 
   const {
     register,
     handleSubmit,
-    setError,
     formState: { errors },
     reset,
   } = useForm<FormValues>({
+    resolver,
     // Use `values` instead of `defaultValues` to keep the form synced when `place` changes or finishes loading
     values: {
       name: place?.name ?? '',
@@ -72,23 +118,12 @@ export function DashboardPlaceEditDialog({ place, onSave, onClose }: DashboardPl
     // Safety check in case the form is somehow submitted while place is undefined
     if (!place) return;
 
-    const validation = validatePlaceName(activity, place.id, data.name);
-    // TODO: Validate Coordinates Inputs (see LocationEditForm form)
-
-    if (!validation.isValid) {
-      setError('name', {
-        type: 'manual',
-        message: validation.error ?? 'Please enter a place name.',
-      });
-      return;
-    }
-
     onSave({
       ...place,
-      name: data.name.trim(),
-      lat: data.lat?.trim(),
-      lon: data.lon?.trim(),
-      notes: data.notes?.trim(),
+      name: data.name,
+      lat: data.lat,
+      lon: data.lon,
+      notes: data.notes,
     });
   };
 
@@ -103,8 +138,8 @@ export function DashboardPlaceEditDialog({ place, onSave, onClose }: DashboardPl
         <DialogContent>
           <Stack spacing={2} sx={{ pt: 1 }}>
             <TextField autoFocus label="Place Name" disabled={isDefault} fullWidth {...register('name')} error={Boolean(errors.name)} helperText={errors.name?.message ?? 'Choose a unique name for this place.'} />
-            <TextField label="Latitude" fullWidth multiline {...register('lat')} />
-            <TextField label="Longitude" fullWidth multiline {...register('lon')} />
+            <TextField label="Latitude" fullWidth {...register('lat')} error={Boolean(errors.lat)} helperText={errors.lat?.message ?? 'Optional, decimal degrees (-90 to 90).'} />
+            <TextField label="Longitude" fullWidth {...register('lon')} error={Boolean(errors.lon)} helperText={errors.lon?.message ?? 'Optional, decimal degrees (-180 to 180).'} />
             <TextField label="Notes" fullWidth multiline minRows={3} {...register('notes')} />
           </Stack>
         </DialogContent>

--- a/src/components/dashboard/DashboardPlaceEditDialog.tsx
+++ b/src/components/dashboard/DashboardPlaceEditDialog.tsx
@@ -35,7 +35,7 @@ const createResolver = (activity: Activity, placeId: string): Resolver<FormValue
       errors.name = { type: 'required', message: 'Name is required' };
     }
 
-    const hasDuplicate = activity.places.some((place) => place.id !== placeId && place.name.trim().toLowerCase() === normalizedValues.name.toLowerCase());
+    const hasDuplicate = (activity.places ?? []).some((place) => place.id !== placeId && place.name.trim().toLowerCase() === normalizedValues.name.toLowerCase());
     if (hasDuplicate) {
       errors.name = { type: 'duplicate', message: 'Place name already exists' };
     }

--- a/src/components/dashboard/DashboardPlaceManager.tsx
+++ b/src/components/dashboard/DashboardPlaceManager.tsx
@@ -11,6 +11,7 @@ import { createNewPlace, DEFAULT_PLACES, EquipmentItem, getDefaultPlaces, isDefa
 
 import { useActivityContext } from '../activities/ActivityProvider';
 import ConfirmDialog from '../ConfirmDialog';
+import { CopyChip } from '../CopyChip';
 import { Draggable, Droppable } from '../DragAndDrop/DnDComponents';
 import { Stack } from '../Material';
 
@@ -219,12 +220,10 @@ function PlaceTile({ place }: { place: Place }) {
           </Box>
           {place.lat?.trim() && place.lon?.trim() && (
             <Box sx={{ width: '100%', mt: 1, p: 1.75, pt: 1, borderTop: '1px solid', borderColor: 'divider' }}>
-              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+              <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
                 Coordinates
               </Typography>
-              <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
-                {`${place.lat?.trim()}, ${place.lon?.trim()}`}
-              </Typography>
+              <CopyChip value={`${place.lat?.trim()}, ${place.lon?.trim()}`} size="small" variant="outlined" sx={{ mt: 1 }} />
             </Box>
           )}
           {place.notes?.trim() && (

--- a/src/components/dashboard/DashboardPlaceManager.tsx
+++ b/src/components/dashboard/DashboardPlaceManager.tsx
@@ -193,37 +193,30 @@ function PlaceTile({ place }: { place: Place }) {
     <Droppable accepts={['participant', 'equipment']} onDrop={handleDrop}>
       <DashboardBoxWithTitle title={place.name} actions={actions} collapsible>
         <Stack spacing={1}>
-          <Box sx={{ flex: 1, minWidth: 0, border: '1px solid', borderColor: 'divider', borderRadius: 2, p: 1 }}>
-            <Typography variant="caption" color="text.secondary" sx={{ pl: 1 }}>
-              Personnel
-            </Typography>
-            <Stack spacing={0.75} sx={{ mt: 0.5 }}>
-              {place.assignedParticipants.length === 0 ? (
-                <Typography variant="body2" color="text.secondary" sx={{ pl: 1 }}>
-                  None
-                </Typography>
-              ) : (
-                participants.map((participant) => {
-                  return (
-                    <Draggable key={participant.id} type="participant" item={participant} callback={() => removeTeamMember(participant.id)}>
-                      <DashboardTeamMember key={participant.id} participant={participant} />
-                    </Draggable>
-                  );
-                })
-              )}
+          {!!place.assignedParticipants.length && (
+            <Stack spacing={0.75} sx={{ mt: 1, pt: 1, borderTop: '1px solid', borderColor: 'divider' }}>
+              <Typography variant="caption" color="text.secondary" sx={{ pl: 1 }}>
+                Personnel
+              </Typography>
+              <Stack spacing={0.75} sx={{ mt: 0.5 }}>
+                {!!place.assignedParticipants.length &&
+                  participants.map((participant) => {
+                    return (
+                      <Draggable key={participant.id} type="participant" item={participant} callback={() => removeTeamMember(participant.id)}>
+                        <DashboardTeamMember key={participant.id} participant={participant} />
+                      </Draggable>
+                    );
+                  })}
+              </Stack>
             </Stack>
-          </Box>
-          <Box sx={{ flex: 1, minWidth: 0, border: '1px solid', borderColor: 'divider', borderRadius: 2, p: 1 }}>
-            <Typography variant="caption" color="text.secondary" sx={{ pl: 1 }}>
-              Equipment
-            </Typography>
-            <Stack spacing={0.75} sx={{ mt: 0.5 }}>
-              {sortedTeamEquipment.length === 0 ? (
-                <Typography variant="body2" color="text.secondary" sx={{ pl: 1 }}>
-                  None
-                </Typography>
-              ) : (
-                sortedTeamEquipment.map((item) => {
+          )}
+          {!!sortedTeamEquipment.length && (
+            <Stack spacing={0.75} sx={{ mt: 1, pt: 1, borderTop: '1px solid', borderColor: 'divider' }}>
+              <Typography variant="caption" color="text.secondary" sx={{ pl: 1 }}>
+                Equipment
+              </Typography>
+              <Stack spacing={0.75} sx={{ mt: 0.5 }}>
+                {sortedTeamEquipment.map((item) => {
                   return (
                     <Draggable
                       key={item.uuid}
@@ -236,10 +229,10 @@ function PlaceTile({ place }: { place: Place }) {
                       <DashboardTeamEquipment key={item.uuid} item={item} />
                     </Draggable>
                   );
-                })
-              )}
+                })}
+              </Stack>
             </Stack>
-          </Box>
+          )}
           {place.lat?.trim() && place.lon?.trim() && (
             <Box sx={{ width: '100%', mt: 1, p: 1.75, pt: 1, borderTop: '1px solid', borderColor: 'divider' }}>
               <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>

--- a/src/components/dashboard/DashboardPlaceManager.tsx
+++ b/src/components/dashboard/DashboardPlaceManager.tsx
@@ -102,6 +102,7 @@ function PlaceTile({ place }: { place: Place }) {
   };
 
   const deletePlace = (id: string) => {
+    // TODO: Reassign remaining resource to the unassigned place.
     dispatch(
       ActivityActions.updatePlaces(
         activity.id,

--- a/src/components/dashboard/DashboardPlaceManager.tsx
+++ b/src/components/dashboard/DashboardPlaceManager.tsx
@@ -6,6 +6,7 @@ import React, { useEffect, useState } from 'react';
 
 import { useAppDispatch } from '@respond/lib/client/store';
 import { ActivityActions } from '@respond/lib/state';
+import { Participant } from '@respond/types/activity';
 import { createNewPlace, DEFAULT_PLACES, EquipmentItem, getDefaultPlaces, isDefaultPlace, Place, sortEquipmentAlphabetically } from '@respond/types/operations';
 
 import { useActivityContext } from '../activities/ActivityProvider';
@@ -14,9 +15,8 @@ import { Stack } from '../Material';
 
 import { DashboardBoxWithTitle } from './DashboardBoxWithTitle';
 import { DashboardPlaceEditDialog } from './DashboardPlaceEditDialog';
-import { DashboardTeamMember } from './DashboardTeamMember';
-import { Participant, ParticipantStatus } from '@respond/types/activity';
 import { DashboardTeamEquipment } from './DashboardTeamEquipment';
+import { DashboardTeamMember } from './DashboardTeamMember';
 
 export function DashboardPlaceManager() {
   const dispatch = useAppDispatch();
@@ -145,17 +145,17 @@ function PlaceTile({ place }: { place: Place }) {
     // Update the Place to include the new participant
     const updated: Place = { ...place, assignedParticipants: [...place.assignedParticipants, participant.id] };
     dispatchUpdate(updated);
-  }
+  };
 
   const removeTeamMember = (participantId: string) => {
     const updated: Place = { ...place, assignedParticipants: place.assignedParticipants.filter((id) => id !== participantId) };
     dispatchUpdate(updated);
-  }
+  };
 
   const addEquipment = (equipment: EquipmentItem) => {
     const updated: Place = { ...place, assignedEquipment: [...place.assignedEquipment, equipment] };
     dispatchUpdate(updated);
-  }
+  };
 
   const removeEquipment = (id: string) => {
     if (place.assignedEquipment.some((item) => item.uuid === id)) {
@@ -163,16 +163,16 @@ function PlaceTile({ place }: { place: Place }) {
       const updated = { ...place, assignedEquipment: place.assignedEquipment.filter((item) => item.uuid !== id) };
       dispatchUpdate(updated);
     }
-  }
+  };
 
   const dispatchUpdate = (updated: Place) => {
     dispatch(
       ActivityActions.updatePlaces(
         activity.id,
-        activity.places.map((p) => p.id === place.id ? updated : p),
+        activity.places.map((p) => (p.id === place.id ? updated : p)),
       ),
     );
-  }
+  };
 
   return (
     <Droppable accepts={['participant', 'equipment']} onDrop={handleDrop}>
@@ -190,7 +190,7 @@ function PlaceTile({ place }: { place: Place }) {
               ) : (
                 participants.map((participant) => {
                   return (
-                    <Draggable type="participant" item={participant} callback={() => removeTeamMember(participant.id)}>
+                    <Draggable key={participant.id} type="participant" item={participant} callback={() => removeTeamMember(participant.id)}>
                       <DashboardTeamMember key={participant.id} participant={participant} />
                     </Draggable>
                   );
@@ -210,9 +210,14 @@ function PlaceTile({ place }: { place: Place }) {
               ) : (
                 sortedTeamEquipment.map((item) => {
                   return (
-                    <Draggable type="equipment" item={item} callback={() => {
-                      if (item.uuid) removeEquipment(item.uuid)
-                    }}>
+                    <Draggable
+                      key={item.uuid}
+                      type="equipment"
+                      item={item}
+                      callback={() => {
+                        if (item.uuid) removeEquipment(item.uuid);
+                      }}
+                    >
                       <DashboardTeamEquipment key={item.uuid} item={item} />
                     </Draggable>
                   );

--- a/src/components/dashboard/DashboardPlaceManager.tsx
+++ b/src/components/dashboard/DashboardPlaceManager.tsx
@@ -3,11 +3,12 @@ import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import EditIcon from '@mui/icons-material/Edit';
 import { Box, Button, Typography } from '@mui/material';
 import React, { useEffect, useState } from 'react';
+import { v4 as uuid } from 'uuid';
 
 import { useAppDispatch } from '@respond/lib/client/store';
 import { ActivityActions } from '@respond/lib/state';
 import { Participant } from '@respond/types/activity';
-import { createNewPlace, DEFAULT_PLACES, EquipmentItem, getDefaultPlaces, isDefaultPlace, Place, sortEquipmentAlphabetically } from '@respond/types/operations';
+import { CommunicationsLogEntry, createNewPlace, DEFAULT_PLACES, EquipmentItem, getDefaultPlaces, isDefaultPlace, Place, sortEquipmentAlphabetically } from '@respond/types/operations';
 
 import { useActivityContext } from '../activities/ActivityProvider';
 import ConfirmDialog from '../ConfirmDialog';
@@ -37,6 +38,11 @@ export function DashboardPlaceManager() {
 
   const addPlace = (placeToCreate: Place) => {
     dispatch(ActivityActions.createPlace(activity.id, placeToCreate));
+    const parts = [placeToCreate.name, 'established: '];
+    if (placeToCreate.lat?.trim() && placeToCreate.lon?.trim()) parts.push(`${placeToCreate.lat.trim()}, ${placeToCreate.lon.trim()}`);
+    if (placeToCreate.notes?.trim()) parts.push(placeToCreate.notes.trim());
+    const comm: CommunicationsLogEntry = { id: uuid(), from: placeToCreate.name, to: 'CP', message: parts.join(' '), timestamp: Date.now(), isAutomated: true, isDeleted: false };
+    dispatch(ActivityActions.addComm(activity.id, comm));
   };
 
   // nullish coalese for backward compatibility on inital render
@@ -102,6 +108,12 @@ function PlaceTile({ place }: { place: Place }) {
       return;
     }
     dispatch(ActivityActions.deletePlace(activity.id, id));
+    logDeleteComm();
+  };
+
+  const logDeleteComm = () => {
+    const comm: CommunicationsLogEntry = { id: uuid(), from: place.name, to: 'CP', message: `${place.name} terminated`, timestamp: Date.now(), isAutomated: true, isDeleted: false };
+    dispatch(ActivityActions.addComm(activity.id, comm));
   };
 
   const deleteAndReassign = () => {
@@ -111,6 +123,7 @@ function PlaceTile({ place }: { place: Place }) {
     const mergedEquipment = [...(fieldPlace?.assignedEquipment ?? []), ...place.assignedEquipment.filter((item) => !existingEquipmentIds.has(item.uuid))];
     const updatedFieldPlace = fieldPlace ? { ...fieldPlace, assignedParticipants: mergedParticipants, assignedEquipment: mergedEquipment } : { ...createNewPlace(DEFAULT_PLACES.field), assignedParticipants: mergedParticipants, assignedEquipment: mergedEquipment };
     dispatch(ActivityActions.batchUpdatePlaces(activity.id, [updatedFieldPlace], [place.id]));
+    logDeleteComm();
   };
 
   const editAction = {

--- a/src/components/dashboard/DashboardPlaceManager.tsx
+++ b/src/components/dashboard/DashboardPlaceManager.tsx
@@ -29,12 +29,12 @@ export function DashboardPlaceManager() {
     const defaultPlaces = getDefaultPlaces(activity);
 
     if (defaultPlaces.length) {
-      dispatch(ActivityActions.updatePlaces(activity.id, [...(activity.places ?? []), ...defaultPlaces]));
+      defaultPlaces.forEach((place) => dispatch(ActivityActions.createPlace(activity.id, place)));
     }
   }, [activity, dispatch]);
 
-  const addPlace = (placeToUpsert: Place) => {
-    dispatch(ActivityActions.updatePlaces(activity.id, [...(activity.places ?? []), placeToUpsert]));
+  const addPlace = (placeToCreate: Place) => {
+    dispatch(ActivityActions.createPlace(activity.id, placeToCreate));
   };
 
   // nullish coalese for backward compatibility on inital render
@@ -82,33 +82,19 @@ function PlaceTile({ place }: { place: Place }) {
 
   const upsertPlace = (placeToUpsert: Place) => {
     const currentPlaces = activity.places ?? [];
-    let exists = false;
+    const exists = currentPlaces.some((p) => p.id === placeToUpsert.id);
 
-    // 1. Map through places: replace if ID matches
-    const updatedPlaces = currentPlaces.map((p) => {
-      if (p.id === placeToUpsert.id) {
-        exists = true;
-        return placeToUpsert; // Replace existing place
-      }
-      return p;
-    });
-
-    // 2. Fallback: if it wasn't found in the map, append it
     if (!exists) {
-      updatedPlaces.push(placeToUpsert);
+      dispatch(ActivityActions.createPlace(activity.id, placeToUpsert));
+      return;
     }
 
-    dispatch(ActivityActions.updatePlaces(activity.id, updatedPlaces));
+    dispatch(ActivityActions.updatePlace(activity.id, placeToUpsert));
   };
 
   const deletePlace = (id: string) => {
     // TODO: Reassign remaining resource to the unassigned place.
-    dispatch(
-      ActivityActions.updatePlaces(
-        activity.id,
-        activity.places.filter((p) => p.id !== id),
-      ),
-    );
+    dispatch(ActivityActions.deletePlace(activity.id, id));
   };
 
   const editAction = {
@@ -166,12 +152,7 @@ function PlaceTile({ place }: { place: Place }) {
   };
 
   const dispatchUpdate = (updated: Place) => {
-    dispatch(
-      ActivityActions.updatePlaces(
-        activity.id,
-        activity.places.map((p) => (p.id === place.id ? updated : p)),
-      ),
-    );
+    dispatch(ActivityActions.updatePlace(activity.id, updated));
   };
 
   return (

--- a/src/components/dashboard/DashboardPlaceManager.tsx
+++ b/src/components/dashboard/DashboardPlaceManager.tsx
@@ -3,12 +3,11 @@ import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import EditIcon from '@mui/icons-material/Edit';
 import { Box, Button, Typography } from '@mui/material';
 import React, { useEffect, useState } from 'react';
-import { v4 as uuid } from 'uuid';
 
 import { useAppDispatch } from '@respond/lib/client/store';
 import { ActivityActions } from '@respond/lib/state';
 import { Participant } from '@respond/types/activity';
-import { CommunicationsLogEntry, createNewPlace, DEFAULT_PLACES, EquipmentItem, getDefaultPlaces, isDefaultPlace, Place, sortEquipmentAlphabetically } from '@respond/types/operations';
+import { CommunicationsLogEntry, createNewCommsEntry, createNewPlace, DEFAULT_PLACES, EquipmentItem, getDefaultPlaces, isDefaultPlace, Place, sortEquipmentAlphabetically } from '@respond/types/operations';
 
 import { useActivityContext } from '../activities/ActivityProvider';
 import ConfirmDialog from '../ConfirmDialog';
@@ -41,7 +40,12 @@ export function DashboardPlaceManager() {
     const parts = [placeToCreate.name, 'established: '];
     if (placeToCreate.lat?.trim() && placeToCreate.lon?.trim()) parts.push(`${placeToCreate.lat.trim()}, ${placeToCreate.lon.trim()}`);
     if (placeToCreate.notes?.trim()) parts.push(placeToCreate.notes.trim());
-    const comm: CommunicationsLogEntry = { id: uuid(), from: placeToCreate.name, to: 'CP', message: parts.join(' '), timestamp: Date.now(), isAutomated: true, isDeleted: false };
+    const comm: CommunicationsLogEntry = createNewCommsEntry({
+      from: placeToCreate.name,
+      to: 'CP',
+      message: parts.join(' '),
+      isAutomated: true,
+    });
     dispatch(ActivityActions.addComm(activity.id, comm));
   };
 
@@ -112,7 +116,12 @@ function PlaceTile({ place }: { place: Place }) {
   };
 
   const logDeleteComm = () => {
-    const comm: CommunicationsLogEntry = { id: uuid(), from: place.name, to: 'CP', message: `${place.name} terminated`, timestamp: Date.now(), isAutomated: true, isDeleted: false };
+    const comm: CommunicationsLogEntry = createNewCommsEntry({
+      from: place.name,
+      to: 'CP',
+      message: `${place.name} terminated`,
+      isAutomated: true,
+    });
     dispatch(ActivityActions.addComm(activity.id, comm));
   };
 

--- a/src/components/dashboard/DashboardPlaceManager.tsx
+++ b/src/components/dashboard/DashboardPlaceManager.tsx
@@ -10,6 +10,7 @@ import { Participant } from '@respond/types/activity';
 import { createNewPlace, DEFAULT_PLACES, EquipmentItem, getDefaultPlaces, isDefaultPlace, Place, sortEquipmentAlphabetically } from '@respond/types/operations';
 
 import { useActivityContext } from '../activities/ActivityProvider';
+import ConfirmDialog from '../ConfirmDialog';
 import { Draggable, Droppable } from '../DragAndDrop/DnDComponents';
 import { Stack } from '../Material';
 
@@ -72,6 +73,7 @@ function PlaceTile({ place }: { place: Place }) {
   const activity = useActivityContext();
 
   const [editingPlace, setEditingPlace] = useState<Place | null>(null);
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
   const participants = (place.assignedParticipants ?? []).flatMap((id) => {
     const participant = activity.participants[id];
@@ -93,8 +95,21 @@ function PlaceTile({ place }: { place: Place }) {
   };
 
   const deletePlace = (id: string) => {
-    // TODO: Reassign remaining resource to the unassigned place.
+    const hasResources = place.assignedParticipants.length > 0 || place.assignedEquipment.length > 0;
+    if (hasResources) {
+      setConfirmDeleteOpen(true);
+      return;
+    }
     dispatch(ActivityActions.deletePlace(activity.id, id));
+  };
+
+  const deleteAndReassign = () => {
+    const fieldPlace = activity.places?.find((p) => p.name === DEFAULT_PLACES.field);
+    const mergedParticipants = Array.from(new Set([...(fieldPlace?.assignedParticipants ?? []), ...place.assignedParticipants]));
+    const existingEquipmentIds = new Set(fieldPlace?.assignedEquipment.map((item) => item.uuid));
+    const mergedEquipment = [...(fieldPlace?.assignedEquipment ?? []), ...place.assignedEquipment.filter((item) => !existingEquipmentIds.has(item.uuid))];
+    const updatedFieldPlace = fieldPlace ? { ...fieldPlace, assignedParticipants: mergedParticipants, assignedEquipment: mergedEquipment } : { ...createNewPlace(DEFAULT_PLACES.field), assignedParticipants: mergedParticipants, assignedEquipment: mergedEquipment };
+    dispatch(ActivityActions.batchUpdatePlaces(activity.id, [updatedFieldPlace], [place.id]));
   };
 
   const editAction = {
@@ -128,26 +143,22 @@ function PlaceTile({ place }: { place: Place }) {
   };
 
   const addTeamMember = (participant: Participant) => {
-    // Update the Place to include the new participant
-    const updated: Place = { ...place, assignedParticipants: [...place.assignedParticipants, participant.id] };
-    dispatchUpdate(updated);
+    dispatchUpdate({ ...place, assignedParticipants: [...place.assignedParticipants, participant.id] });
   };
 
   const removeTeamMember = (participantId: string) => {
-    const updated: Place = { ...place, assignedParticipants: place.assignedParticipants.filter((id) => id !== participantId) };
-    dispatchUpdate(updated);
+    if (place.assignedParticipants.includes(participantId)) {
+      dispatchUpdate({ ...place, assignedParticipants: place.assignedParticipants.filter((id) => id !== participantId) });
+    }
   };
 
   const addEquipment = (equipment: EquipmentItem) => {
-    const updated: Place = { ...place, assignedEquipment: [...place.assignedEquipment, equipment] };
-    dispatchUpdate(updated);
+    dispatchUpdate({ ...place, assignedEquipment: [...place.assignedEquipment, equipment] });
   };
 
   const removeEquipment = (id: string) => {
     if (place.assignedEquipment.some((item) => item.uuid === id)) {
-      // Remove the equipment from the team
-      const updated = { ...place, assignedEquipment: place.assignedEquipment.filter((item) => item.uuid !== id) };
-      dispatchUpdate(updated);
+      dispatchUpdate({ ...place, assignedEquipment: place.assignedEquipment.filter((item) => item.uuid !== id) });
     }
   };
 
@@ -207,7 +218,7 @@ function PlaceTile({ place }: { place: Place }) {
             </Stack>
           </Box>
           {place.lat?.trim() && place.lon?.trim() && (
-            <Box sx={{ width: '100%', mt: 1, pt: 1, borderTop: '1px solid', borderColor: 'divider' }}>
+            <Box sx={{ width: '100%', mt: 1, p: 1.75, pt: 1, borderTop: '1px solid', borderColor: 'divider' }}>
               <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
                 Coordinates
               </Typography>
@@ -217,7 +228,7 @@ function PlaceTile({ place }: { place: Place }) {
             </Box>
           )}
           {place.notes?.trim() && (
-            <Box sx={{ width: '100%', mt: 1, pt: 1, borderTop: '1px solid', borderColor: 'divider' }}>
+            <Box sx={{ width: '100%', mt: 1, p: 1.75, pt: 1, borderTop: '1px solid', borderColor: 'divider' }}>
               <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
                 Notes
               </Typography>
@@ -235,6 +246,15 @@ function PlaceTile({ place }: { place: Place }) {
           setEditingPlace(null);
         }}
         onClose={() => setEditingPlace(null)}
+      />
+      <ConfirmDialog
+        open={confirmDeleteOpen}
+        prompt={`"${place.name}" still has assigned members or equipment. They will be moved to ${DEFAULT_PLACES.field}. Delete anyway?`}
+        onConfirm={() => {
+          deleteAndReassign();
+          setConfirmDeleteOpen(false);
+        }}
+        onClose={() => setConfirmDeleteOpen(false)}
       />
     </Droppable>
   );

--- a/src/components/dashboard/DashboardPlaceManager.tsx
+++ b/src/components/dashboard/DashboardPlaceManager.tsx
@@ -11,11 +11,11 @@ import { CommunicationsLogEntry, createNewCommsEntry, createNewPlace, DEFAULT_PL
 
 import { useActivityContext } from '../activities/ActivityProvider';
 import ConfirmDialog from '../ConfirmDialog';
-import { CopyChip } from '../CopyChip';
 import { Draggable, Droppable } from '../DragAndDrop/DnDComponents';
 import { Stack } from '../Material';
 
 import { DashboardBoxWithTitle } from './DashboardBoxWithTitle';
+import { DashboardCopyChip } from './DashboardCopyChip';
 import { DashboardPlaceEditDialog } from './DashboardPlaceEditDialog';
 import { DashboardTeamEquipment } from './DashboardTeamEquipment';
 import { DashboardTeamMember } from './DashboardTeamMember';
@@ -234,15 +234,15 @@ function PlaceTile({ place }: { place: Place }) {
             </Stack>
           )}
           {place.lat?.trim() && place.lon?.trim() && (
-            <Box sx={{ width: '100%', mt: 1, p: 1.75, pt: 1, borderTop: '1px solid', borderColor: 'divider' }}>
+            <Box sx={{ width: '100%', mt: 1, px: 1.75, py: 1, borderTop: '1px solid', borderColor: 'divider' }}>
               <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
                 Coordinates
               </Typography>
-              <CopyChip value={`${place.lat?.trim()}, ${place.lon?.trim()}`} size="small" variant="outlined" sx={{ mt: 1 }} />
+              <DashboardCopyChip value={`${place.lat?.trim()}, ${place.lon?.trim()}`} />
             </Box>
           )}
           {place.notes?.trim() && (
-            <Box sx={{ width: '100%', mt: 1, p: 1.75, pt: 1, borderTop: '1px solid', borderColor: 'divider' }}>
+            <Box sx={{ width: '100%', mt: 1, px: 1.75, py: 1, borderTop: '1px solid', borderColor: 'divider' }}>
               <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
                 Notes
               </Typography>

--- a/src/components/dashboard/DashboardPlaceManager.tsx
+++ b/src/components/dashboard/DashboardPlaceManager.tsx
@@ -151,12 +151,16 @@ function PlaceTile({ place }: { place: Place }) {
   const actions = isDefaultPlace(place) ? [editAction] : [editAction, deleteAction];
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const handleDrop = (item: any, type: string, callback?: () => void) => {
+  const handleDrop = (item: any, type: string, callback?: (...args: any[]) => void) => {
     if (type === 'participant') {
       // If the item was dragged and dropped back to the same place, cancel.
       if (place.assignedParticipants.includes(item.id)) return;
       addTeamMember(item);
     } else if (type === 'equipment') {
+      if (!!callback && item.type === 'Custom' && item.name === 'Custom Item') {
+        callback({ item, onSave: (newItem: EquipmentItem) => addEquipment(newItem) });
+        return;
+      }
       // If the item was dragged and dropped back to the same place, cancel.
       if (place.assignedEquipment.find((equipment) => item.uuid === equipment.uuid)) return;
       addEquipment(item);

--- a/src/components/dashboard/DashboardPlaceManager.tsx
+++ b/src/components/dashboard/DashboardPlaceManager.tsx
@@ -1,0 +1,254 @@
+import AddIcon from '@mui/icons-material/Add';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import EditIcon from '@mui/icons-material/Edit';
+import { Box, Button, Typography } from '@mui/material';
+import React, { useEffect, useState } from 'react';
+
+import { useAppDispatch } from '@respond/lib/client/store';
+import { ActivityActions } from '@respond/lib/state';
+import { createNewPlace, DEFAULT_PLACES, EquipmentItem, getDefaultPlaces, isDefaultPlace, Place, sortEquipmentAlphabetically } from '@respond/types/operations';
+
+import { useActivityContext } from '../activities/ActivityProvider';
+import { Draggable, Droppable } from '../DragAndDrop/DnDComponents';
+import { Stack } from '../Material';
+
+import { DashboardBoxWithTitle } from './DashboardBoxWithTitle';
+import { DashboardPlaceEditDialog } from './DashboardPlaceEditDialog';
+import { DashboardTeamMember } from './DashboardTeamMember';
+import { Participant, ParticipantStatus } from '@respond/types/activity';
+import { DashboardTeamEquipment } from './DashboardTeamEquipment';
+
+export function DashboardPlaceManager() {
+  const dispatch = useAppDispatch();
+  const activity = useActivityContext();
+
+  const [addingPlace, setAddingPlace] = useState<Place | null>(null);
+
+  // For backward compatibility, if the activity does not have places
+  useEffect(() => {
+    const defaultPlaces = getDefaultPlaces(activity);
+
+    if (defaultPlaces.length) {
+      dispatch(ActivityActions.updatePlaces(activity.id, [...(activity.places ?? []), ...defaultPlaces]));
+    }
+  }, [activity, dispatch]);
+
+  const addPlace = (placeToUpsert: Place) => {
+    dispatch(ActivityActions.updatePlaces(activity.id, [...(activity.places ?? []), placeToUpsert]));
+  };
+
+  // nullish coalese for backward compatibility on inital render
+  const activityPlaces = activity.places?.filter((f) => f.name !== DEFAULT_PLACES.field || f.assignedParticipants.length || f.assignedEquipment.length) ?? [];
+
+  return (
+    <>
+      <Stack spacing={1} sx={{ overflow: 'auto' }}>
+        <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={1} sx={{ mb: 1 }}>
+          <Box />
+          <Button size="small" variant="contained" startIcon={<AddIcon />} onClick={() => setAddingPlace(createNewPlace('New Place'))}>
+            Add
+          </Button>
+        </Stack>
+        <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 1 }}>
+          {activityPlaces.map((place) => (
+            <PlaceTile key={place.id} place={place}></PlaceTile>
+          ))}
+        </Box>
+      </Stack>
+      <DashboardPlaceEditDialog
+        place={addingPlace}
+        onSave={(placeFromForm) => {
+          addPlace(placeFromForm);
+          setAddingPlace(null);
+        }}
+        onClose={() => setAddingPlace(null)}
+      />
+    </>
+  );
+}
+
+function PlaceTile({ place }: { place: Place }) {
+  const dispatch = useAppDispatch();
+  const activity = useActivityContext();
+
+  const [editingPlace, setEditingPlace] = useState<Place | null>(null);
+
+  const participants = (place.assignedParticipants ?? []).flatMap((id) => {
+    const participant = activity.participants[id];
+    return participant ? [participant] : [];
+  });
+
+  const sortedTeamEquipment = [...place.assignedEquipment].sort(sortEquipmentAlphabetically);
+
+  const upsertPlace = (placeToUpsert: Place) => {
+    const currentPlaces = activity.places ?? [];
+    let exists = false;
+
+    // 1. Map through places: replace if ID matches
+    const updatedPlaces = currentPlaces.map((p) => {
+      if (p.id === placeToUpsert.id) {
+        exists = true;
+        return placeToUpsert; // Replace existing place
+      }
+      return p;
+    });
+
+    // 2. Fallback: if it wasn't found in the map, append it
+    if (!exists) {
+      updatedPlaces.push(placeToUpsert);
+    }
+
+    dispatch(ActivityActions.updatePlaces(activity.id, updatedPlaces));
+  };
+
+  const deletePlace = (id: string) => {
+    dispatch(
+      ActivityActions.updatePlaces(
+        activity.id,
+        activity.places.filter((p) => p.id !== id),
+      ),
+    );
+  };
+
+  const editAction = {
+    id: 'edit',
+    icon: <EditIcon sx={{ fontSize: 16 }} />,
+    onClick: () => setEditingPlace(place),
+  };
+
+  const deleteAction = {
+    id: 'delete',
+    icon: <DeleteOutlineIcon sx={{ fontSize: 16, color: 'darkred' }} />,
+    onClick: () => deletePlace(place.id),
+  };
+
+  const actions = isDefaultPlace(place) ? [editAction] : [editAction, deleteAction];
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handleDrop = (item: any, type: string, callback?: () => void) => {
+    if (type === 'participant') {
+      // If the item was dragged and dropped back to the same place, cancel.
+      if (place.assignedParticipants.includes(item.id)) return;
+      addTeamMember(item);
+    } else if (type === 'equipment') {
+      // If the item was dragged and dropped back to the same place, cancel.
+      if (place.assignedEquipment.find((equipment) => item.uuid === equipment.uuid)) return;
+      addEquipment(item);
+    } else {
+      return;
+    }
+    callback?.();
+  };
+
+  const addTeamMember = (participant: Participant) => {
+    // Update the Place to include the new participant
+    const updated: Place = { ...place, assignedParticipants: [...place.assignedParticipants, participant.id] };
+    dispatchUpdate(updated);
+  }
+
+  const removeTeamMember = (participantId: string) => {
+    const updated: Place = { ...place, assignedParticipants: place.assignedParticipants.filter((id) => id !== participantId) };
+    dispatchUpdate(updated);
+  }
+
+  const addEquipment = (equipment: EquipmentItem) => {
+    const updated: Place = { ...place, assignedEquipment: [...place.assignedEquipment, equipment] };
+    dispatchUpdate(updated);
+  }
+
+  const removeEquipment = (id: string) => {
+    if (place.assignedEquipment.some((item) => item.uuid === id)) {
+      // Remove the equipment from the team
+      const updated = { ...place, assignedEquipment: place.assignedEquipment.filter((item) => item.uuid !== id) };
+      dispatchUpdate(updated);
+    }
+  }
+
+  const dispatchUpdate = (updated: Place) => {
+    dispatch(
+      ActivityActions.updatePlaces(
+        activity.id,
+        activity.places.map((p) => p.id === place.id ? updated : p),
+      ),
+    );
+  }
+
+  return (
+    <Droppable accepts={['participant', 'equipment']} onDrop={handleDrop}>
+      <DashboardBoxWithTitle title={place.name} actions={actions} collapsible>
+        <Stack spacing={1}>
+          <Box sx={{ flex: 1, minWidth: 0, border: '1px solid', borderColor: 'divider', borderRadius: 2, p: 1 }}>
+            <Typography variant="caption" color="text.secondary" sx={{ pl: 1 }}>
+              Personnel
+            </Typography>
+            <Stack spacing={0.75} sx={{ mt: 0.5 }}>
+              {place.assignedParticipants.length === 0 ? (
+                <Typography variant="body2" color="text.secondary" sx={{ pl: 1 }}>
+                  None
+                </Typography>
+              ) : (
+                participants.map((participant) => {
+                  return (
+                    <Draggable type="participant" item={participant} callback={() => removeTeamMember(participant.id)}>
+                      <DashboardTeamMember key={participant.id} participant={participant} />
+                    </Draggable>
+                  );
+                })
+              )}
+            </Stack>
+          </Box>
+          <Box sx={{ flex: 1, minWidth: 0, border: '1px solid', borderColor: 'divider', borderRadius: 2, p: 1 }}>
+            <Typography variant="caption" color="text.secondary" sx={{ pl: 1 }}>
+              Equipment
+            </Typography>
+            <Stack spacing={0.75} sx={{ mt: 0.5 }}>
+              {sortedTeamEquipment.length === 0 ? (
+                <Typography variant="body2" color="text.secondary" sx={{ pl: 1 }}>
+                  None
+                </Typography>
+              ) : (
+                sortedTeamEquipment.map((item) => {
+                  return (
+                    <Draggable type="equipment" item={item} callback={() => {
+                      if (item.uuid) removeEquipment(item.uuid)
+                    }}>
+                      <DashboardTeamEquipment key={item.uuid} item={item} />
+                    </Draggable>
+                  );
+                })
+              )}
+            </Stack>
+          </Box>
+          {place.lat?.trim() && place.lon?.trim() && (
+            <Box sx={{ width: '100%', mt: 1, pt: 1, borderTop: '1px solid', borderColor: 'divider' }}>
+              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+                Coordinates
+              </Typography>
+              <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+                {`${place.lat?.trim()}, ${place.lon?.trim()}`}
+              </Typography>
+            </Box>
+          )}
+          {place.notes?.trim() && (
+            <Box sx={{ width: '100%', mt: 1, pt: 1, borderTop: '1px solid', borderColor: 'divider' }}>
+              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+                Notes
+              </Typography>
+              <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+                {place.notes.trim()}
+              </Typography>
+            </Box>
+          )}
+        </Stack>
+      </DashboardBoxWithTitle>
+      <DashboardPlaceEditDialog
+        place={editingPlace}
+        onSave={(placeFromForm) => {
+          upsertPlace(placeFromForm);
+          setEditingPlace(null);
+        }}
+        onClose={() => setEditingPlace(null)}
+      />
+    </Droppable>
+  );
+}

--- a/src/components/dashboard/DashboardPlaceManager.tsx
+++ b/src/components/dashboard/DashboardPlaceManager.tsx
@@ -19,6 +19,7 @@ import { DashboardCopyChip } from './DashboardCopyChip';
 import { DashboardPlaceEditDialog } from './DashboardPlaceEditDialog';
 import { DashboardTeamEquipment } from './DashboardTeamEquipment';
 import { DashboardTeamMember } from './DashboardTeamMember';
+import { DashboardDividedSection } from './DashboardDividedSection';
 
 export function DashboardPlaceManager() {
   const dispatch = useAppDispatch();
@@ -194,11 +195,8 @@ function PlaceTile({ place }: { place: Place }) {
       <DashboardBoxWithTitle title={place.name} actions={actions} collapsible>
         <Stack spacing={1}>
           {!!place.assignedParticipants.length && (
-            <Stack spacing={0.75} sx={{ mt: 1, pt: 1, borderTop: '1px solid', borderColor: 'divider' }}>
-              <Typography variant="caption" color="text.secondary" sx={{ pl: 1 }}>
-                Personnel
-              </Typography>
-              <Stack spacing={0.75} sx={{ mt: 0.5 }}>
+            <DashboardDividedSection title="Personnel">
+              <Stack spacing={0.75}>
                 {!!place.assignedParticipants.length &&
                   participants.map((participant) => {
                     return (
@@ -208,14 +206,11 @@ function PlaceTile({ place }: { place: Place }) {
                     );
                   })}
               </Stack>
-            </Stack>
+            </DashboardDividedSection>
           )}
           {!!sortedTeamEquipment.length && (
-            <Stack spacing={0.75} sx={{ mt: 1, pt: 1, borderTop: '1px solid', borderColor: 'divider' }}>
-              <Typography variant="caption" color="text.secondary" sx={{ pl: 1 }}>
-                Equipment
-              </Typography>
-              <Stack spacing={0.75} sx={{ mt: 0.5 }}>
+            <DashboardDividedSection title="Equipment">
+              <Stack spacing={0.75}>
                 {sortedTeamEquipment.map((item) => {
                   return (
                     <Draggable
@@ -231,25 +226,19 @@ function PlaceTile({ place }: { place: Place }) {
                   );
                 })}
               </Stack>
-            </Stack>
+            </DashboardDividedSection>
           )}
           {place.lat?.trim() && place.lon?.trim() && (
-            <Box sx={{ width: '100%', mt: 1, px: 1.75, py: 1, borderTop: '1px solid', borderColor: 'divider' }}>
-              <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-                Coordinates
-              </Typography>
+            <DashboardDividedSection title="Coordinates">
               <DashboardCopyChip value={`${place.lat?.trim()}, ${place.lon?.trim()}`} />
-            </Box>
+            </DashboardDividedSection>
           )}
           {place.notes?.trim() && (
-            <Box sx={{ width: '100%', mt: 1, px: 1.75, py: 1, borderTop: '1px solid', borderColor: 'divider' }}>
-              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
-                Notes
-              </Typography>
+            <DashboardDividedSection title="Notes">
               <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
                 {place.notes.trim()}
               </Typography>
-            </Box>
+            </DashboardDividedSection>
           )}
         </Stack>
       </DashboardBoxWithTitle>

--- a/src/components/dashboard/DashboardPlaceManager.tsx
+++ b/src/components/dashboard/DashboardPlaceManager.tsx
@@ -16,10 +16,10 @@ import { Stack } from '../Material';
 
 import { DashboardBoxWithTitle } from './DashboardBoxWithTitle';
 import { DashboardCopyChip } from './DashboardCopyChip';
+import { DashboardDividedSection } from './DashboardDividedSection';
 import { DashboardPlaceEditDialog } from './DashboardPlaceEditDialog';
 import { DashboardTeamEquipment } from './DashboardTeamEquipment';
 import { DashboardTeamMember } from './DashboardTeamMember';
-import { DashboardDividedSection } from './DashboardDividedSection';
 
 export function DashboardPlaceManager() {
   const dispatch = useAppDispatch();

--- a/src/components/dashboard/DashboardResponderManager.tsx
+++ b/src/components/dashboard/DashboardResponderManager.tsx
@@ -11,13 +11,18 @@ import { Draggable, Droppable } from '../DragAndDrop/DnDComponents';
 
 import DashboardParticipantCard from './DashboardParticipantCard';
 
-export function DashboardAvailableParticipants() {
+export function DashboardResponderManager() {
   const dispatch = useAppDispatch();
 
   const activity = useActivityContext();
 
   const availableParticipants = useMemo(() => {
-    return Object.values(activity.participants).filter((participant) => participant.timeline[0].status === ParticipantStatus.Available);
+    const assignedParticipants = activity.teams.flatMap((team) => team.assignedParticipants.map((id) => id));
+    return Object.values(activity.participants)
+      .filter((participant) => {
+        return participant.timeline[0].status === ParticipantStatus.Available && !assignedParticipants.includes(participant.id);
+      })
+      .sort((a, b) => a.firstname.localeCompare(b.lastname));
   }, [activity]);
 
   const setAssigned = (participant: Participant) => {
@@ -27,10 +32,11 @@ export function DashboardAvailableParticipants() {
 
   const handleDrop = (participant: Participant, type: string, callback?: () => void) => {
     // If the participant is not in Assigned status, do not overwrite the current status.
-    if (participant.timeline[0].status !== ParticipantStatus.Assigned) return;
-    // Update the Participant Status to Available
-    const update = { time: Date.now(), status: ParticipantStatus.Available, organizationId: participant.organizationId };
-    dispatch(ActivityActions.participantTimelineAdd(activity.id, participant.id, update));
+    if (participant.timeline[0].status === ParticipantStatus.Assigned) {
+      // Update the Participant Status to Available
+      const update = { time: Date.now(), status: ParticipantStatus.Available, organizationId: participant.organizationId };
+      dispatch(ActivityActions.participantTimelineAdd(activity.id, participant.id, update));
+    }
     callback?.();
   };
 

--- a/src/components/dashboard/DashboardResponderManager.tsx
+++ b/src/components/dashboard/DashboardResponderManager.tsx
@@ -16,14 +16,18 @@ export function DashboardResponderManager() {
 
   const activity = useActivityContext();
 
+  const teams = useMemo(() => {
+    return Object.values(activity.teams ?? []).filter((team) => team.status !== 'Disbanded');
+  }, [activity]);
+
   const availableParticipants = useMemo(() => {
-    const assignedParticipants = activity.teams.flatMap((team) => team.assignedParticipants.map((id) => id));
+    const assignedParticipants = teams.flatMap((team) => team.assignedParticipants.map((id) => id));
     return Object.values(activity.participants)
       .filter((participant) => {
         return participant.timeline[0].status === ParticipantStatus.Available && !assignedParticipants.includes(participant.id);
       })
       .sort((a, b) => a.firstname.localeCompare(b.lastname));
-  }, [activity]);
+  }, [activity, teams]);
 
   const setAssigned = (isSelf: boolean, participant: Participant) => {
     if (isSelf) return; // If the participant is dragged from the Responders list to the Responders list, cancel.

--- a/src/components/dashboard/DashboardResponderManager.tsx
+++ b/src/components/dashboard/DashboardResponderManager.tsx
@@ -25,19 +25,20 @@ export function DashboardResponderManager() {
       .sort((a, b) => a.firstname.localeCompare(b.lastname));
   }, [activity]);
 
-  const setAssigned = (participant: Participant) => {
+  const setAssigned = (isSelf: boolean, participant: Participant) => {
+    if (isSelf) return; // If the participant is dragged from the Responders list to the Responders list, cancel.
     const update = { time: Date.now(), status: ParticipantStatus.Assigned, organizationId: participant.organizationId };
     dispatch(ActivityActions.participantTimelineAdd(activity.id, participant.id, update));
   };
 
-  const handleDrop = (participant: Participant, type: string, callback?: () => void) => {
+  const handleDrop = (participant: Participant, type: string, callback?: (isSelf: boolean) => void) => {
     // If the participant is not in Assigned status, do not overwrite the current status.
     if (participant.timeline[0].status === ParticipantStatus.Assigned) {
       // Update the Participant Status to Available
       const update = { time: Date.now(), status: ParticipantStatus.Available, organizationId: participant.organizationId };
       dispatch(ActivityActions.participantTimelineAdd(activity.id, participant.id, update));
     }
-    callback?.();
+    callback?.(true);
   };
 
   return (
@@ -52,7 +53,7 @@ export function DashboardResponderManager() {
         ) : (
           availableParticipants.map((participant) => {
             return (
-              <Draggable key={participant.id} type="participant" item={participant} callback={() => setAssigned(participant)}>
+              <Draggable key={participant.id} type="participant" item={participant} callback={(isSelf: boolean) => setAssigned(isSelf, participant)}>
                 <DashboardParticipantCard key={participant.id} participant={participant} />
               </Draggable>
             );

--- a/src/components/dashboard/DashboardResponderSummary.tsx
+++ b/src/components/dashboard/DashboardResponderSummary.tsx
@@ -4,7 +4,7 @@ import { ParticipantStatus } from '@respond/types/activity';
 
 import { useActivityContext } from '../activities/ActivityProvider';
 
-import { DashboardCollapsibleBox } from './DashboardCollapsibleBox';
+import { DashboardBoxWithTitle } from './DashboardBoxWithTitle';
 
 export function DashboardResponderSummary() {
   const activity = useActivityContext();
@@ -33,12 +33,12 @@ export function DashboardResponderSummary() {
   ] as const;
 
   return (
-    <DashboardCollapsibleBox title="Responders" sx={{ p: 1 }}>
+    <DashboardBoxWithTitle title="Responders" sx={{ p: 1 }} collapsible>
       {summaryLines.map(([label, count]) => (
         <Typography key={label} variant="subtitle1">
           {`${label} (${count})`}
         </Typography>
       ))}
-    </DashboardCollapsibleBox>
+    </DashboardBoxWithTitle>
   );
 }

--- a/src/components/dashboard/DashboardResponderSummary.tsx
+++ b/src/components/dashboard/DashboardResponderSummary.tsx
@@ -1,0 +1,45 @@
+import { Box, Typography } from '@mui/material';
+
+import { ParticipantStatus } from '@respond/types/activity';
+
+import { useActivityContext } from '../activities/ActivityProvider';
+
+export function DashboardResponderSummary() {
+  const activity = useActivityContext();
+
+  const totals = Object.values(activity.participants).reduce(
+    (counts, participant) => {
+      const status = participant.timeline?.[0]?.status;
+
+      if (status === ParticipantStatus.SignedIn) {
+        counts.Responding += 1;
+      } else if (status === ParticipantStatus.Available) {
+        counts.Available += 1;
+      } else if (status === ParticipantStatus.Assigned) {
+        counts.Assigned += 1;
+      }
+
+      return counts;
+    },
+    { Responding: 0, Available: 0, Assigned: 0 },
+  );
+
+  const summaryLines = [
+    ['Assigned', totals.Assigned],
+    ['Available', totals.Available],
+    ['Responding', totals.Responding],
+  ] as const;
+
+  return (
+    <Box sx={{ px: 1 }}>
+      <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+        Responders
+      </Typography>
+      {summaryLines.map(([label, count]) => (
+        <Typography key={label} variant="subtitle1">
+          {`${label} (${count})`}
+        </Typography>
+      ))}
+    </Box>
+  );
+}

--- a/src/components/dashboard/DashboardResponderSummary.tsx
+++ b/src/components/dashboard/DashboardResponderSummary.tsx
@@ -9,7 +9,7 @@ import { DashboardBoxWithTitle } from './DashboardBoxWithTitle';
 export function DashboardResponderSummary() {
   const activity = useActivityContext();
 
-  const totals = Object.values(activity.participants).reduce(
+  const participantTotals = Object.values(activity.participants).reduce(
     (counts, participant) => {
       const status = participant.timeline?.[0]?.status;
 
@@ -26,10 +26,16 @@ export function DashboardResponderSummary() {
     { Responding: 0, Available: 0, Assigned: 0 },
   );
 
+  const fieldResources = Object.values(activity.teams).reduce((count, team) => {
+    if (['In Base','Disbanded'].includes(team.status)) return count;
+    return count + team.assignedParticipants.length;
+  }, 0);
+
   const summaryLines = [
-    ['Assigned', totals.Assigned],
-    ['Available', totals.Available],
-    ['Responding', totals.Responding],
+    ['Field', fieldResources],
+    ['Assigned', participantTotals.Assigned],
+    ['Available', participantTotals.Available],
+    ['Responding', participantTotals.Responding],
   ] as const;
 
   return (

--- a/src/components/dashboard/DashboardResponderSummary.tsx
+++ b/src/components/dashboard/DashboardResponderSummary.tsx
@@ -1,8 +1,10 @@
-import { Box, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 
 import { ParticipantStatus } from '@respond/types/activity';
 
 import { useActivityContext } from '../activities/ActivityProvider';
+
+import { DashboardCollapsibleBox } from './DashboardCollapsibleBox';
 
 export function DashboardResponderSummary() {
   const activity = useActivityContext();
@@ -31,15 +33,12 @@ export function DashboardResponderSummary() {
   ] as const;
 
   return (
-    <Box sx={{ px: 1 }}>
-      <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
-        Responders
-      </Typography>
+    <DashboardCollapsibleBox title="Responders" sx={{ p: 1 }}>
       {summaryLines.map(([label, count]) => (
         <Typography key={label} variant="subtitle1">
           {`${label} (${count})`}
         </Typography>
       ))}
-    </Box>
+    </DashboardCollapsibleBox>
   );
 }

--- a/src/components/dashboard/DashboardResponderSummary.tsx
+++ b/src/components/dashboard/DashboardResponderSummary.tsx
@@ -33,7 +33,7 @@ export function DashboardResponderSummary() {
   ] as const;
 
   return (
-    <DashboardBoxWithTitle title="Responders" sx={{ p: 1 }} collapsible>
+    <DashboardBoxWithTitle title="Responders" collapsible>
       {summaryLines.map(([label, count]) => (
         <Typography key={label} variant="subtitle1">
           {`${label} (${count})`}

--- a/src/components/dashboard/DashboardResponderSummary.tsx
+++ b/src/components/dashboard/DashboardResponderSummary.tsx
@@ -26,7 +26,7 @@ export function DashboardResponderSummary() {
     { Responding: 0, Available: 0, Assigned: 0 },
   );
 
-  const fieldResources = Object.values(activity.teams).reduce((count, team) => {
+  const fieldResources = Object.values(activity.teams ?? [])?.reduce((count, team) => {
     if (['In Base', 'Disbanded'].includes(team.status)) return count;
     return count + team.assignedParticipants.length;
   }, 0);

--- a/src/components/dashboard/DashboardResponderSummary.tsx
+++ b/src/components/dashboard/DashboardResponderSummary.tsx
@@ -42,7 +42,7 @@ export function DashboardResponderSummary() {
     <DashboardBoxWithTitle title="Responders" collapsible>
       {summaryLines.map(([label, count]) => (
         <Typography key={label} variant="subtitle1">
-          {`${label} (${count})`}
+          {`${count} - ${label}`}
         </Typography>
       ))}
     </DashboardBoxWithTitle>

--- a/src/components/dashboard/DashboardResponderSummary.tsx
+++ b/src/components/dashboard/DashboardResponderSummary.tsx
@@ -27,7 +27,7 @@ export function DashboardResponderSummary() {
   );
 
   const fieldResources = Object.values(activity.teams).reduce((count, team) => {
-    if (['In Base','Disbanded'].includes(team.status)) return count;
+    if (['In Base', 'Disbanded'].includes(team.status)) return count;
     return count + team.assignedParticipants.length;
   }, 0);
 

--- a/src/components/dashboard/DashboardRoleTile.tsx
+++ b/src/components/dashboard/DashboardRoleTile.tsx
@@ -1,0 +1,38 @@
+import { Paper, Typography } from '@mui/material';
+import { useState } from 'react';
+
+import { useAppDispatch } from '@respond/lib/client/store';
+import { ActivityActions } from '@respond/lib/state';
+import { Participant } from '@respond/types/activity';
+
+import { useActivityContext } from '../activities/ActivityProvider';
+import { Droppable } from '../DragAndDrop/DnDComponents';
+
+export function DashboardRoleTile({ title, id }: { title: string; id?: string }) {
+  const [selected, setSelected] = useState<string | undefined>(id);
+  const dispatch = useAppDispatch();
+  const activity = useActivityContext();
+
+  const participant = selected ? activity.participants[selected] : undefined;
+  const name = participant ? `${participant.firstname} ${participant.lastname}` : 'Unassigned';
+
+  const handleDrop = (p: Participant | null) => {
+    setSelected(p?.id);
+    if (p && activity && activity.id) {
+      dispatch(ActivityActions.updateStaff(activity.id, { [title]: p.id }));
+    }
+  };
+
+  return (
+    <Droppable accepts="participant" onDrop={handleDrop}>
+      <Paper variant="outlined" sx={{ p: 1 }}>
+        <Typography component="div" variant="subtitle1" sx={{ fontWeight: 700 }}>
+          {title}
+        </Typography>
+        <Typography component="div" sx={{ color: 'text.secondary' }}>
+          {name}
+        </Typography>
+      </Paper>
+    </Droppable>
+  );
+}

--- a/src/components/dashboard/DashboardRoleTile.tsx
+++ b/src/components/dashboard/DashboardRoleTile.tsx
@@ -1,37 +1,61 @@
-import { Paper, Typography } from '@mui/material';
-import { useState } from 'react';
+import ClearIcon from '@mui/icons-material/Clear';
+import { Box, IconButton, Paper, Stack, Typography } from '@mui/material';
 
 import { useAppDispatch } from '@respond/lib/client/store';
 import { ActivityActions } from '@respond/lib/state';
 import { Participant } from '@respond/types/activity';
+import { CommunicationsLogEntry, createNewCommsEntry } from '@respond/types/operations';
 
 import { useActivityContext } from '../activities/ActivityProvider';
 import { Droppable } from '../DragAndDrop/DnDComponents';
 
 export function DashboardRoleTile({ title, id }: { title: string; id?: string }) {
-  const [selected, setSelected] = useState<string | undefined>(id);
   const dispatch = useAppDispatch();
   const activity = useActivityContext();
 
-  const participant = selected ? activity.participants[selected] : undefined;
+  const selectedId = activity.staff?.[title] ?? id;
+  const participant = selectedId ? activity.participants[selectedId] : undefined;
   const name = participant ? `${participant.firstname} ${participant.lastname}` : 'Unassigned';
 
   const handleDrop = (p: Participant | null) => {
-    setSelected(p?.id);
     if (p && activity && activity.id) {
       dispatch(ActivityActions.updateStaff(activity.id, { [title]: p.id }));
+      autoLog(`${p.firstname} ${p.lastname} assuming ${title}`);
     }
+  };
+
+  const handleDelete = (): void => {
+    if (activity && activity.id) {
+      dispatch(ActivityActions.updateStaff(activity.id, { [title]: '' }));
+      autoLog(`${title} unassigned`);
+    }
+  };
+
+  const autoLog = (message: string) => {
+    const comm: CommunicationsLogEntry = createNewCommsEntry({
+      from: 'CP',
+      message: message,
+      isAutomated: true,
+    });
+    dispatch(ActivityActions.addComm(activity.id, comm));
   };
 
   return (
     <Droppable accepts="participant" onDrop={handleDrop}>
       <Paper variant="outlined" sx={{ p: 1 }}>
-        <Typography component="div" variant="subtitle1" sx={{ fontWeight: 700 }}>
-          {title}
-        </Typography>
-        <Typography component="div" sx={{ color: 'text.secondary' }}>
-          {name}
-        </Typography>
+        <Box sx={{ '&:hover .action': { opacity: 1, visibility: 'visible' } }}>
+          <Typography component="div" variant="subtitle1" sx={{ fontWeight: 700 }}>
+            {title}
+          </Typography>
+          <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={1}>
+            <Typography component="div" sx={{ color: 'text.secondary' }}>
+              {name}
+            </Typography>
+            <IconButton className="action" onClick={handleDelete} size="small" aria-label="delete communication" sx={{ opacity: 0, visibility: 'hidden', transition: 'opacity 180ms ease' }}>
+              <ClearIcon sx={{ fontSize: 16, color: 'darkred' }} />
+            </IconButton>
+          </Stack>
+        </Box>
       </Paper>
     </Droppable>
   );

--- a/src/components/dashboard/DashboardSearchBox.tsx
+++ b/src/components/dashboard/DashboardSearchBox.tsx
@@ -2,7 +2,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import { Box, IconButton, InputAdornment, SxProps, TextField, Theme } from '@mui/material';
 import { useState } from 'react';
 
-export function DashboardSearchBox({ onChange, sx }: { onChange: (value: string) => void; sx?: SxProps<Theme> | undefined }) {
+export function DashboardSearchBox({ placeholder, onChange, sx }: { placeholder?: string; onChange: (value: string) => void; sx?: SxProps<Theme> | undefined }) {
   const [searchQuery, setSearchQuery] = useState('');
   const handleChange = (value: string) => {
     setSearchQuery(value);
@@ -12,7 +12,7 @@ export function DashboardSearchBox({ onChange, sx }: { onChange: (value: string)
     <Box sx={sx}>
       <TextField
         size="small"
-        placeholder="Search messages, to, or from"
+        placeholder={placeholder || 'Search...'}
         fullWidth
         value={searchQuery}
         onChange={(e) => handleChange(e.target.value)}

--- a/src/components/dashboard/DashboardSearchBox.tsx
+++ b/src/components/dashboard/DashboardSearchBox.tsx
@@ -1,0 +1,32 @@
+import CloseIcon from '@mui/icons-material/Close';
+import { Box, IconButton, InputAdornment, SxProps, TextField, Theme } from '@mui/material';
+import { useState } from 'react';
+
+export function DashboardSearchBox({ onChange, sx }: { onChange: (value: string) => void; sx?: SxProps<Theme> | undefined }) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const handleChange = (value: string) => {
+    setSearchQuery(value);
+    onChange(value);
+  };
+  return (
+    <Box sx={sx}>
+      <TextField
+        size="small"
+        placeholder="Search messages, to, or from"
+        fullWidth
+        value={searchQuery}
+        onChange={(e) => handleChange(e.target.value)}
+        sx={{ '& .MuiInputBase-root': { height: 32 } }}
+        InputProps={{
+          endAdornment: searchQuery ? (
+            <InputAdornment position="end">
+              <IconButton size="small" onClick={() => handleChange('')} aria-label="clear search">
+                <CloseIcon fontSize="small" />
+              </IconButton>
+            </InputAdornment>
+          ) : undefined,
+        }}
+      />
+    </Box>
+  );
+}

--- a/src/components/dashboard/DashboardTeamCard.tsx
+++ b/src/components/dashboard/DashboardTeamCard.tsx
@@ -80,7 +80,7 @@ export default function DashboardTeamCard({ team, defaultExpanded }: { team: Tea
       const updatedTeam = { ...team, assignedParticipants: team.assignedParticipants.filter((id) => id !== participantId), teamLeaderParticipantId: team.teamLeaderParticipantId === participantId ? null : team.teamLeaderParticipantId };
       updateTeam(updatedTeam);
     }
-  }
+  };
 
   const addEquipment = (equipment: EquipmentItem) => {
     // If the item was dragged and dropped back to the same team, cancel.
@@ -96,7 +96,7 @@ export default function DashboardTeamCard({ team, defaultExpanded }: { team: Tea
       const updatedTeam = { ...team, assignedEquipment: team.assignedEquipment.filter((item) => item.uuid !== id) };
       updateTeam(updatedTeam);
     }
-  }
+  };
 
   const updateTeam = (team: Team) => {
     // TODO: Reassign remaining resource to the unassigned place.
@@ -184,7 +184,7 @@ export default function DashboardTeamCard({ team, defaultExpanded }: { team: Tea
                       ) : (
                         teamMembers.map((participant) => {
                           return (
-                            <Draggable type="participant" item={participant} callback={() => removeTeamMember(participant.id)}>
+                            <Draggable key={participant.id} type="participant" item={participant} callback={() => removeTeamMember(participant.id)}>
                               <DashboardTeamMember key={participant.id} participant={participant} onPromote={() => updateTeamLeader(participant.id)} />
                             </Draggable>
                           );
@@ -213,9 +213,14 @@ export default function DashboardTeamCard({ team, defaultExpanded }: { team: Tea
                       ) : (
                         sortedTeamEquipment.map((item) => {
                           return (
-                            <Draggable type="equipment" item={item} callback={() => {
-                              if (item.uuid) removeEquipment(item.uuid)
-                            }}>
+                            <Draggable
+                              key={item.uuid}
+                              type="equipment"
+                              item={item}
+                              callback={() => {
+                                if (item.uuid) removeEquipment(item.uuid);
+                              }}
+                            >
                               <DashboardTeamEquipment key={item.uuid} item={item} />
                             </Draggable>
                           );

--- a/src/components/dashboard/DashboardTeamCard.tsx
+++ b/src/components/dashboard/DashboardTeamCard.tsx
@@ -1,0 +1,235 @@
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { Box, Chip, Divider, IconButton, Stack, Typography } from '@mui/material';
+import { useEffect, useState } from 'react';
+import { v4 as uuid } from 'uuid';
+
+import { useAppDispatch } from '@respond/lib/client/store';
+import { ActivityActions } from '@respond/lib/state';
+import { CommunicationsLogEntry, Participant, ParticipantStatus } from '@respond/types/activity';
+
+import { EquipmentItem, Team, TeamStatus } from '../../types/team';
+import { useActivityContext } from '../activities/ActivityProvider';
+import { Droppable } from '../DragAndDrop/DnDComponents';
+import { StatusContainer } from '../StatusContainer';
+
+import { DashboardTeamEditDialog } from './DashboardTeamEditDialog';
+import { DashboardTeamEquipment } from './DashboardTeamEquipment';
+import { DashboardTeamMember } from './DashboardTeamMember';
+import { TeamStatusSelect } from './DashboardTeamStatusSelect';
+
+const sortParicipantsAlphabetically = (left: Participant, right: Participant) => {
+  return `${left.firstname} ${left.lastname}`.localeCompare(`${right.firstname} ${right.lastname}`);
+};
+
+const sortEquipmentAlphabetically = (left: EquipmentItem, right: EquipmentItem) => {
+  return left.name.localeCompare(right.name);
+};
+
+export default function DashboardTeamCard({ team, defaultExpanded }: { team: Team; defaultExpanded?: boolean }) {
+  const dispatch = useAppDispatch();
+
+  const activity = useActivityContext();
+
+  const [openTeamEditor, setOpenTeamEditor] = useState<Team | null>(null);
+  const [localExpanded, setLocalExpanded] = useState<boolean>(defaultExpanded ?? false);
+  const isExpanded = localExpanded;
+
+  useEffect(() => {
+    if (defaultExpanded !== undefined) {
+      setLocalExpanded(defaultExpanded);
+    }
+  }, [defaultExpanded]);
+
+  const teamParticipants: Participant[] = Object.values(activity.participants).filter((participant) => team.assignedParticipants.includes(participant.id));
+  const teamLeader: Participant | undefined = teamParticipants.find((participant) => participant.id === team.teamLeaderParticipantId);
+  const teamMembers = teamParticipants.filter((participant) => participant.id !== team.teamLeaderParticipantId).sort(sortParicipantsAlphabetically);
+
+  const sortedTeamEquipment = [...team.assignedEquipment].sort(sortEquipmentAlphabetically);
+
+  const updateTeamLeader = (newLeaderId: string) => {
+    dispatch(ActivityActions.updateTeam(activity.id, { ...team, teamLeaderParticipantId: newLeaderId }));
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handleDrop = (item: any, type: string) => {
+    if (type === 'participant') {
+      addTeamMember(item);
+    }
+    if (type === 'equipment') {
+      addEquipment(item);
+    }
+  };
+
+  const addTeamMember = (participant: Participant) => {
+    // If the item was dragged and dropped back to the same team, cancel.
+    if (team.assignedParticipants.find((id) => id === participant.id)) return;
+    // Update the Participant Status to Assigned
+    if (participant.timeline[0].status !== ParticipantStatus.Assigned) {
+      const update = { time: Date.now(), status: ParticipantStatus.Assigned, organizationId: participant.organizationId };
+      dispatch(ActivityActions.participantTimelineAdd(activity.id, participant.id, update));
+    }
+    // Remove from the previous team, if any
+    // TODO: need actions to club these updates into a single activity transaction
+    activity.teams.forEach((team) => {
+      if (team.assignedParticipants.includes(participant.id)) {
+        // Remove the participant from the team
+        const updatedTeam = { ...team, assignedParticipants: team.assignedParticipants.filter((id) => id !== participant.id) };
+        dispatch(ActivityActions.updateTeam(activity.id, updatedTeam));
+      }
+    });
+    // Update the Team to include the new participant
+    const updatedTeam = { ...team, assignedParticipants: [...team.assignedParticipants, participant.id], teamLeaderParticipantId: team.teamLeaderParticipantId || participant.id };
+    dispatch(ActivityActions.updateTeam(activity.id, updatedTeam));
+  };
+
+  const addEquipment = (equipment: EquipmentItem) => {
+    // If the item was dragged and dropped back to the same team, cancel.
+    if (team.assignedEquipment.find((item) => item.uuid === equipment.uuid)) return;
+    // Remove from the previous team, if any
+    // TODO: need actions to club these updates into a single activity transaction
+    activity.teams.forEach((team) => {
+      if (team.assignedEquipment.some((item) => item.uuid === equipment.uuid)) {
+        // Remove the participant from the team
+        const updatedTeam = { ...team, assignedEquipment: team.assignedEquipment.filter((item) => item.uuid !== equipment.uuid) };
+        dispatch(ActivityActions.updateTeam(activity.id, updatedTeam));
+      }
+    });
+    // Update the Team to include the new participant
+    const updatedTeam = { ...team, assignedEquipment: [...team.assignedEquipment, equipment] };
+    dispatch(ActivityActions.updateTeam(activity.id, updatedTeam));
+  };
+
+  const updateTeam = (team: Team) => {
+    dispatch(ActivityActions.updateTeam(activity.id, team));
+  };
+
+  const logStatusChange = (from: string, status: TeamStatus) => {
+    const messages = {
+      'In Base': 'In Base',
+      'In Transit': 'With Transportation',
+      'On Assignment': 'Starting Assignment',
+      'On Scene': 'On Scene',
+      'Returning To Base': 'RTB',
+    };
+    const comm: CommunicationsLogEntry = {
+      id: uuid(),
+      from,
+      to: 'CP',
+      message: messages[status],
+      timestamp: Date.now(),
+      isAutomated: true,
+      isDeleted: false,
+    };
+    dispatch(ActivityActions.addComm(activity.id, comm));
+  };
+
+  const handleExpandClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    setLocalExpanded((current) => !current);
+  };
+
+  const statusColor = {
+    green: 'green',
+    amber: 'goldenrod',
+    red: 'darkred',
+  }[team.gar];
+
+  return (
+    <>
+      <Droppable accepts={['participant', 'equipment']} onDrop={handleDrop}>
+        <StatusContainer color={statusColor} sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2 }}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', borderRadius: 2, p: 1.5, bgcolor: 'background.paper', height: '100%' }}>
+            <Stack direction="row" alignItems="center" justifyContent="space-between">
+              <Stack direction="row" alignItems="center">
+                <IconButton onClick={handleExpandClick} size="small" sx={{ width: 32, height: 32 }}>
+                  {isExpanded ? <ExpandMoreIcon /> : <ChevronRightIcon />}
+                </IconButton>
+                <Stack direction="row" spacing={2} alignItems="center">
+                  <Typography variant="subtitle1" sx={{ fontWeight: 700, cursor: 'pointer' }} onClick={() => setOpenTeamEditor(team)}>
+                    {team.name}
+                  </Typography>
+                  {teamLeader && <DashboardTeamMember key={teamLeader.id} participant={teamLeader} />}
+                </Stack>
+              </Stack>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <TeamStatusSelect
+                  value={team.status}
+                  onChange={(newStatus) => {
+                    console.log(newStatus);
+                    updateTeam({ ...team, status: newStatus });
+                    logStatusChange(team.name, newStatus);
+                  }}
+                />
+                <Chip label={`${teamParticipants.length} members`} size="small" variant="outlined" />
+              </Stack>
+            </Stack>
+            {isExpanded && (
+              <>
+                <Divider sx={{ my: 1 }} />
+                <Stack direction="row" spacing={1} sx={{ flex: 1, overflow: 'auto' }}>
+                  <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <Typography variant="caption" color="text.secondary" sx={{ pl: 1 }}>
+                      Team Members
+                    </Typography>
+                    <Stack spacing={0.75} sx={{ mt: 0.5 }}>
+                      {teamMembers.length === 0 ? (
+                        <Typography variant="body2" color="text.secondary" sx={{ pl: 1 }}>
+                          None
+                        </Typography>
+                      ) : (
+                        teamMembers.map((participant) => <DashboardTeamMember key={participant.id} participant={participant} onPromote={() => updateTeamLeader(participant.id)} />)
+                      )}
+                    </Stack>
+                  </Box>
+                  <Box sx={{ textAlign: 'center', flex: 1, minWidth: 0 }}>
+                    <Typography variant="caption" color="text.secondary">
+                      Details
+                    </Typography>
+                    <Stack spacing={0.75} sx={{ mt: 0.5 }}>
+                      <Typography variant="body2">GAR: {team.gar}</Typography>
+                      {team.assignment && <Typography variant="body2">Assignment: {team.assignment}</Typography>}
+                    </Stack>
+                  </Box>
+                  <Box sx={{ textAlign: 'right', flex: 1, minWidth: 0 }}>
+                    <Typography variant="caption" color="text.secondary" sx={{ pr: 1 }}>
+                      Equipment
+                    </Typography>
+                    <Stack spacing={0.75} sx={{ mt: 0.5 }}>
+                      {sortedTeamEquipment.length === 0 ? (
+                        <Typography variant="body2" color="text.secondary" sx={{ pr: 1 }}>
+                          None
+                        </Typography>
+                      ) : (
+                        sortedTeamEquipment.map((item) => <DashboardTeamEquipment key={item.uuid} item={item} />)
+                      )}
+                    </Stack>
+                  </Box>
+                </Stack>
+                {team.notes?.trim() && (
+                  <Box sx={{ width: '100%', mt: 1, pt: 1, borderTop: '1px solid', borderColor: 'divider' }}>
+                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+                      Notes
+                    </Typography>
+                    <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+                      {team.notes}
+                    </Typography>
+                  </Box>
+                )}
+              </>
+            )}
+          </Box>
+        </StatusContainer>
+      </Droppable>
+      <DashboardTeamEditDialog
+        team={openTeamEditor}
+        teams={activity.teams}
+        onSave={(team) => {
+          updateTeam(team);
+          setOpenTeamEditor(null);
+        }}
+        onClose={() => setOpenTeamEditor(null)}
+      />
+    </>
+  );
+}

--- a/src/components/dashboard/DashboardTeamCard.tsx
+++ b/src/components/dashboard/DashboardTeamCard.tsx
@@ -102,7 +102,7 @@ export default function DashboardTeamCard({ team, defaultExpanded }: { team: Tea
   };
 
   const updateTeam = (team: Team) => {
-    const originalTeam = activity.teams.find((t) => t.id === team.id);
+    const originalTeam = (activity.teams ?? []).find((t) => t.id === team.id);
     if (team.gar !== originalTeam?.gar) {
       autoLog(`${team.name} GAR changed to ${team.gar.toUpperCase()}`, team.gar !== 'green');
     }
@@ -235,7 +235,7 @@ export default function DashboardTeamCard({ team, defaultExpanded }: { team: Tea
       </Droppable>
       <DashboardTeamEditDialog
         team={openTeamEditor}
-        teams={activity.teams}
+        teams={activity.teams ?? []}
         onSave={(team) => {
           updateTeam(team);
           setOpenTeamEditor(null);

--- a/src/components/dashboard/DashboardTeamCard.tsx
+++ b/src/components/dashboard/DashboardTeamCard.tsx
@@ -6,11 +6,11 @@ import { v4 as uuid } from 'uuid';
 
 import { useAppDispatch } from '@respond/lib/client/store';
 import { ActivityActions } from '@respond/lib/state';
-import { Participant, ParticipantStatus } from '@respond/types/activity';
+import { Participant } from '@respond/types/activity';
 
 import { CommunicationsLogEntry, EquipmentItem, Team, TeamStatus } from '../../types/operations';
 import { useActivityContext } from '../activities/ActivityProvider';
-import { Droppable } from '../DragAndDrop/DnDComponents';
+import { Draggable, Droppable } from '../DragAndDrop/DnDComponents';
 import { StatusContainer } from '../StatusContainer';
 
 import { DashboardTeamEditDialog } from './DashboardTeamEditDialog';
@@ -52,53 +52,51 @@ export default function DashboardTeamCard({ team, defaultExpanded }: { team: Tea
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const handleDrop = (item: any, type: string) => {
+  const handleDrop = (item: any, type: string, callback?: () => void) => {
     if (type === 'participant') {
+      // If the item was dragged and dropped back to the same team, cancel.
+      if (team.assignedParticipants.includes(item.id)) return;
       addTeamMember(item);
-    }
-    if (type === 'equipment') {
+    } else if (type === 'equipment') {
+      // If the item was dragged and dropped back to the same place, cancel.
+      if (team.assignedEquipment.find((equipment) => item.uuid === equipment.uuid)) return;
       addEquipment(item);
+    } else {
+      return;
     }
+    callback?.();
   };
 
   const addTeamMember = (participant: Participant) => {
-    // If the item was dragged and dropped back to the same team, cancel.
     if (team.assignedParticipants.find((id) => id === participant.id)) return;
-    // Update the Participant Status to Assigned
-    if (participant.timeline[0].status !== ParticipantStatus.Assigned) {
-      const update = { time: Date.now(), status: ParticipantStatus.Assigned, organizationId: participant.organizationId };
-      dispatch(ActivityActions.participantTimelineAdd(activity.id, participant.id, update));
-    }
-    // Remove from the previous team, if any
-    // TODO: need actions to club these updates into a single activity transaction
-    activity.teams.forEach((team) => {
-      if (team.assignedParticipants.includes(participant.id)) {
-        // Remove the participant from the team
-        const updatedTeam = { ...team, assignedParticipants: team.assignedParticipants.filter((id) => id !== participant.id) };
-        dispatch(ActivityActions.updateTeam(activity.id, updatedTeam));
-      }
-    });
     // Update the Team to include the new participant
     const updatedTeam = { ...team, assignedParticipants: [...team.assignedParticipants, participant.id], teamLeaderParticipantId: team.teamLeaderParticipantId || participant.id };
-    dispatch(ActivityActions.updateTeam(activity.id, updatedTeam));
+    updateTeam(updatedTeam);
   };
+
+  const removeTeamMember = (participantId: string) => {
+    if (team.assignedParticipants.includes(participantId)) {
+      // Remove the participant from the team
+      const updatedTeam = { ...team, assignedParticipants: team.assignedParticipants.filter((id) => id !== participantId), teamLeaderParticipantId: team.teamLeaderParticipantId === participantId ? null : team.teamLeaderParticipantId };
+      updateTeam(updatedTeam);
+    }
+  }
 
   const addEquipment = (equipment: EquipmentItem) => {
     // If the item was dragged and dropped back to the same team, cancel.
     if (team.assignedEquipment.find((item) => item.uuid === equipment.uuid)) return;
-    // Remove from the previous team, if any
-    // TODO: need actions to club these updates into a single activity transaction
-    activity.teams.forEach((team) => {
-      if (team.assignedEquipment.some((item) => item.uuid === equipment.uuid)) {
-        // Remove the participant from the team
-        const updatedTeam = { ...team, assignedEquipment: team.assignedEquipment.filter((item) => item.uuid !== equipment.uuid) };
-        dispatch(ActivityActions.updateTeam(activity.id, updatedTeam));
-      }
-    });
     // Update the Team to include the new participant
     const updatedTeam = { ...team, assignedEquipment: [...team.assignedEquipment, equipment] };
-    dispatch(ActivityActions.updateTeam(activity.id, updatedTeam));
+    updateTeam(updatedTeam);
   };
+
+  const removeEquipment = (id: string) => {
+    if (team.assignedEquipment.some((item) => item.uuid === id)) {
+      // Remove the equipment from the team
+      const updatedTeam = { ...team, assignedEquipment: team.assignedEquipment.filter((item) => item.uuid !== id) };
+      updateTeam(updatedTeam);
+    }
+  }
 
   const updateTeam = (team: Team) => {
     dispatch(ActivityActions.updateTeam(activity.id, team));
@@ -150,7 +148,11 @@ export default function DashboardTeamCard({ team, defaultExpanded }: { team: Tea
                   <Typography variant="subtitle1" sx={{ fontWeight: 700, cursor: 'pointer' }} onClick={() => setOpenTeamEditor(team)}>
                     {team.name}
                   </Typography>
-                  {teamLeader && <DashboardTeamMember key={teamLeader.id} participant={teamLeader} />}
+                  {teamLeader && (
+                    <Draggable type="participant" item={teamLeader} callback={() => removeTeamMember(teamLeader.id)}>
+                      <DashboardTeamMember key={teamLeader.id} participant={teamLeader} />
+                    </Draggable>
+                  )}
                 </Stack>
               </Stack>
               <Stack direction="row" spacing={1} alignItems="center">
@@ -179,7 +181,13 @@ export default function DashboardTeamCard({ team, defaultExpanded }: { team: Tea
                           None
                         </Typography>
                       ) : (
-                        teamMembers.map((participant) => <DashboardTeamMember key={participant.id} participant={participant} onPromote={() => updateTeamLeader(participant.id)} />)
+                        teamMembers.map((participant) => {
+                          return (
+                            <Draggable type="participant" item={participant} callback={() => removeTeamMember(participant.id)}>
+                              <DashboardTeamMember key={participant.id} participant={participant} onPromote={() => updateTeamLeader(participant.id)} />
+                            </Draggable>
+                          );
+                        })
                       )}
                     </Stack>
                   </Box>
@@ -202,7 +210,15 @@ export default function DashboardTeamCard({ team, defaultExpanded }: { team: Tea
                           None
                         </Typography>
                       ) : (
-                        sortedTeamEquipment.map((item) => <DashboardTeamEquipment key={item.uuid} item={item} />)
+                        sortedTeamEquipment.map((item) => {
+                          return (
+                            <Draggable type="equipment" item={item} callback={() => {
+                              if (item.uuid) removeEquipment(item.uuid)
+                            }}>
+                              <DashboardTeamEquipment key={item.uuid} item={item} />
+                            </Draggable>
+                          );
+                        })
                       )}
                     </Stack>
                   </Box>

--- a/src/components/dashboard/DashboardTeamCard.tsx
+++ b/src/components/dashboard/DashboardTeamCard.tsx
@@ -51,12 +51,16 @@ export default function DashboardTeamCard({ team, defaultExpanded }: { team: Tea
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const handleDrop = (item: any, type: string, callback?: () => void) => {
+  const handleDrop = (item: any, type: string, callback?: (...args: any[]) => void) => {
     if (type === 'participant') {
       // If the item was dragged and dropped back to the same team, cancel.
       if (team.assignedParticipants.includes(item.id)) return;
       addTeamMember(item);
     } else if (type === 'equipment') {
+      if (!!callback && item.type === 'Custom' && item.name === 'Custom Item') {
+        callback({ item, onSave: (newItem: EquipmentItem) => addEquipment(newItem) });
+        return;
+      }
       // If the item was dragged and dropped back to the same place, cancel.
       if (team.assignedEquipment.find((equipment) => item.uuid === equipment.uuid)) return;
       addEquipment(item);

--- a/src/components/dashboard/DashboardTeamCard.tsx
+++ b/src/components/dashboard/DashboardTeamCard.tsx
@@ -2,13 +2,12 @@ import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { Box, Chip, Divider, IconButton, Stack, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
-import { v4 as uuid } from 'uuid';
 
 import { useAppDispatch } from '@respond/lib/client/store';
 import { ActivityActions } from '@respond/lib/state';
 import { Participant } from '@respond/types/activity';
 
-import { CommunicationsLogEntry, EquipmentItem, Team, TeamStatus } from '../../types/operations';
+import { EquipmentItem, Team } from '../../types/operations';
 import { useActivityContext } from '../activities/ActivityProvider';
 import { Draggable, Droppable } from '../DragAndDrop/DnDComponents';
 import { StatusContainer } from '../StatusContainer';
@@ -99,29 +98,7 @@ export default function DashboardTeamCard({ team, defaultExpanded }: { team: Tea
   };
 
   const updateTeam = (team: Team) => {
-    // TODO: Reassign remaining resource to the unassigned place.
     dispatch(ActivityActions.updateTeam(activity.id, team));
-  };
-
-  const logStatusChange = (from: string, status: TeamStatus) => {
-    const messages = {
-      'In Base': 'In Base',
-      'In Transit': 'With Transportation',
-      'On Assignment': 'Starting Assignment',
-      'On Scene': 'On Scene',
-      'Returning To Base': 'RTB',
-      Disbanded: 'Disbanded',
-    };
-    const comm: CommunicationsLogEntry = {
-      id: uuid(),
-      from,
-      to: 'CP',
-      message: messages[status],
-      timestamp: Date.now(),
-      isAutomated: true,
-      isDeleted: false,
-    };
-    dispatch(ActivityActions.addComm(activity.id, comm));
   };
 
   const handleExpandClick = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -157,14 +134,7 @@ export default function DashboardTeamCard({ team, defaultExpanded }: { team: Tea
                 </Stack>
               </Stack>
               <Stack direction="row" spacing={1} alignItems="center">
-                <TeamStatusSelect
-                  value={team.status}
-                  onChange={(newStatus) => {
-                    console.log(newStatus);
-                    updateTeam({ ...team, status: newStatus });
-                    logStatusChange(team.name, newStatus);
-                  }}
-                />
+                <TeamStatusSelect team={team} />
                 <Chip label={`${teamParticipants.length} members`} size="small" variant="outlined" />
               </Stack>
             </Stack>

--- a/src/components/dashboard/DashboardTeamCard.tsx
+++ b/src/components/dashboard/DashboardTeamCard.tsx
@@ -7,7 +7,7 @@ import { useAppDispatch } from '@respond/lib/client/store';
 import { ActivityActions } from '@respond/lib/state';
 import { Participant } from '@respond/types/activity';
 
-import { EquipmentItem, Team } from '../../types/operations';
+import { CommunicationsLogEntry, createNewCommsEntry, EquipmentItem, Team } from '../../types/operations';
 import { useActivityContext } from '../activities/ActivityProvider';
 import { Draggable, Droppable } from '../DragAndDrop/DnDComponents';
 import { StatusContainer } from '../StatusContainer';
@@ -98,7 +98,22 @@ export default function DashboardTeamCard({ team, defaultExpanded }: { team: Tea
   };
 
   const updateTeam = (team: Team) => {
+    const originalTeam = activity.teams.find((t) => t.id === team.id);
+    if (team.gar !== originalTeam?.gar) {
+      autoLog(`${team.name} GAR changed to ${team.gar.toUpperCase()}`, team.gar !== 'green');
+    }
     dispatch(ActivityActions.updateTeam(activity.id, team));
+  };
+
+  const autoLog = (message: string, isFavorite = false) => {
+    const comm: CommunicationsLogEntry = createNewCommsEntry({
+      from: team.name,
+      to: 'CP',
+      message: message,
+      isAutomated: true,
+      isFavorite,
+    });
+    dispatch(ActivityActions.addComm(activity.id, comm));
   };
 
   const handleExpandClick = (event: React.MouseEvent<HTMLButtonElement>) => {

--- a/src/components/dashboard/DashboardTeamCard.tsx
+++ b/src/components/dashboard/DashboardTeamCard.tsx
@@ -6,9 +6,9 @@ import { v4 as uuid } from 'uuid';
 
 import { useAppDispatch } from '@respond/lib/client/store';
 import { ActivityActions } from '@respond/lib/state';
-import { CommunicationsLogEntry, Participant, ParticipantStatus } from '@respond/types/activity';
+import { Participant, ParticipantStatus } from '@respond/types/activity';
 
-import { EquipmentItem, Team, TeamStatus } from '../../types/team';
+import { CommunicationsLogEntry, EquipmentItem, Team, TeamStatus } from '../../types/operations';
 import { useActivityContext } from '../activities/ActivityProvider';
 import { Droppable } from '../DragAndDrop/DnDComponents';
 import { StatusContainer } from '../StatusContainer';

--- a/src/components/dashboard/DashboardTeamCard.tsx
+++ b/src/components/dashboard/DashboardTeamCard.tsx
@@ -99,6 +99,7 @@ export default function DashboardTeamCard({ team, defaultExpanded }: { team: Tea
   }
 
   const updateTeam = (team: Team) => {
+    // TODO: Reassign remaining resource to the unassigned place.
     dispatch(ActivityActions.updateTeam(activity.id, team));
   };
 

--- a/src/components/dashboard/DashboardTeamCard.tsx
+++ b/src/components/dashboard/DashboardTeamCard.tsx
@@ -111,6 +111,7 @@ export default function DashboardTeamCard({ team, defaultExpanded }: { team: Tea
       'On Assignment': 'Starting Assignment',
       'On Scene': 'On Scene',
       'Returning To Base': 'RTB',
+      Disbanded: 'Disbanded',
     };
     const comm: CommunicationsLogEntry = {
       id: uuid(),
@@ -138,7 +139,7 @@ export default function DashboardTeamCard({ team, defaultExpanded }: { team: Tea
   return (
     <>
       <Droppable accepts={['participant', 'equipment']} onDrop={handleDrop}>
-        <StatusContainer color={statusColor} sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2 }}>
+        <StatusContainer color={team.status === 'Disbanded' ? 'grey' : statusColor} sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2 }}>
           <Box sx={{ display: 'flex', flexDirection: 'column', borderRadius: 2, p: 1.5, bgcolor: 'background.paper', height: '100%' }}>
             <Stack direction="row" alignItems="center" justifyContent="space-between">
               <Stack direction="row" alignItems="center">

--- a/src/components/dashboard/DashboardTeamEditDialog.tsx
+++ b/src/components/dashboard/DashboardTeamEditDialog.tsx
@@ -91,7 +91,7 @@ export function DashboardTeamEditDialog({ team, teams, onSave, onClose }: Dashbo
 
   return (
     <DialogWithHistory fullWidth={true} open={Boolean(team)} onClose={onClose}>
-      <DialogTitle>Edit team</DialogTitle>
+      <DialogTitle>Edit Team</DialogTitle>
 
       <form onSubmit={handleSubmit(handleSave)}>
         <DialogContent>

--- a/src/components/dashboard/DashboardTeamEditDialog.tsx
+++ b/src/components/dashboard/DashboardTeamEditDialog.tsx
@@ -2,7 +2,7 @@ import { Button, DialogActions, DialogContent, DialogTitle, MenuItem, TextField 
 import { useEffect } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
-import { SarGar, Team } from '../../types/team';
+import { SarGar, Team } from '../../types/operations';
 import DialogWithHistory from '../DialogWithHistory';
 import { Stack } from '../Material';
 

--- a/src/components/dashboard/DashboardTeamEditDialog.tsx
+++ b/src/components/dashboard/DashboardTeamEditDialog.tsx
@@ -1,0 +1,126 @@
+import { Button, DialogActions, DialogContent, DialogTitle, MenuItem, TextField } from '@mui/material';
+import { useEffect } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+
+import { SarGar, Team } from '../../types/team';
+import DialogWithHistory from '../DialogWithHistory';
+import { Stack } from '../Material';
+
+type DashboardTeamEditDialogProps = {
+  team: Team | null;
+  teams: Team[];
+  onSave: (team: Team) => void;
+  onClose: () => void;
+};
+
+type FormValues = {
+  name: string;
+  gar: SarGar;
+  assignment: string;
+  notes: string;
+};
+
+export function validateTeamName(teams: Team[], currentTeamId: string, name: string): { isValid: boolean; error?: string } {
+  const trimmedName = name.trim();
+
+  if (!trimmedName) {
+    return { isValid: false, error: 'Team name is required.' };
+  }
+
+  const hasDuplicate = teams.some((team) => team.id !== currentTeamId && team.name.trim().toLowerCase() === trimmedName.toLowerCase());
+
+  if (hasDuplicate) {
+    return { isValid: false, error: 'Team name already exists.' };
+  }
+
+  return { isValid: true };
+}
+
+export function DashboardTeamEditDialog({ team, teams, onSave, onClose }: DashboardTeamEditDialogProps) {
+  const {
+    register,
+    control,
+    handleSubmit,
+    setError,
+    formState: { errors },
+    reset,
+  } = useForm<FormValues>({
+    // Use `values` instead of `defaultValues` to keep the form synced when `team` changes or finishes loading
+    values: {
+      name: team?.name ?? '',
+      gar: team?.gar ?? 'green',
+      assignment: team?.assignment ?? '',
+      notes: team?.notes ?? '',
+    },
+  });
+
+  useEffect(() => {
+    reset({
+      name: team?.name ?? '',
+      gar: team?.gar ?? 'green',
+      assignment: team?.assignment ?? '',
+      notes: team?.notes ?? '',
+    });
+  }, [team, reset]);
+
+  const handleSave = (data: FormValues) => {
+    // Safety check in case the form is somehow submitted while team is undefined
+    if (!team) return;
+
+    const validation = validateTeamName(teams, team.id, data.name);
+
+    if (!validation.isValid) {
+      setError('name', {
+        type: 'manual',
+        message: validation.error ?? 'Please enter a team name.',
+      });
+      return;
+    }
+
+    onSave({
+      ...team,
+      name: data.name.trim(),
+      gar: data.gar,
+      assignment: data.assignment?.trim(),
+      notes: data.notes?.trim(),
+    });
+  };
+
+  // Prevent rendering dialog contents if team is null/undefined
+  if (!team) return null;
+
+  return (
+    <DialogWithHistory fullWidth={true} open={Boolean(team)} onClose={onClose}>
+      <DialogTitle>Edit team</DialogTitle>
+
+      <form onSubmit={handleSubmit(handleSave)}>
+        <DialogContent>
+          <Stack spacing={2} sx={{ pt: 1 }}>
+            <TextField autoFocus label="Team name" fullWidth {...register('name')} error={Boolean(errors.name)} helperText={errors.name?.message ?? 'Choose a unique name for this team.'} />
+            <Controller
+              name="gar"
+              control={control}
+              defaultValue={team?.gar ?? 'green'}
+              render={({ field }) => (
+                <TextField label="GAR" select fullWidth {...field}>
+                  <MenuItem value="green">Green</MenuItem>
+                  <MenuItem value="amber">Amber</MenuItem>
+                  <MenuItem value="red">Red</MenuItem>
+                </TextField>
+              )}
+            />
+            <TextField label="Assignment" fullWidth {...register('assignment')} />
+            <TextField label="Notes" fullWidth multiline minRows={3} {...register('notes')} />
+          </Stack>
+        </DialogContent>
+
+        <DialogActions>
+          <Button onClick={onClose}>Cancel</Button>
+          <Button type="submit" variant="contained">
+            Save
+          </Button>
+        </DialogActions>
+      </form>
+    </DialogWithHistory>
+  );
+}

--- a/src/components/dashboard/DashboardTeamEquipment.tsx
+++ b/src/components/dashboard/DashboardTeamEquipment.tsx
@@ -2,33 +2,29 @@ import { Stack, Typography } from '@mui/material';
 
 import { EquipmentItem } from '@respond/types/operations';
 
-import { Draggable } from '../DragAndDrop/DnDComponents';
-
 export function DashboardTeamEquipment({ item }: { item: EquipmentItem }) {
   return (
-    <Draggable type="equipment" item={item}>
-      <Stack
-        direction="row"
-        alignItems="center"
-        spacing={1}
-        sx={{
-          borderRadius: 1,
-          px: 1,
-          py: 0.75,
-          ':hover': {
-            bgcolor: 'grey.100',
-            // Targets the child element with class 'promote-button' when Stack is hovered
-            '& .promote-button': {
-              opacity: 1,
-              visibility: 'visible',
-            },
+    <Stack
+      direction="row"
+      alignItems="center"
+      spacing={1}
+      sx={{
+        borderRadius: 1,
+        px: 1,
+        py: 0.75,
+        ':hover': {
+          bgcolor: 'grey.100',
+          // Targets the child element with class 'promote-button' when Stack is hovered
+          '& .promote-button': {
+            opacity: 1,
+            visibility: 'visible',
           },
-        }}
-      >
-        <Typography variant="body2" sx={{ flexGrow: 1 }}>
-          {item.name}
-        </Typography>
-      </Stack>
-    </Draggable>
+        },
+      }}
+    >
+      <Typography variant="body2" sx={{ flexGrow: 1 }}>
+        {item.name}
+      </Typography>
+    </Stack>
   );
 }

--- a/src/components/dashboard/DashboardTeamEquipment.tsx
+++ b/src/components/dashboard/DashboardTeamEquipment.tsx
@@ -2,29 +2,16 @@ import { Stack, Typography } from '@mui/material';
 
 import { EquipmentItem } from '@respond/types/operations';
 
+import { DashboardDraggableContainer } from './DashboardDraggableContainer';
+
 export function DashboardTeamEquipment({ item }: { item: EquipmentItem }) {
   return (
-    <Stack
-      direction="row"
-      alignItems="center"
-      spacing={1}
-      sx={{
-        borderRadius: 1,
-        px: 1,
-        py: 0.75,
-        ':hover': {
-          bgcolor: 'grey.100',
-          // Targets the child element with class 'promote-button' when Stack is hovered
-          '& .promote-button': {
-            opacity: 1,
-            visibility: 'visible',
-          },
-        },
-      }}
-    >
-      <Typography variant="body2" sx={{ flexGrow: 1 }}>
-        {item.name}
-      </Typography>
-    </Stack>
+    <DashboardDraggableContainer variant="compact">
+      <Stack direction="row" alignItems="center" spacing={1}>
+        <Typography variant="body2" sx={{ flexGrow: 1 }}>
+          {item.name}
+        </Typography>
+      </Stack>
+    </DashboardDraggableContainer>
   );
 }

--- a/src/components/dashboard/DashboardTeamEquipment.tsx
+++ b/src/components/dashboard/DashboardTeamEquipment.tsx
@@ -1,0 +1,34 @@
+import { Stack, Typography } from '@mui/material';
+
+import { EquipmentItem } from '@respond/types/team';
+
+import { Draggable } from '../DragAndDrop/DnDComponents';
+
+export function DashboardTeamEquipment({ item }: { item: EquipmentItem }) {
+  return (
+    <Draggable type="equipment" item={item}>
+      <Stack
+        direction="row"
+        alignItems="center"
+        spacing={1}
+        sx={{
+          borderRadius: 1,
+          px: 1,
+          py: 0.75,
+          ':hover': {
+            bgcolor: 'grey.100',
+            // Targets the child element with class 'promote-button' when Stack is hovered
+            '& .promote-button': {
+              opacity: 1,
+              visibility: 'visible',
+            },
+          },
+        }}
+      >
+        <Typography variant="body2" sx={{ flexGrow: 1 }}>
+          {item.name}
+        </Typography>
+      </Stack>
+    </Draggable>
+  );
+}

--- a/src/components/dashboard/DashboardTeamEquipment.tsx
+++ b/src/components/dashboard/DashboardTeamEquipment.tsx
@@ -1,6 +1,6 @@
 import { Stack, Typography } from '@mui/material';
 
-import { EquipmentItem } from '@respond/types/team';
+import { EquipmentItem } from '@respond/types/operations';
 
 import { Draggable } from '../DragAndDrop/DnDComponents';
 

--- a/src/components/dashboard/DashboardTeamManager.tsx
+++ b/src/components/dashboard/DashboardTeamManager.tsx
@@ -64,9 +64,10 @@ export function DashboardTeamManager() {
 
   const activity = useActivityContext();
   const [expandedAll, setExpandedAll] = useState(false);
+  const teams = activity.teams ?? [];
 
   const addTeam = () => {
-    const nextTeamNumber = getNextTeamNumber(activity.teams);
+    const nextTeamNumber = getNextTeamNumber(teams);
     dispatch(ActivityActions.createTeam(activity.id, createNewTeam(`Team ${nextTeamNumber}`)));
   };
 
@@ -86,8 +87,8 @@ export function DashboardTeamManager() {
       </Stack>
       <Box sx={{ flex: 1, width: '100%', overflow: 'auto', display: 'flex', flexDirection: 'column' }}>
         <Stack direction="column" spacing={1} sx={{ minHeight: 0, flex: 1 }}>
-          {activity.teams?.length ? (
-            [...activity.teams].sort(sortTeams).map((team) => {
+          {teams.length ? (
+            [...teams].sort(sortTeams).map((team) => {
               return <DashboardTeamCard key={team.id} team={team} defaultExpanded={expandedAll} />;
             })
           ) : (

--- a/src/components/dashboard/DashboardTeamManager.tsx
+++ b/src/components/dashboard/DashboardTeamManager.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 
 import { useAppDispatch } from '@respond/lib/client/store';
 import { ActivityActions } from '@respond/lib/state';
-import { createNewTeam, Team } from '@respond/types/team';
+import { createNewTeam, Team } from '@respond/types/operations';
 
 import { useActivityContext } from '../activities/ActivityProvider';
 import { Stack } from '../Material';

--- a/src/components/dashboard/DashboardTeamManager.tsx
+++ b/src/components/dashboard/DashboardTeamManager.tsx
@@ -30,6 +30,23 @@ function getNextTeamNumber(teams: Team[]): number {
 }
 
 const sortTeams = (left: Team, right: Team) => {
+  // Sort order for dashboard team listing:
+  // 1. All non-disbanded teams should appear before any 'Disbanded' teams.
+  // 2. Teams with status 'Disbanded' should still be alphabetized by name.
+  // 3. For active teams, sort by GAR priority (red first, then amber, then green).
+  // 4. If GAR is the same, sort active teams alphabetically by name.
+  if (left.status === 'Disbanded' && right.status !== 'Disbanded') {
+    return 1;
+  }
+
+  if (right.status === 'Disbanded' && left.status !== 'Disbanded') {
+    return -1;
+  }
+
+  if (left.status === 'Disbanded' && right.status === 'Disbanded') {
+    return left.name.localeCompare(right.name, undefined, { sensitivity: 'base' });
+  }
+
   const garPriority: Team['gar'][] = ['red', 'amber', 'green'];
 
   const leftPriority = garPriority.indexOf(left.gar as Team['gar']);

--- a/src/components/dashboard/DashboardTeamManager.tsx
+++ b/src/components/dashboard/DashboardTeamManager.tsx
@@ -1,0 +1,87 @@
+import AddIcon from '@mui/icons-material/Add';
+import { Box, Button, Typography } from '@mui/material';
+import { useState } from 'react';
+
+import { useAppDispatch } from '@respond/lib/client/store';
+import { ActivityActions } from '@respond/lib/state';
+import { createNewTeam, Team } from '@respond/types/team';
+
+import { useActivityContext } from '../activities/ActivityProvider';
+import { Stack } from '../Material';
+
+import DashboardTeamCard from './DashboardTeamCard';
+
+function getNextTeamNumber(teams: Team[]): number {
+  const usedNumbers = new Set<number>();
+
+  (teams ?? []).forEach((team) => {
+    const match = team.name.trim().match(/^team\s+(\d+)$/i);
+    if (match) {
+      usedNumbers.add(Number(match[1]));
+    }
+  });
+
+  let nextNumber = 1;
+  while (usedNumbers.has(nextNumber)) {
+    nextNumber += 1;
+  }
+
+  return nextNumber;
+}
+
+const sortTeams = (left: Team, right: Team) => {
+  const garPriority: Team['gar'][] = ['red', 'amber', 'green'];
+
+  const leftPriority = garPriority.indexOf(left.gar as Team['gar']);
+  const rightPriority = garPriority.indexOf(right.gar as Team['gar']);
+
+  if (leftPriority !== rightPriority) {
+    return leftPriority - rightPriority;
+  }
+
+  return left.name.localeCompare(right.name, undefined, { sensitivity: 'base' });
+};
+
+export function DashboardTeamManager() {
+  const dispatch = useAppDispatch();
+
+  const activity = useActivityContext();
+  const [expandedAll, setExpandedAll] = useState(false);
+
+  const addTeam = () => {
+    const nextTeamNumber = getNextTeamNumber(activity.teams);
+    dispatch(ActivityActions.createTeam(activity.id, createNewTeam(`Team ${nextTeamNumber}`)));
+  };
+
+  const toggleAll = () => {
+    setExpandedAll((current) => !current);
+  };
+
+  return (
+    <>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={1} sx={{ mb: 2 }}>
+        <Button size="small" variant="outlined" onClick={toggleAll}>
+          {expandedAll ? 'Collapse all' : 'Expand all'}
+        </Button>
+        <Button size="small" variant="contained" startIcon={<AddIcon />} onClick={addTeam}>
+          Add
+        </Button>
+      </Stack>
+      <Box sx={{ flex: 1, width: '100%', overflow: 'auto', display: 'flex', flexDirection: 'column' }}>
+        <Stack direction="column" spacing={1} sx={{ minHeight: 0, flex: 1 }}>
+          {activity.teams?.length ? (
+            [...activity.teams].sort(sortTeams).map((team) => {
+              return <DashboardTeamCard key={team.id} team={team} defaultExpanded={expandedAll} />;
+            })
+          ) : (
+            <Box sx={{ flex: 1, minHeight: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <Typography variant="body2" color="text.secondary" textAlign="center">
+                There are no active teams.
+              </Typography>
+            </Box>
+          )}
+        </Stack>
+      </Box>
+    </>
+  );
+}

--- a/src/components/dashboard/DashboardTeamMember.tsx
+++ b/src/components/dashboard/DashboardTeamMember.tsx
@@ -1,12 +1,13 @@
 import KeyboardDoubleArrowUpIcon from '@mui/icons-material/KeyboardDoubleArrowUp';
 import { IconButton, Stack, Typography } from '@mui/material';
 
-import { getOrganizationName, Participant } from '@respond/types/activity';
+import { getOrganizationName, Participant, ParticipantStatus } from '@respond/types/activity';
 
 import { useActivityContext } from '../activities/ActivityProvider';
 
 export function DashboardTeamMember({ participant, onPromote }: { participant: Participant; onPromote?: () => void }) {
   const activity = useActivityContext();
+  const participantStatus: ParticipantStatus = participant.timeline?.[0]?.status;
   const organizationName = getOrganizationName(activity, participant.organizationId);
   return (
     <Stack
@@ -17,8 +18,9 @@ export function DashboardTeamMember({ participant, onPromote }: { participant: P
         borderRadius: 1,
         px: 1,
         py: 0.75,
+        bgcolor: participantStatus !== ParticipantStatus.Assigned ? '#ffd7d7' : undefined,
         ':hover': {
-          bgcolor: 'grey.100',
+          bgcolor: participantStatus !== ParticipantStatus.Assigned ? '#f0bcbc' : 'grey.100',
           // Targets the child element with class 'promote-button' when Stack is hovered
           '& .promote-button': {
             opacity: 1,
@@ -31,28 +33,30 @@ export function DashboardTeamMember({ participant, onPromote }: { participant: P
         {participant.firstname} {participant.lastname} ({organizationName})
       </Typography>
 
-      {!!onPromote &&<IconButton
-        className="promote-button"
-        onClick={(event) => {
-          event.stopPropagation();
-          onPromote?.();
-        }}
-        size="small"
-        disableRipple // Optional: prevents grey ripple effect on click
-        sx={{
-          width: 16,
-          height: 16,
-          opacity: 0,
-          visibility: 'hidden',
-          transition: 'opacity 0.2s ease-in-out',
-          bgcolor: 'transparent',
-          ':hover': {
-            bgcolor: 'transparent', // Ensures button stays transparent even when directly hovered
-          },
-        }}
-      >
-        <KeyboardDoubleArrowUpIcon sx={{ fontSize: 14 }} />
-      </IconButton>}
+      {!!onPromote && (
+        <IconButton
+          className="promote-button"
+          onClick={(event) => {
+            event.stopPropagation();
+            onPromote?.();
+          }}
+          size="small"
+          disableRipple // Optional: prevents grey ripple effect on click
+          sx={{
+            width: 16,
+            height: 16,
+            opacity: 0,
+            visibility: 'hidden',
+            transition: 'opacity 0.2s ease-in-out',
+            bgcolor: 'transparent',
+            ':hover': {
+              bgcolor: 'transparent', // Ensures button stays transparent even when directly hovered
+            },
+          }}
+        >
+          <KeyboardDoubleArrowUpIcon sx={{ fontSize: 14 }} />
+        </IconButton>
+      )}
     </Stack>
   );
 }

--- a/src/components/dashboard/DashboardTeamMember.tsx
+++ b/src/components/dashboard/DashboardTeamMember.tsx
@@ -1,0 +1,58 @@
+import KeyboardDoubleArrowUpIcon from '@mui/icons-material/KeyboardDoubleArrowUp';
+import { IconButton, Stack, Typography } from '@mui/material';
+
+import { getOrganizationName, Participant } from '@respond/types/activity';
+
+import { useActivityContext } from '../activities/ActivityProvider';
+import { Draggable } from '../DragAndDrop/DnDComponents';
+
+export function DashboardTeamMember({ participant, onPromote }: { participant: Participant; onPromote?: () => void }) {
+  const activity = useActivityContext();
+  const organizationName = getOrganizationName(activity, participant.organizationId);
+  return (
+    <Draggable type="participant" item={participant}>
+      <Stack
+        direction="row"
+        alignItems="center"
+        spacing={1}
+        sx={{
+          borderRadius: 1,
+          px: 1,
+          py: 0.75,
+          ':hover': {
+            bgcolor: 'grey.100',
+            // Targets the child element with class 'promote-button' when Stack is hovered
+            '& .promote-button': {
+              opacity: 1,
+              visibility: 'visible',
+            },
+          },
+        }}
+      >
+        <Typography variant="body2" sx={{ flexGrow: 1 }}>
+          {participant.firstname} {participant.lastname} ({organizationName})
+        </Typography>
+
+        <IconButton
+          className="promote-button"
+          onClick={onPromote}
+          size="small"
+          disableRipple // Optional: prevents grey ripple effect on click
+          sx={{
+            width: 16,
+            height: 16,
+            opacity: 0,
+            visibility: 'hidden',
+            transition: 'opacity 0.2s ease-in-out',
+            bgcolor: 'transparent',
+            ':hover': {
+              bgcolor: 'transparent', // Ensures button stays transparent even when directly hovered
+            },
+          }}
+        >
+          {!!onPromote && <KeyboardDoubleArrowUpIcon sx={{ fontSize: 14 }} />}
+        </IconButton>
+      </Stack>
+    </Draggable>
+  );
+}

--- a/src/components/dashboard/DashboardTeamMember.tsx
+++ b/src/components/dashboard/DashboardTeamMember.tsx
@@ -4,55 +4,55 @@ import { IconButton, Stack, Typography } from '@mui/material';
 import { getOrganizationName, Participant } from '@respond/types/activity';
 
 import { useActivityContext } from '../activities/ActivityProvider';
-import { Draggable } from '../DragAndDrop/DnDComponents';
 
 export function DashboardTeamMember({ participant, onPromote }: { participant: Participant; onPromote?: () => void }) {
   const activity = useActivityContext();
   const organizationName = getOrganizationName(activity, participant.organizationId);
   return (
-    <Draggable type="participant" item={participant}>
-      <Stack
-        direction="row"
-        alignItems="center"
-        spacing={1}
+    <Stack
+      direction="row"
+      alignItems="center"
+      spacing={1}
+      sx={{
+        borderRadius: 1,
+        px: 1,
+        py: 0.75,
+        ':hover': {
+          bgcolor: 'grey.100',
+          // Targets the child element with class 'promote-button' when Stack is hovered
+          '& .promote-button': {
+            opacity: 1,
+            visibility: 'visible',
+          },
+        },
+      }}
+    >
+      <Typography variant="body2" sx={{ flexGrow: 1 }}>
+        {participant.firstname} {participant.lastname} ({organizationName})
+      </Typography>
+
+      {!!onPromote &&<IconButton
+        className="promote-button"
+        onClick={(event) => {
+          event.stopPropagation();
+          onPromote?.();
+        }}
+        size="small"
+        disableRipple // Optional: prevents grey ripple effect on click
         sx={{
-          borderRadius: 1,
-          px: 1,
-          py: 0.75,
+          width: 16,
+          height: 16,
+          opacity: 0,
+          visibility: 'hidden',
+          transition: 'opacity 0.2s ease-in-out',
+          bgcolor: 'transparent',
           ':hover': {
-            bgcolor: 'grey.100',
-            // Targets the child element with class 'promote-button' when Stack is hovered
-            '& .promote-button': {
-              opacity: 1,
-              visibility: 'visible',
-            },
+            bgcolor: 'transparent', // Ensures button stays transparent even when directly hovered
           },
         }}
       >
-        <Typography variant="body2" sx={{ flexGrow: 1 }}>
-          {participant.firstname} {participant.lastname} ({organizationName})
-        </Typography>
-
-        <IconButton
-          className="promote-button"
-          onClick={onPromote}
-          size="small"
-          disableRipple // Optional: prevents grey ripple effect on click
-          sx={{
-            width: 16,
-            height: 16,
-            opacity: 0,
-            visibility: 'hidden',
-            transition: 'opacity 0.2s ease-in-out',
-            bgcolor: 'transparent',
-            ':hover': {
-              bgcolor: 'transparent', // Ensures button stays transparent even when directly hovered
-            },
-          }}
-        >
-          {!!onPromote && <KeyboardDoubleArrowUpIcon sx={{ fontSize: 14 }} />}
-        </IconButton>
-      </Stack>
-    </Draggable>
+        <KeyboardDoubleArrowUpIcon sx={{ fontSize: 14 }} />
+      </IconButton>}
+    </Stack>
   );
 }

--- a/src/components/dashboard/DashboardTeamMember.tsx
+++ b/src/components/dashboard/DashboardTeamMember.tsx
@@ -5,58 +5,57 @@ import { getOrganizationName, Participant, ParticipantStatus } from '@respond/ty
 
 import { useActivityContext } from '../activities/ActivityProvider';
 
+import { DashboardDraggableContainer } from './DashboardDraggableContainer';
+
 export function DashboardTeamMember({ participant, onPromote }: { participant: Participant; onPromote?: () => void }) {
   const activity = useActivityContext();
   const participantStatus: ParticipantStatus = participant.timeline?.[0]?.status;
   const organizationName = getOrganizationName(activity, participant.organizationId);
   return (
-    <Stack
-      direction="row"
-      alignItems="center"
-      spacing={1}
-      sx={{
-        borderRadius: 1,
-        px: 1,
-        py: 0.75,
-        bgcolor: participantStatus !== ParticipantStatus.Assigned ? '#ffd7d7' : undefined,
-        ':hover': {
-          bgcolor: participantStatus !== ParticipantStatus.Assigned ? '#f0bcbc' : 'grey.100',
-          // Targets the child element with class 'promote-button' when Stack is hovered
-          '& .promote-button': {
-            opacity: 1,
-            visibility: 'visible',
-          },
-        },
-      }}
-    >
-      <Typography variant="body2" sx={{ flexGrow: 1 }}>
-        {participant.firstname} {participant.lastname} ({organizationName})
-      </Typography>
-
-      {!!onPromote && (
-        <IconButton
-          className="promote-button"
-          onClick={(event) => {
-            event.stopPropagation();
-            onPromote?.();
-          }}
-          size="small"
-          disableRipple // Optional: prevents grey ripple effect on click
-          sx={{
-            width: 16,
-            height: 16,
-            opacity: 0,
-            visibility: 'hidden',
-            transition: 'opacity 0.2s ease-in-out',
-            bgcolor: 'transparent',
-            ':hover': {
-              bgcolor: 'transparent', // Ensures button stays transparent even when directly hovered
+    <DashboardDraggableContainer variant="compact" sx={{ bgcolor: participantStatus !== ParticipantStatus.Assigned ? '#f0bcbc' : 'background.paper' }}>
+      <Stack
+        direction="row"
+        alignItems="center"
+        spacing={1}
+        sx={{
+          ':hover': {
+            // Targets the child element with class 'promote-button' when Stack is hovered
+            '& .promote-button': {
+              opacity: 1,
+              visibility: 'visible',
             },
-          }}
-        >
-          <KeyboardDoubleArrowUpIcon sx={{ fontSize: 14 }} />
-        </IconButton>
-      )}
-    </Stack>
+          },
+        }}
+      >
+        <Typography variant="body2" sx={{ flexGrow: 1 }}>
+          {participant.firstname} {participant.lastname} ({organizationName})
+        </Typography>
+
+        {!!onPromote && (
+          <IconButton
+            className="promote-button"
+            onClick={(event) => {
+              event.stopPropagation();
+              onPromote?.();
+            }}
+            size="small"
+            disableRipple // Optional: prevents grey ripple effect on click
+            sx={{
+              width: 16,
+              height: 16,
+              opacity: 0,
+              visibility: 'hidden',
+              transition: 'opacity 0.2s ease-in-out',
+              bgcolor: 'transparent',
+              ':hover': {
+                bgcolor: 'transparent', // Ensures button stays transparent even when directly hovered
+              },
+            }}
+          >
+            <KeyboardDoubleArrowUpIcon sx={{ fontSize: 14 }} />
+          </IconButton>
+        )}
+      </Stack>
+    </DashboardDraggableContainer>
   );
 }

--- a/src/components/dashboard/DashboardTeamStatusSelect.tsx
+++ b/src/components/dashboard/DashboardTeamStatusSelect.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { TeamStatus } from '../../types/team';
 
-const TEAM_STATUSES: TeamStatus[] = ['In Base', 'In Transit', 'On Assignment', 'On Scene', 'Returning To Base'];
+const TEAM_STATUSES: TeamStatus[] = ['In Base', 'In Transit', 'On Assignment', 'On Scene', 'Returning To Base', 'Disbanded'];
 
 // Color mapping for status visual indicators
 const STATUS_COLORS: Record<TeamStatus, 'default' | 'info' | 'warning' | 'success' | 'secondary'> = {
@@ -12,6 +12,7 @@ const STATUS_COLORS: Record<TeamStatus, 'default' | 'info' | 'warning' | 'succes
   'On Assignment': 'warning',
   'On Scene': 'success',
   'Returning To Base': 'secondary',
+  Disbanded: 'default',
 };
 
 interface TeamStatusSelectProps {

--- a/src/components/dashboard/DashboardTeamStatusSelect.tsx
+++ b/src/components/dashboard/DashboardTeamStatusSelect.tsx
@@ -1,12 +1,11 @@
 import { Box, Chip, MenuItem, Select, SelectChangeEvent } from '@mui/material';
 import React, { useState } from 'react';
-import { v4 as uuid } from 'uuid';
 
 import { useAppDispatch } from '@respond/lib/client/store';
 import { ActivityActions } from '@respond/lib/state';
 import { ParticipantStatus } from '@respond/types/activity';
 
-import { CommunicationsLogEntry, createNewPlace, DEFAULT_PLACES, Team, TeamStatus } from '../../types/operations';
+import { CommunicationsLogEntry, createNewCommsEntry, createNewPlace, DEFAULT_PLACES, Team, TeamStatus } from '../../types/operations';
 import { useActivityContext } from '../activities/ActivityProvider';
 import ConfirmDialog from '../ConfirmDialog';
 
@@ -43,15 +42,13 @@ export const TeamStatusSelect: React.FC<TeamStatusSelectProps> = ({ team }) => {
       'Returning To Base': 'RTB',
       Disbanded: 'Disbanded',
     };
-    const comm: CommunicationsLogEntry = {
-      id: uuid(),
+    const comm: CommunicationsLogEntry = createNewCommsEntry({
       from: team.name,
       to: 'CP',
       message: messages[status],
-      timestamp: Date.now(),
       isAutomated: true,
-      isDeleted: false,
-    };
+    });
+    console.log('Logging status change:', comm); // Debugging log
     dispatch(ActivityActions.addComm(activity.id, comm));
   };
 

--- a/src/components/dashboard/DashboardTeamStatusSelect.tsx
+++ b/src/components/dashboard/DashboardTeamStatusSelect.tsx
@@ -28,25 +28,29 @@ interface TeamStatusSelectProps {
   size?: 'small' | 'medium';
 }
 
+type CommsLogTeamStatus = TeamStatus | 'Subject Located';
+
 export const TeamStatusSelect: React.FC<TeamStatusSelectProps> = ({ team }) => {
   const dispatch = useAppDispatch();
   const activity = useActivityContext();
   const [confirmOpen, setConfirmOpen] = useState(false);
 
-  const logStatusChange = (status: TeamStatus) => {
-    const messages: Record<TeamStatus, string> = {
+  const logStatusChange = (status: CommsLogTeamStatus) => {
+    const messages: Record<CommsLogTeamStatus, string> = {
       'In Base': 'In Base',
-      'In Transit': 'With Transportation',
+      'In Transit': 'In Transit',
       'On Assignment': 'Starting Assignment',
       'On Scene': 'On Scene',
       'Returning To Base': 'RTB',
+      'Subject Located': 'Subject Located',
       Disbanded: 'Disbanded',
     };
     const comm: CommunicationsLogEntry = createNewCommsEntry({
       from: team.name,
       to: 'CP',
-      message: messages[status],
+      message: messages[status] ?? status,
       isAutomated: true,
+      isFavorite: status === 'Subject Located',
     });
     console.log('Logging status change:', comm); // Debugging log
     dispatch(ActivityActions.addComm(activity.id, comm));
@@ -125,8 +129,12 @@ export const TeamStatusSelect: React.FC<TeamStatusSelectProps> = ({ team }) => {
   const handleChange = (event: SelectChangeEvent<string>) => {
     const newStatus = event.target.value as TeamStatus;
     if (newStatus !== 'Disbanded') {
+      if (newStatus === 'On Scene' && !activity.teams.some((t) => t.status === 'On Scene')) {
+        logStatusChange('Subject Located');
+      } else {
+        logStatusChange(newStatus);
+      }
       dispatch(ActivityActions.updateTeam(activity.id, { ...team, status: newStatus }));
-      logStatusChange(newStatus);
       return;
     }
 

--- a/src/components/dashboard/DashboardTeamStatusSelect.tsx
+++ b/src/components/dashboard/DashboardTeamStatusSelect.tsx
@@ -1,7 +1,7 @@
 import { Box, Chip, MenuItem, Select, SelectChangeEvent } from '@mui/material';
 import React from 'react';
 
-import { TeamStatus } from '../../types/team';
+import { TeamStatus } from '../../types/operations';
 
 const TEAM_STATUSES: TeamStatus[] = ['In Base', 'In Transit', 'On Assignment', 'On Scene', 'Returning To Base', 'Disbanded'];
 

--- a/src/components/dashboard/DashboardTeamStatusSelect.tsx
+++ b/src/components/dashboard/DashboardTeamStatusSelect.tsx
@@ -1,0 +1,84 @@
+import { Box, Chip, MenuItem, Select, SelectChangeEvent } from '@mui/material';
+import React from 'react';
+
+import { TeamStatus } from '../../types/team';
+
+const TEAM_STATUSES: TeamStatus[] = ['In Base', 'In Transit', 'On Assignment', 'On Scene', 'Returning To Base'];
+
+// Color mapping for status visual indicators
+const STATUS_COLORS: Record<TeamStatus, 'default' | 'info' | 'warning' | 'success' | 'secondary'> = {
+  'In Base': 'default',
+  'In Transit': 'info',
+  'On Assignment': 'warning',
+  'On Scene': 'success',
+  'Returning To Base': 'secondary',
+};
+
+interface TeamStatusSelectProps {
+  value: TeamStatus;
+  onChange: (status: TeamStatus) => void;
+  label?: string;
+  fullWidth?: boolean;
+  size?: 'small' | 'medium';
+}
+
+export const TeamStatusSelect: React.FC<TeamStatusSelectProps> = ({ value, onChange }) => {
+  const handleChange = (event: SelectChangeEvent<string>) => {
+    onChange(event.target.value as TeamStatus);
+  };
+
+  return (
+    <Select
+      value={value}
+      onChange={handleChange}
+      variant="outlined"
+      size="small"
+      sx={{
+        borderRadius: '16px', // Pill shape
+        height: 28,
+        fontSize: '0.75rem',
+        fontWeight: 600,
+        '& .MuiOutlinedInput-notchedOutline': {
+          border: 'none', // Removes the standard input border box
+        },
+        '&:hover .MuiOutlinedInput-notchedOutline': {
+          border: 'none',
+        },
+        '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+          border: 'none',
+        },
+        '& .MuiSelect-select': {
+          paddingLeft: '12px',
+          paddingRight: '28px !important', // Leaves space for the arrow
+          paddingTop: '2px',
+          paddingBottom: '2px',
+          display: 'flex',
+          alignItems: 'center',
+        },
+        '& .MuiSelect-icon': {
+          right: '6px',
+          color: 'inherit', // Arrow inherits text color
+          fontSize: '1.1rem',
+        },
+      }}
+    >
+      {TEAM_STATUSES.map((status) => (
+        <MenuItem key={status} value={status}>
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            <Chip
+              label={status}
+              size="small"
+              color={STATUS_COLORS[status]}
+              sx={{
+                height: 20,
+                fontSize: '0.75rem',
+                fontWeight: 600,
+                cursor: 'pointer',
+              }}
+            />
+          </Box>
+        </MenuItem>
+      ))}
+    </Select>
+  );
+};

--- a/src/components/dashboard/DashboardTeamStatusSelect.tsx
+++ b/src/components/dashboard/DashboardTeamStatusSelect.tsx
@@ -1,7 +1,14 @@
 import { Box, Chip, MenuItem, Select, SelectChangeEvent } from '@mui/material';
-import React from 'react';
+import React, { useState } from 'react';
+import { v4 as uuid } from 'uuid';
 
-import { TeamStatus } from '../../types/operations';
+import { useAppDispatch } from '@respond/lib/client/store';
+import { ActivityActions } from '@respond/lib/state';
+import { ParticipantStatus } from '@respond/types/activity';
+
+import { CommunicationsLogEntry, createNewPlace, DEFAULT_PLACES, Team, TeamStatus } from '../../types/operations';
+import { useActivityContext } from '../activities/ActivityProvider';
+import ConfirmDialog from '../ConfirmDialog';
 
 const TEAM_STATUSES: TeamStatus[] = ['In Base', 'In Transit', 'On Assignment', 'On Scene', 'Returning To Base', 'Disbanded'];
 
@@ -16,70 +23,205 @@ const STATUS_COLORS: Record<TeamStatus, 'default' | 'info' | 'warning' | 'succes
 };
 
 interface TeamStatusSelectProps {
-  value: TeamStatus;
-  onChange: (status: TeamStatus) => void;
+  team: Team;
   label?: string;
   fullWidth?: boolean;
   size?: 'small' | 'medium';
 }
 
-export const TeamStatusSelect: React.FC<TeamStatusSelectProps> = ({ value, onChange }) => {
+export const TeamStatusSelect: React.FC<TeamStatusSelectProps> = ({ team }) => {
+  const dispatch = useAppDispatch();
+  const activity = useActivityContext();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const logStatusChange = (status: TeamStatus) => {
+    const messages: Record<TeamStatus, string> = {
+      'In Base': 'In Base',
+      'In Transit': 'With Transportation',
+      'On Assignment': 'Starting Assignment',
+      'On Scene': 'On Scene',
+      'Returning To Base': 'RTB',
+      Disbanded: 'Disbanded',
+    };
+    const comm: CommunicationsLogEntry = {
+      id: uuid(),
+      from: team.name,
+      to: 'CP',
+      message: messages[status],
+      timestamp: Date.now(),
+      isAutomated: true,
+      isDeleted: false,
+    };
+    dispatch(ActivityActions.addComm(activity.id, comm));
+  };
+
+  const disbandDirectly = () => {
+    const updates = team.assignedParticipants
+      .map((participantId) => {
+        const participant = activity.participants[participantId];
+        if (!participant) {
+          return undefined;
+        }
+        return {
+          participantId,
+          update: {
+            time: Date.now(),
+            status: ParticipantStatus.Available,
+            organizationId: participant.organizationId,
+          },
+        };
+      })
+      .filter((item): item is { participantId: string; update: { time: number; status: ParticipantStatus; organizationId: string } } => Boolean(item));
+
+    if (updates.length) {
+      dispatch(ActivityActions.bulkParticipantUpdate(activity.id, updates));
+    }
+
+    dispatch(
+      ActivityActions.updateTeam(activity.id, {
+        ...team,
+        status: 'Disbanded',
+        assignedParticipants: [],
+        assignedEquipment: [],
+        teamLeaderParticipantId: null,
+      }),
+    );
+    logStatusChange('Disbanded');
+  };
+
+  const disbandWithReassign = () => {
+    const fieldPlace = activity.places?.find((place) => place.name === DEFAULT_PLACES.field);
+    const mergedParticipants = Array.from(new Set([...(fieldPlace?.assignedParticipants ?? []), ...team.assignedParticipants]));
+    const existingEquipmentIds = new Set(fieldPlace?.assignedEquipment.map((item) => item.uuid));
+    const mergedEquipment = [...(fieldPlace?.assignedEquipment ?? []), ...team.assignedEquipment.filter((item) => !existingEquipmentIds.has(item.uuid))];
+
+    const updatedFieldPlace = fieldPlace
+      ? {
+          ...fieldPlace,
+          assignedParticipants: mergedParticipants,
+          assignedEquipment: mergedEquipment,
+        }
+      : {
+          ...createNewPlace(DEFAULT_PLACES.field),
+          assignedParticipants: mergedParticipants,
+          assignedEquipment: mergedEquipment,
+        };
+
+    if (fieldPlace) {
+      dispatch(ActivityActions.updatePlace(activity.id, updatedFieldPlace));
+    } else {
+      dispatch(ActivityActions.createPlace(activity.id, updatedFieldPlace));
+    }
+
+    dispatch(
+      ActivityActions.updateTeam(activity.id, {
+        ...team,
+        status: 'Disbanded',
+        assignedParticipants: [],
+        assignedEquipment: [],
+        teamLeaderParticipantId: null,
+      }),
+    );
+    logStatusChange('Disbanded');
+  };
+
   const handleChange = (event: SelectChangeEvent<string>) => {
-    onChange(event.target.value as TeamStatus);
+    const newStatus = event.target.value as TeamStatus;
+    if (newStatus !== 'Disbanded') {
+      dispatch(ActivityActions.updateTeam(activity.id, { ...team, status: newStatus }));
+      logStatusChange(newStatus);
+      return;
+    }
+
+    if (team.status === 'Disbanded') {
+      return;
+    }
+
+    const isSafeDisband = team.status === 'In Base' || team.status === 'Returning To Base';
+    const needsConfirm = !isSafeDisband && (team.assignedParticipants.length > 0 || team.assignedEquipment.length > 0);
+
+    if (isSafeDisband) {
+      disbandDirectly();
+      return;
+    }
+
+    if (needsConfirm) {
+      setConfirmOpen(true);
+      return;
+    }
+
+    dispatch(
+      ActivityActions.updateTeam(activity.id, {
+        ...team,
+        status: 'Disbanded',
+      }),
+    );
+    logStatusChange('Disbanded');
   };
 
   return (
-    <Select
-      value={value}
-      onChange={handleChange}
-      variant="outlined"
-      size="small"
-      sx={{
-        borderRadius: '16px', // Pill shape
-        height: 28,
-        fontSize: '0.75rem',
-        fontWeight: 600,
-        '& .MuiOutlinedInput-notchedOutline': {
-          border: 'none', // Removes the standard input border box
-        },
-        '&:hover .MuiOutlinedInput-notchedOutline': {
-          border: 'none',
-        },
-        '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-          border: 'none',
-        },
-        '& .MuiSelect-select': {
-          paddingLeft: '12px',
-          paddingRight: '28px !important', // Leaves space for the arrow
-          paddingTop: '2px',
-          paddingBottom: '2px',
-          display: 'flex',
-          alignItems: 'center',
-        },
-        '& .MuiSelect-icon': {
-          right: '6px',
-          color: 'inherit', // Arrow inherits text color
-          fontSize: '1.1rem',
-        },
-      }}
-    >
-      {TEAM_STATUSES.map((status) => (
-        <MenuItem key={status} value={status}>
-          <Box sx={{ display: 'flex', alignItems: 'center' }}>
-            <Chip
-              label={status}
-              size="small"
-              color={STATUS_COLORS[status]}
-              sx={{
-                height: 20,
-                fontSize: '0.75rem',
-                fontWeight: 600,
-                cursor: 'pointer',
-              }}
-            />
-          </Box>
-        </MenuItem>
-      ))}
-    </Select>
+    <>
+      <Select
+        value={team.status}
+        onChange={handleChange}
+        variant="outlined"
+        size="small"
+        sx={{
+          borderRadius: '16px', // Pill shape
+          height: 28,
+          fontSize: '0.75rem',
+          fontWeight: 600,
+          '& .MuiOutlinedInput-notchedOutline': {
+            border: 'none', // Removes the standard input border box
+          },
+          '&:hover .MuiOutlinedInput-notchedOutline': {
+            border: 'none',
+          },
+          '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+            border: 'none',
+          },
+          '& .MuiSelect-select': {
+            paddingLeft: '12px',
+            paddingRight: '28px !important', // Leaves space for the arrow
+            paddingTop: '2px',
+            paddingBottom: '2px',
+            display: 'flex',
+            alignItems: 'center',
+          },
+          '& .MuiSelect-icon': {
+            right: '6px',
+            color: 'inherit', // Arrow inherits text color
+            fontSize: '1.1rem',
+          },
+        }}
+      >
+        {TEAM_STATUSES.map((status) => (
+          <MenuItem key={status} value={status}>
+            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+              <Chip
+                label={status}
+                size="small"
+                color={STATUS_COLORS[status]}
+                sx={{
+                  height: 20,
+                  fontSize: '0.75rem',
+                  fontWeight: 600,
+                  cursor: 'pointer',
+                }}
+              />
+            </Box>
+          </MenuItem>
+        ))}
+      </Select>
+      <ConfirmDialog
+        open={confirmOpen}
+        prompt={`Disbanding ${team.name} will move remaining members and equipment to ${DEFAULT_PLACES.field}. Continue?`}
+        onConfirm={() => {
+          disbandWithReassign();
+          setConfirmOpen(false);
+        }}
+        onClose={() => setConfirmOpen(false)}
+      />
+    </>
   );
 };

--- a/src/components/dashboard/DashboardTeamStatusSelect.tsx
+++ b/src/components/dashboard/DashboardTeamStatusSelect.tsx
@@ -93,7 +93,7 @@ export const TeamStatusSelect: React.FC<TeamStatusSelectProps> = ({ team }) => {
   const disbandWithReassign = () => {
     const fieldPlace = activity.places?.find((place) => place.name === DEFAULT_PLACES.field);
     const mergedParticipants = Array.from(new Set([...(fieldPlace?.assignedParticipants ?? []), ...team.assignedParticipants]));
-    const existingEquipmentIds = new Set(fieldPlace?.assignedEquipment.map((item) => item.uuid));
+    const existingEquipmentIds = new Set((fieldPlace?.assignedEquipment ?? []).map((item) => item.uuid));
     const mergedEquipment = [...(fieldPlace?.assignedEquipment ?? []), ...team.assignedEquipment.filter((item) => !existingEquipmentIds.has(item.uuid))];
 
     const updatedFieldPlace = fieldPlace
@@ -129,7 +129,7 @@ export const TeamStatusSelect: React.FC<TeamStatusSelectProps> = ({ team }) => {
   const handleChange = (event: SelectChangeEvent<string>) => {
     const newStatus = event.target.value as TeamStatus;
     if (newStatus !== 'Disbanded') {
-      if (newStatus === 'On Scene' && !activity.teams.some((t) => t.status === 'On Scene')) {
+      if (newStatus === 'On Scene' && !(activity.teams ?? []).some((t) => t.status === 'On Scene')) {
         logStatusChange('Subject Located');
       } else {
         logStatusChange(newStatus);

--- a/src/components/dashboard/DashboardWeather.tsx
+++ b/src/components/dashboard/DashboardWeather.tsx
@@ -1,0 +1,123 @@
+import React, { useEffect, useState } from 'react';
+
+interface WeatherProps {
+  lat: string | number;
+  lon: string | number;
+  className?: string;
+}
+
+interface WeatherData {
+  temperature: number;
+  humidity: number;
+  windSpeed: number;
+  weatherCode: number;
+  unit: string;
+}
+
+// Maps Open-Meteo WMO Weather Interpretation Codes to human-readable labels & emoji
+const getWeatherCondition = (code: number): { label: string; icon: string } => {
+  if (code === 0) return { label: 'Clear Sky', icon: '☀️' };
+  if (code >= 1 && code <= 3) return { label: 'Partly Cloudy', icon: '⛅' };
+  if (code >= 45 && code <= 48) return { label: 'Foggy', icon: '🌫️' };
+  if (code >= 51 && code <= 55) return { label: 'Drizzle', icon: '🌧️' };
+  if (code >= 61 && code <= 65) return { label: 'Rain', icon: '🌧️' };
+  if (code >= 71 && code <= 77) return { label: 'Snow', icon: '❄️' };
+  if (code >= 80 && code <= 82) return { label: 'Rain Showers', icon: '🌦️' };
+  if (code >= 95) return { label: 'Thunderstorm', icon: '⛈️' };
+  return { label: 'Unknown', icon: '🌡️' };
+};
+
+export const DashboardWeather: React.FC<WeatherProps> = ({ lat, lon, className = '' }) => {
+  const [data, setData] = useState<WeatherData | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchWeather = async () => {
+      // Validate decimal coordinates
+      const latitude = parseFloat(String(lat));
+      const longitude = parseFloat(String(lon));
+
+      if (isNaN(latitude) || isNaN(longitude)) {
+        setError('Invalid coordinates provided.');
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const url = `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&current=temperature_2m,relative_humidity_2m,weather_code,wind_speed_10m&temperature_unit=fahrenheit`;
+
+        const response = await fetch(url);
+        if (!response.ok) {
+          throw new Error(`Weather service error (${response.status})`);
+        }
+
+        const json = await response.json();
+        const current = json.current;
+
+        setData({
+          temperature: Math.round(current.temperature_2m),
+          humidity: current.relative_humidity_2m,
+          windSpeed: Math.round(current.wind_speed_10m),
+          weatherCode: current.weather_code,
+          unit: json.current_units?.temperature_2m || '°F',
+        });
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load weather');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchWeather();
+  }, [lat, lon]);
+
+  if (loading) {
+    return (
+      <div className={`weather-card loading ${className}`}>
+        <span>Loading weather...</span>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className={`weather-card error ${className}`}>
+        <span>⚠️ {error || 'No weather data available'}</span>
+      </div>
+    );
+  }
+
+  const { label, icon } = getWeatherCondition(data.weatherCode);
+
+  return (
+    <div
+      className={`weather-card ${className}`}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '12px',
+        padding: '12px 16px',
+        borderRadius: '8px',
+        border: '1px solid #e2e8f0',
+        backgroundColor: '#ffffff',
+        fontFamily: 'system-ui, sans-serif',
+        boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+      }}
+    >
+      <span style={{ fontSize: '28px' }}>{icon}</span>
+      <div>
+        <div style={{ fontSize: '18px', fontWeight: 'bold' }}>
+          {data.temperature}
+          {data.unit}
+        </div>
+        <div style={{ fontSize: '12px', color: '#64748b' }}>
+          {label} • Wind: {data.windSpeed} mph • Humidity: {data.humidity}%
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/dashboard/OperationsDashboard.tsx
+++ b/src/components/dashboard/OperationsDashboard.tsx
@@ -88,7 +88,7 @@ function OperationsDashboardContent() {
             <DashboardCommsManager />
           </DashboardPanel>
           <DashboardPanel title="Operations" collapse="right" icon={<HubIcon />}>
-            <Stack direction="column" spacing={1} overflow="auto" sx={{ flex: 1, minHeight: 0 }}>
+            <Stack direction="column" spacing={1} overflow="auto" sx={{ flex: 1, minHeight: 0, p: 0.5 }}>
               <DashboardRoleTile title="Rescue Group" id={activity.staff?.['Rescue Group']} />
               <DashboardRoleTile title="Medical Group" id={activity.staff?.['Medical Group']} />
               <DashboardRoleTile title="Rigging Group" id={activity.staff?.['Rigging Group']} />

--- a/src/components/dashboard/OperationsDashboard.tsx
+++ b/src/components/dashboard/OperationsDashboard.tsx
@@ -70,13 +70,13 @@ function OperationsDashboardContent() {
         <Box sx={{ display: 'flex', flex: 1, gap: 2, minHeight: 0 }} ref={centerRef}>
           {/* Left Side Panels */}
           <Box sx={{ display: 'flex', gap: 2, minHeight: 0, mr: 'auto' }}>
-            <DashboardPanel title="Responders" collapse="left" icon={<PeopleAltIcon />}>
+            <DashboardPanel title="Responders" collapse="left" icon={<PeopleAltIcon />} sx={{ width: 400 }}>
               <DashboardAvailableParticipants />
             </DashboardPanel>
             <DashboardPanel title="Equipment" collapse="left" icon={<Inventory2Icon />}>
               <DashboardEquipmentManager />
             </DashboardPanel>
-            <DashboardPanel title="Places" collapse="left" icon={<MapIcon />}>
+            <DashboardPanel title="Places" collapse="left" icon={<MapIcon />} sx={{ width: 400 }}>
               <DashboardPlaceManager />
             </DashboardPanel>
           </Box>

--- a/src/components/dashboard/OperationsDashboard.tsx
+++ b/src/components/dashboard/OperationsDashboard.tsx
@@ -13,13 +13,13 @@ import { useActivityContext } from '../activities/ActivityProvider';
 import { DnDProvider } from '../DragAndDrop/DnDProvider';
 import { ToolbarPage } from '../ToolbarPage';
 
-import { DashboardAvailableParticipants } from './DashboardAvailableParticipants';
 import { DashboardCommsManager } from './DashboardCommsManager';
 import { DashboardEquipmentManager } from './DashboardEquipmentManager';
 import { DashboardEquipmentSummary } from './DashboardEquipmentSummary';
 import { DashboardHeader } from './DashboardHeader';
 import { DashboardPanel } from './DashboardPanel';
 import { DashboardPlaceManager } from './DashboardPlaceManager';
+import { DashboardResponderManager } from './DashboardResponderManager';
 import { DashboardResponderSummary } from './DashboardResponderSummary';
 import { DashboardRoleTile } from './DashboardRoleTile';
 import { DashboardTeamManager } from './DashboardTeamManager';
@@ -71,7 +71,7 @@ function OperationsDashboardContent() {
           {/* Left Side Panels */}
           <Box sx={{ display: 'flex', gap: 2, minHeight: 0, mr: 'auto' }}>
             <DashboardPanel title="Responders" collapse="left" icon={<PeopleAltIcon />}>
-              <DashboardAvailableParticipants />
+              <DashboardResponderManager />
             </DashboardPanel>
             <DashboardPanel title="Equipment" collapse="left" icon={<Inventory2Icon />}>
               <DashboardEquipmentManager />

--- a/src/components/dashboard/OperationsDashboard.tsx
+++ b/src/components/dashboard/OperationsDashboard.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
+import GroupsIcon from '@mui/icons-material/Groups';
+import HubIcon from '@mui/icons-material/Hub';
+import Inventory2Icon from '@mui/icons-material/Inventory2';
+import PeopleAltIcon from '@mui/icons-material/PeopleAlt';
+import { Box, Stack } from '@mui/material';
+import { useEffect, useRef, useState } from 'react';
+
+import { useActivityContext } from '../activities/ActivityProvider';
+import { DnDProvider } from '../DragAndDrop/DnDProvider';
+import { ToolbarPage } from '../ToolbarPage';
+
+import { DashboardAvailableParticipants } from './DashboardAvailableParticipants';
+import { DashboardCommsManager } from './DashboardCommsManager';
+import { DashboardEquipmentManager } from './DashboardEquipmentManager';
+import { DashboardEquipmentSummary } from './DashboardEquipmentSummary';
+import { DashboardHeader } from './DashboardHeader';
+import { DashboardPanel } from './DashboardPanel';
+import { DashboardResponderSummary } from './DashboardResponderSummary';
+import { DashboardRoleTile } from './DashboardRoleTile';
+import { DashboardTeamManager } from './DashboardTeamManager';
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+function OperationsDashboardContent() {
+  const activity = useActivityContext();
+
+  const [isResizing, setIsResizing] = useState(false);
+  const centerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!isResizing) return;
+
+    const handlePointerMove = (event: MouseEvent) => {
+      const rect = centerRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const nextRatio = clamp((event.clientY - rect.top) / rect.height, 0.3, 0.75);
+      void nextRatio;
+    };
+
+    const stopResizing = () => {
+      setIsResizing(false);
+    };
+
+    window.addEventListener('mousemove', handlePointerMove);
+    window.addEventListener('mouseup', stopResizing);
+
+    return () => {
+      window.removeEventListener('mousemove', handlePointerMove);
+      window.removeEventListener('mouseup', stopResizing);
+    };
+  }, [isResizing]);
+
+  if (!activity) {
+    return (
+      <ToolbarPage maxWidth={false}>
+        <Box sx={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: 0 }}>Loading activity…</Box>
+      </ToolbarPage>
+    );
+  }
+
+  return (
+    <ToolbarPage maxWidth={false}>
+      <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 2, minHeight: 0 }}>
+        <DashboardHeader />
+        <Box sx={{ display: 'flex', flex: 1, gap: 2, minHeight: 0 }} ref={centerRef}>
+          {/* Left Side Panels */}
+          <Box sx={{ display: 'flex', gap: 2, minHeight: 0, mr: 'auto' }}>
+            <DashboardPanel title="Responders" collapse="left" icon={<PeopleAltIcon />}>
+              <DashboardAvailableParticipants />
+            </DashboardPanel>
+            <DashboardPanel title="Equipment" collapse="left" icon={<Inventory2Icon />}>
+              <DashboardEquipmentManager />
+            </DashboardPanel>
+          </Box>
+          {/* Right Side Panels */}
+          <DashboardPanel title="Team Manager" collapse="right" icon={<GroupsIcon />} grow>
+            <DashboardTeamManager />
+          </DashboardPanel>
+          <DashboardPanel title="Communcations Log" collapse="right" icon={<ChatBubbleOutlineIcon />} grow>
+            <DashboardCommsManager />
+          </DashboardPanel>
+          <DashboardPanel title="Operations" collapse="right" icon={<HubIcon />}>
+            <Stack direction="column" spacing={1}>
+              <DashboardRoleTile title="Rescue Group" id={activity.staff?.['Rescue Group']} />
+              <DashboardRoleTile title="Medical Group" id={activity.staff?.['Medical Group']} />
+              <DashboardRoleTile title="Rigging Group" id={activity.staff?.['Rigging Group']} />
+              <DashboardResponderSummary />
+              <DashboardEquipmentSummary />
+            </Stack>
+          </DashboardPanel>
+        </Box>
+      </Box>
+    </ToolbarPage>
+  );
+}
+
+export function OperationsDashboard() {
+  return (
+    <DnDProvider>
+      <OperationsDashboardContent />
+    </DnDProvider>
+  );
+}

--- a/src/components/dashboard/OperationsDashboard.tsx
+++ b/src/components/dashboard/OperationsDashboard.tsx
@@ -4,6 +4,7 @@ import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import GroupsIcon from '@mui/icons-material/Groups';
 import HubIcon from '@mui/icons-material/Hub';
 import Inventory2Icon from '@mui/icons-material/Inventory2';
+import MapIcon from '@mui/icons-material/Map';
 import PeopleAltIcon from '@mui/icons-material/PeopleAlt';
 import { Box, Stack } from '@mui/material';
 import { useEffect, useRef, useState } from 'react';
@@ -18,6 +19,7 @@ import { DashboardEquipmentManager } from './DashboardEquipmentManager';
 import { DashboardEquipmentSummary } from './DashboardEquipmentSummary';
 import { DashboardHeader } from './DashboardHeader';
 import { DashboardPanel } from './DashboardPanel';
+import { DashboardPlaceManager } from './DashboardPlaceManager';
 import { DashboardResponderSummary } from './DashboardResponderSummary';
 import { DashboardRoleTile } from './DashboardRoleTile';
 import { DashboardTeamManager } from './DashboardTeamManager';
@@ -73,6 +75,9 @@ function OperationsDashboardContent() {
             </DashboardPanel>
             <DashboardPanel title="Equipment" collapse="left" icon={<Inventory2Icon />}>
               <DashboardEquipmentManager />
+            </DashboardPanel>
+            <DashboardPanel title="Places" collapse="left" icon={<MapIcon />}>
+              <DashboardPlaceManager />
             </DashboardPanel>
           </Box>
           {/* Right Side Panels */}

--- a/src/components/dashboard/OperationsDashboard.tsx
+++ b/src/components/dashboard/OperationsDashboard.tsx
@@ -70,13 +70,13 @@ function OperationsDashboardContent() {
         <Box sx={{ display: 'flex', flex: 1, gap: 2, minHeight: 0 }} ref={centerRef}>
           {/* Left Side Panels */}
           <Box sx={{ display: 'flex', gap: 2, minHeight: 0, mr: 'auto' }}>
-            <DashboardPanel title="Responders" collapse="left" icon={<PeopleAltIcon />} sx={{ width: 400 }}>
+            <DashboardPanel title="Responders" collapse="left" icon={<PeopleAltIcon />}>
               <DashboardAvailableParticipants />
             </DashboardPanel>
             <DashboardPanel title="Equipment" collapse="left" icon={<Inventory2Icon />}>
               <DashboardEquipmentManager />
             </DashboardPanel>
-            <DashboardPanel title="Places" collapse="left" icon={<MapIcon />} sx={{ width: 400 }}>
+            <DashboardPanel title="Places" collapse="left" icon={<MapIcon />}>
               <DashboardPlaceManager />
             </DashboardPanel>
           </Box>

--- a/src/components/dashboard/OperationsDashboard.tsx
+++ b/src/components/dashboard/OperationsDashboard.tsx
@@ -88,7 +88,7 @@ function OperationsDashboardContent() {
             <DashboardCommsManager />
           </DashboardPanel>
           <DashboardPanel title="Operations" collapse="right" icon={<HubIcon />}>
-            <Stack direction="column" spacing={1}>
+            <Stack direction="column" spacing={1} overflow="auto" sx={{ flex: 1, minHeight: 0 }}>
               <DashboardRoleTile title="Rescue Group" id={activity.staff?.['Rescue Group']} />
               <DashboardRoleTile title="Medical Group" id={activity.staff?.['Medical Group']} />
               <DashboardRoleTile title="Rigging Group" id={activity.staff?.['Rigging Group']} />

--- a/src/lib/client/store/activities.ts
+++ b/src/lib/client/store/activities.ts
@@ -41,7 +41,9 @@ const activitySliceArgs = {
       .addCase(ActivityActions.updateStaff, BasicActivityReducers[ActivityActions.updateStaff.type])
       .addCase(ActivityActions.createPlace, BasicActivityReducers[ActivityActions.createPlace.type])
       .addCase(ActivityActions.updatePlace, BasicActivityReducers[ActivityActions.updatePlace.type])
-      .addCase(ActivityActions.deletePlace, BasicActivityReducers[ActivityActions.deletePlace.type]);
+      .addCase(ActivityActions.deletePlace, BasicActivityReducers[ActivityActions.deletePlace.type])
+      .addCase(ActivityActions.batchUpdatePlaces, BasicActivityReducers[ActivityActions.batchUpdatePlaces.type])
+      .addCase(ActivityActions.bulkParticipantUpdate, BasicActivityReducers[ActivityActions.bulkParticipantUpdate.type]);
   },
 };
 

--- a/src/lib/client/store/activities.ts
+++ b/src/lib/client/store/activities.ts
@@ -39,7 +39,9 @@ const activitySliceArgs = {
       .addCase(ActivityActions.addComm, BasicActivityReducers[ActivityActions.addComm.type])
       .addCase(ActivityActions.updateComm, BasicActivityReducers[ActivityActions.updateComm.type])
       .addCase(ActivityActions.updateStaff, BasicActivityReducers[ActivityActions.updateStaff.type])
-      .addCase(ActivityActions.updatePlaces, BasicActivityReducers[ActivityActions.updatePlaces.type]);
+      .addCase(ActivityActions.createPlace, BasicActivityReducers[ActivityActions.createPlace.type])
+      .addCase(ActivityActions.updatePlace, BasicActivityReducers[ActivityActions.updatePlace.type])
+      .addCase(ActivityActions.deletePlace, BasicActivityReducers[ActivityActions.deletePlace.type]);
   },
 };
 

--- a/src/lib/client/store/activities.ts
+++ b/src/lib/client/store/activities.ts
@@ -38,7 +38,8 @@ const activitySliceArgs = {
       .addCase(ActivityActions.updateTeam, BasicActivityReducers[ActivityActions.updateTeam.type])
       .addCase(ActivityActions.addComm, BasicActivityReducers[ActivityActions.addComm.type])
       .addCase(ActivityActions.updateComm, BasicActivityReducers[ActivityActions.updateComm.type])
-      .addCase(ActivityActions.updateStaff, BasicActivityReducers[ActivityActions.updateStaff.type]);
+      .addCase(ActivityActions.updateStaff, BasicActivityReducers[ActivityActions.updateStaff.type])
+      .addCase(ActivityActions.updatePlaces, BasicActivityReducers[ActivityActions.updatePlaces.type]);
   },
 };
 

--- a/src/lib/client/store/activities.ts
+++ b/src/lib/client/store/activities.ts
@@ -29,10 +29,16 @@ const activitySliceArgs = {
       .addCase(ActivityActions.complete, BasicActivityReducers[ActivityActions.complete.type])
       .addCase(ActivityActions.appendOrganizationTimeline, BasicActivityReducers[ActivityActions.appendOrganizationTimeline.type])
       .addCase(ActivityActions.participantTimelineUpdate, BasicActivityReducers[ActivityActions.participantTimelineUpdate.type])
+      .addCase(ActivityActions.participantTimelineAdd, BasicActivityReducers[ActivityActions.participantTimelineAdd.type])
       .addCase(ActivityActions.participantMilesUpdate, BasicActivityReducers[ActivityActions.participantMilesUpdate.type])
       .addCase(ActivityActions.participantEtaUpdate, BasicActivityReducers[ActivityActions.participantEtaUpdate.type])
       .addCase(ActivityActions.participantUpdate, BasicActivityReducers[ActivityActions.participantUpdate.type])
-      .addCase(ActivityActions.tagParticipant, BasicActivityReducers[ActivityActions.tagParticipant.type]);
+      .addCase(ActivityActions.tagParticipant, BasicActivityReducers[ActivityActions.tagParticipant.type])
+      .addCase(ActivityActions.createTeam, BasicActivityReducers[ActivityActions.createTeam.type])
+      .addCase(ActivityActions.updateTeam, BasicActivityReducers[ActivityActions.updateTeam.type])
+      .addCase(ActivityActions.addComm, BasicActivityReducers[ActivityActions.addComm.type])
+      .addCase(ActivityActions.updateComm, BasicActivityReducers[ActivityActions.updateComm.type])
+      .addCase(ActivityActions.updateStaff, BasicActivityReducers[ActivityActions.updateStaff.type]);
   },
 };
 

--- a/src/lib/state/__tests__/activityReducerTests.ts
+++ b/src/lib/state/__tests__/activityReducerTests.ts
@@ -1,6 +1,7 @@
 import produce from 'immer';
 
 import { defaultEarlySigninWindow } from '@respond/lib/client/store/activities';
+import { Activity, createNewActivity } from '@respond/types/activity';
 import { createNewLocation } from '@respond/types/location';
 
 import { ActivityState } from '..';
@@ -12,34 +13,33 @@ describe('Activity Reducers', () => {
     const activityId = '369a6656-19e5-4828-8b40-db325d78ca0a';
     const participantId = '12345';
 
+    const activity: Activity = createNewActivity();
+    activity.id = activityId;
+    activity.forceStandbyOnly = false;
+    activity.idNumber = '';
+    activity.title = 'sample event';
+    activity.description = '';
+    activity.location = createNewLocation();
+    activity.mapId = '';
+    activity.startTime = 1699765740000;
+    activity.earlySignInWindow = defaultEarlySigninWindow;
+    activity.isMission = false;
+    activity.asMission = false;
+    activity.ownerOrgId = '1';
+    activity.participants = {
+      [participantId]: {
+        id: participantId,
+        firstname: 'Matt',
+        lastname: 'Cosand',
+        organizationId: '1',
+        miles: 0,
+        timeline: [{ time: 1699766001841, status: 3, organizationId: '1' }],
+      },
+    };
+    activity.organizations = { '1': { timeline: [{ status: 4, time: 1699765795339 }], id: '1', title: 'King County Explorer Search and Rescue', rosterName: 'ESAR' } };
+
     const startState: ActivityState = {
-      list: [
-        {
-          id: activityId,
-          forceStandbyOnly: false,
-          idNumber: '',
-          title: 'sample event',
-          description: '',
-          location: createNewLocation(),
-          mapId: '',
-          startTime: 1699765740000,
-          earlySignInWindow: defaultEarlySigninWindow,
-          isMission: false,
-          asMission: false,
-          ownerOrgId: '1',
-          participants: {
-            [participantId]: {
-              id: participantId,
-              firstname: 'Matt',
-              lastname: 'Cosand',
-              organizationId: '1',
-              miles: 0,
-              timeline: [{ time: 1699766001841, status: 3, organizationId: '1' }],
-            },
-          },
-          organizations: { '1': { timeline: [{ status: 4, time: 1699765795339 }], id: '1', title: 'King County Explorer Search and Rescue', rosterName: 'ESAR' } },
-        },
-      ],
+      list: [activity],
     };
 
     const tags = ['Snow', 'OL', 'Rigger', 'RigLead'];
@@ -51,25 +51,24 @@ describe('Activity Reducers', () => {
 
   it('supports updating activity type via ActivityActions.update', () => {
     const activityId = 'd5ce23b0-4a91-4f2d-ad34-b39166a1d5f4';
+    const activity: Activity = createNewActivity();
+    activity.id = activityId;
+    activity.forceStandbyOnly = false;
+    activity.idNumber = '';
+    activity.title = 'sample event';
+    activity.description = '';
+    activity.location = createNewLocation();
+    activity.mapId = '';
+    activity.startTime = 1699765740000;
+    activity.earlySignInWindow = defaultEarlySigninWindow;
+    activity.isMission = false;
+    activity.asMission = false;
+    activity.ownerOrgId = '1';
+    activity.participants = {};
+    activity.organizations = {};
+
     const startState: ActivityState = {
-      list: [
-        {
-          id: activityId,
-          forceStandbyOnly: false,
-          idNumber: '',
-          title: 'sample event',
-          description: '',
-          location: createNewLocation(),
-          mapId: '',
-          startTime: 1699765740000,
-          earlySignInWindow: defaultEarlySigninWindow,
-          isMission: false,
-          asMission: false,
-          ownerOrgId: '1',
-          participants: {},
-          organizations: {},
-        },
-      ],
+      list: [activity],
     };
 
     const updatedActivity = {

--- a/src/lib/state/activityActions.ts
+++ b/src/lib/state/activityActions.ts
@@ -1,7 +1,7 @@
 import { createAction } from '@reduxjs/toolkit';
 
 import { Activity, OrganizationStatus, ParticipantStatus, ParticipantUpdate, pickActivityProperties } from '@respond/types/activity';
-import { CommunicationsLogEntry, Place, pickTeamProperties, Team } from '@respond/types/operations';
+import { CommunicationsLogEntry, pickTeamProperties, Place, Team } from '@respond/types/operations';
 
 import { ActivityState } from '.';
 
@@ -15,8 +15,18 @@ const update = createAction('activity/update', (updates: Partial<Activity> & { i
   meta: { sync: true },
 }));
 
-const updatePlaces = createAction('activity/placesUpdate', (activityId: string, places: Place[]) => ({
-  payload: { activityId, places },
+const createPlace = createAction('place/create', (activityId: string, place: Place) => ({
+  payload: { activityId, place },
+  meta: { sync: true },
+}));
+
+const updatePlace = createAction('place/update', (activityId: string, place: Place) => ({
+  payload: { activityId, place },
+  meta: { sync: true },
+}));
+
+const deletePlace = createAction('place/delete', (activityId: string, placeId: string) => ({
+  payload: { activityId, placeId },
   meta: { sync: true },
 }));
 
@@ -149,7 +159,9 @@ const updateTeam = createAction('team/update', (activityId: string, updates: Par
 export const ActivityActions = {
   reload,
   update,
-  updatePlaces,
+  createPlace,
+  updatePlace,
+  deletePlace,
   remove,
   reactivate,
   complete,

--- a/src/lib/state/activityActions.ts
+++ b/src/lib/state/activityActions.ts
@@ -143,7 +143,7 @@ const updateComm = createAction('activity/commsUpdate', (activityId: string, com
   meta: { sync: true },
 }));
 
-const updateStaff = createAction('activity/staffUpdate', (activityId: string, staff: Record<string, string>) => ({
+const updateStaff = createAction('activity/updateStaff', (activityId: string, staff: Record<string, string>) => ({
   payload: {
     activityId,
     staff,

--- a/src/lib/state/activityActions.ts
+++ b/src/lib/state/activityActions.ts
@@ -1,7 +1,7 @@
 import { createAction } from '@reduxjs/toolkit';
 
 import { Activity, OrganizationStatus, ParticipantStatus, ParticipantUpdate, pickActivityProperties } from '@respond/types/activity';
-import { CommunicationsLogEntry, pickTeamProperties, Team } from '@respond/types/operations';
+import { CommunicationsLogEntry, Place, pickTeamProperties, Team } from '@respond/types/operations';
 
 import { ActivityState } from '.';
 
@@ -12,6 +12,11 @@ const reload = createAction('activities/load', (state: ActivityState) => ({
 
 const update = createAction('activity/update', (updates: Partial<Activity> & { id: string }) => ({
   payload: pickActivityProperties(updates),
+  meta: { sync: true },
+}));
+
+const updatePlaces = createAction('activity/placesUpdate', (activityId: string, places: Place[]) => ({
+  payload: { activityId, places },
   meta: { sync: true },
 }));
 
@@ -144,6 +149,7 @@ const updateTeam = createAction('team/update', (activityId: string, updates: Par
 export const ActivityActions = {
   reload,
   update,
+  updatePlaces,
   remove,
   reactivate,
   complete,

--- a/src/lib/state/activityActions.ts
+++ b/src/lib/state/activityActions.ts
@@ -30,6 +30,12 @@ const deletePlace = createAction('place/delete', (activityId: string, placeId: s
   meta: { sync: true },
 }));
 
+// upsert = create-or-update; delete by id
+const batchUpdatePlaces = createAction('place/batchUpdate', (activityId: string, upserts: Place[], deleteIds: string[]) => ({
+  payload: { activityId, upserts, deleteIds },
+  meta: { sync: true },
+}));
+
 const remove = createAction('activity/remove', (activityId: string) => ({
   payload: { id: activityId },
   meta: { sync: true },
@@ -66,6 +72,11 @@ const participantUpdate = createAction('participant/update', (activityId: string
       status,
     },
   },
+  meta: { sync: true },
+}));
+
+const bulkParticipantUpdate = createAction('participant/bulkUpdate', (activityId: string, updates: Array<{ participantId: string; update: ParticipantUpdate }>) => ({
+  payload: { activityId, updates },
   meta: { sync: true },
 }));
 
@@ -162,11 +173,13 @@ export const ActivityActions = {
   createPlace,
   updatePlace,
   deletePlace,
+  batchUpdatePlaces,
   remove,
   reactivate,
   complete,
   appendOrganizationTimeline,
   participantUpdate,
+  bulkParticipantUpdate,
   participantTimelineUpdate,
   participantTimelineAdd,
   participantMilesUpdate,

--- a/src/lib/state/activityActions.ts
+++ b/src/lib/state/activityActions.ts
@@ -1,6 +1,7 @@
 import { createAction } from '@reduxjs/toolkit';
 
-import { Activity, OrganizationStatus, ParticipantStatus, ParticipantUpdate, pickActivityProperties } from '@respond/types/activity';
+import { Activity, CommunicationsLogEntry, OrganizationStatus, ParticipantStatus, ParticipantUpdate, pickActivityProperties } from '@respond/types/activity';
+import { pickTeamProperties, Team } from '@respond/types/team';
 
 import { ActivityState } from '.';
 
@@ -63,6 +64,15 @@ const participantTimelineUpdate = createAction('participant/timeline', (activity
   meta: { sync: true },
 }));
 
+const participantTimelineAdd = createAction('participant/timelineAdd', (activityId: string, participantId: string, update: ParticipantUpdate) => ({
+  payload: {
+    activityId,
+    participantId,
+    update,
+  },
+  meta: { sync: true },
+}));
+
 const participantMilesUpdate = createAction('participant/milesUpdate', (activityId: string, participantId: string, miles: number) => ({
   payload: {
     activityId,
@@ -90,6 +100,47 @@ const tagParticipant = createAction('participant/tag', (activityId: string, part
   meta: { sync: false },
 }));
 
+const addComm = createAction('activity/commsAdd', (activityId: string, comm: CommunicationsLogEntry) => ({
+  payload: {
+    activityId,
+    comm,
+  },
+  meta: { sync: true },
+}));
+
+const updateComm = createAction('activity/commsUpdate', (activityId: string, commId: string, updates: Partial<CommunicationsLogEntry>) => ({
+  payload: {
+    activityId,
+    commId,
+    updates,
+  },
+  meta: { sync: true },
+}));
+
+const updateStaff = createAction('activity/staffUpdate', (activityId: string, staff: Record<string, string>) => ({
+  payload: {
+    activityId,
+    staff,
+  },
+  meta: { sync: true },
+}));
+
+const createTeam = createAction('team/create', (activityId: string, team: Team) => ({
+  payload: {
+    activityId,
+    team,
+  },
+  meta: { sync: true },
+}));
+
+const updateTeam = createAction('team/update', (activityId: string, updates: Partial<Team> & { id: string }) => ({
+  payload: {
+    activityId,
+    updates: pickTeamProperties(updates),
+  },
+  meta: { sync: true },
+}));
+
 export const ActivityActions = {
   reload,
   update,
@@ -99,9 +150,15 @@ export const ActivityActions = {
   appendOrganizationTimeline,
   participantUpdate,
   participantTimelineUpdate,
+  participantTimelineAdd,
   participantMilesUpdate,
   participantEtaUpdate,
   tagParticipant,
+  addComm,
+  updateComm,
+  updateStaff,
+  createTeam,
+  updateTeam,
 };
 
 export type ActivityActionsType = typeof ActivityActions;

--- a/src/lib/state/activityActions.ts
+++ b/src/lib/state/activityActions.ts
@@ -1,7 +1,7 @@
 import { createAction } from '@reduxjs/toolkit';
 
-import { Activity, CommunicationsLogEntry, OrganizationStatus, ParticipantStatus, ParticipantUpdate, pickActivityProperties } from '@respond/types/activity';
-import { pickTeamProperties, Team } from '@respond/types/team';
+import { Activity, OrganizationStatus, ParticipantStatus, ParticipantUpdate, pickActivityProperties } from '@respond/types/activity';
+import { CommunicationsLogEntry, pickTeamProperties, Team } from '@respond/types/operations';
 
 import { ActivityState } from '.';
 

--- a/src/lib/state/activityReducers.ts
+++ b/src/lib/state/activityReducers.ts
@@ -2,7 +2,7 @@ import { Draft } from '@reduxjs/toolkit';
 import merge from 'lodash.merge';
 
 import { createNewActivity, ParticipantStatus, pickActivityProperties } from '@respond/types/activity';
-import { pickTeamProperties } from '@respond/types/team';
+import { pickTeamProperties } from '@respond/types/operations';
 
 import { ActivityActions, ActivityActionsType } from './activityActions';
 

--- a/src/lib/state/activityReducers.ts
+++ b/src/lib/state/activityReducers.ts
@@ -67,6 +67,16 @@ export const BasicReducers: ActivityReducers = {
     activity.places = (activity.places ?? []).filter((place) => place.id !== payload.placeId);
   },
 
+  [ActivityActions.batchUpdatePlaces.type]: (state, { payload }) => {
+    const activity = state.list.find((a) => a.id === payload.activityId);
+    if (!activity) return;
+    const deleteSet = new Set(payload.deleteIds);
+    const upsertMap = new Map(payload.upserts.map((p) => [p.id, p]));
+    const kept = (activity.places ?? []).filter((p) => !deleteSet.has(p.id)).map((p) => upsertMap.get(p.id) ?? p);
+    const created = payload.upserts.filter((p) => !(activity.places ?? []).some((existing) => existing.id === p.id));
+    activity.places = [...kept, ...created];
+  },
+
   [ActivityActions.remove.type]: (state, { payload }) => {
     state.list = state.list.filter((f) => f.id !== payload.id);
   },
@@ -157,6 +167,31 @@ export const BasicReducers: ActivityReducers = {
       if (payload.update.status !== ParticipantStatus.SignedIn) {
         signOutFromOtherActivities(state, payload.activityId, payload.participant.id, payload.update.time);
       }
+    }
+  },
+
+  [ActivityActions.bulkParticipantUpdate.type]: (state, { payload }) => {
+    const activity = state.list.find((f) => f.id === payload.activityId);
+    if (!activity) return;
+
+    for (const updateRequest of payload.updates) {
+      const participant = activity.participants[updateRequest.participantId];
+      if (!participant) continue;
+
+      BasicReducers[ActivityActions.participantUpdate.type](state, {
+        payload: {
+          activityId: payload.activityId,
+          participant: {
+            id: participant.id,
+            firstname: participant.firstname,
+            lastname: participant.lastname,
+            organizationId: updateRequest.update.organizationId,
+            miles: participant.miles,
+            eta: participant.eta,
+          },
+          update: updateRequest.update,
+        },
+      });
     }
   },
 

--- a/src/lib/state/activityReducers.ts
+++ b/src/lib/state/activityReducers.ts
@@ -42,6 +42,19 @@ export const BasicReducers: ActivityReducers = {
     merge(target, trimmedToProps);
   },
 
+  [ActivityActions.updatePlaces.type]: (state, { payload }) => {
+    const activity = state.list.find((a) => a.id === payload.activityId);
+    if (activity) {
+      activity.places = payload.places;
+      return;
+    }
+
+    const newActivity = createNewActivity();
+    newActivity.id = payload.activityId;
+    newActivity.places = payload.places;
+    state.list.push(newActivity);
+  },
+
   [ActivityActions.remove.type]: (state, { payload }) => {
     state.list = state.list.filter((f) => f.id !== payload.id);
   },

--- a/src/lib/state/activityReducers.ts
+++ b/src/lib/state/activityReducers.ts
@@ -2,10 +2,26 @@ import { Draft } from '@reduxjs/toolkit';
 import merge from 'lodash.merge';
 
 import { createNewActivity, ParticipantStatus, pickActivityProperties } from '@respond/types/activity';
+import { pickTeamProperties } from '@respond/types/team';
 
 import { ActivityActions, ActivityActionsType } from './activityActions';
 
 import { ActivityState } from '.';
+
+function signOutFromOtherActivities(state: Draft<ActivityState>, activityId: string, participantId: string, time: number) {
+  state.list
+    .filter((f) => f.id !== activityId && f.participants[participantId])
+    .forEach((otherActivity) => {
+      const timeline = otherActivity.participants[participantId].timeline;
+      if (timeline[0].status === ParticipantStatus.SignedIn) {
+        timeline.unshift({
+          time,
+          status: ParticipantStatus.SignedOut,
+          organizationId: timeline[0].organizationId,
+        });
+      }
+    });
+}
 
 type ActivityReducers = {
   [K in keyof ActivityActionsType as ActivityActionsType[K]['type']]: (state: Draft<ActivityState>, action: { payload: ReturnType<ActivityActionsType[K]>['payload'] }) => void;
@@ -112,24 +128,10 @@ export const BasicReducers: ActivityReducers = {
         organizationId: payload.participant.organizationId,
       });
 
-      // If this is not a sign-in, then we are done.
-      if (payload.update.status !== ParticipantStatus.SignedIn) {
-        return;
-      }
-
       // If this is a sign-in and the user is already signed into another activity, sign them out of the other activity.
-      state.list
-        .filter((f) => f.id !== payload.activityId && f.participants[payload.participant.id])
-        .forEach((otherActivity) => {
-          const timeline = otherActivity.participants[payload.participant.id].timeline;
-          if (timeline[0].status === ParticipantStatus.SignedIn) {
-            timeline.unshift({
-              time: payload.update.time,
-              status: ParticipantStatus.SignedOut,
-              organizationId: timeline[0].organizationId,
-            });
-          }
-        });
+      if (payload.update.status !== ParticipantStatus.SignedIn) {
+        signOutFromOtherActivities(state, payload.activityId, payload.participant.id, payload.update.time);
+      }
     }
   },
 
@@ -143,6 +145,20 @@ export const BasicReducers: ActivityReducers = {
       return;
     }
     person.timeline[payload.index] = payload.update;
+  },
+
+  [ActivityActions.participantTimelineAdd.type]: (state, { payload }) => {
+    const activity = state.list.find((f) => f.id === payload.activityId);
+    if (!activity) return;
+    const person = activity.participants[payload.participantId];
+    if (!person) return;
+
+    person.timeline.unshift(payload.update);
+
+    // If this is a sign-in and the user is already signed into another activity, sign them out of the other activity.
+    if (payload.update.status === ParticipantStatus.SignedIn) {
+      signOutFromOtherActivities(state, payload.activityId, payload.participantId, payload.update.time);
+    }
   },
 
   [ActivityActions.participantMilesUpdate.type]: (state, { payload }) => {
@@ -178,5 +194,59 @@ export const BasicReducers: ActivityReducers = {
         person.tags = payload.tags;
       }
     }
+  },
+
+  [ActivityActions.createTeam.type]: (state, { payload }) => {
+    const activity = state.list.find((f) => f.id === payload.activityId);
+    if (!activity) {
+      return;
+    }
+    activity.teams = activity.teams ?? [];
+    activity.teams.push(payload.team);
+  },
+
+  [ActivityActions.addComm.type]: (state, { payload }) => {
+    const activity = state.list.find((f) => f.id === payload.activityId);
+    if (!activity) {
+      return;
+    }
+    activity.comms = activity.comms ?? [];
+    activity.comms.push(payload.comm);
+  },
+
+  [ActivityActions.updateComm.type]: (state, { payload }) => {
+    const activity = state.list.find((f) => f.id === payload.activityId);
+    if (!activity || !activity.comms) {
+      return;
+    }
+    const comm = activity.comms.find((entry) => entry.id === payload.commId);
+    if (!comm) {
+      return;
+    }
+    Object.assign(comm, payload.updates);
+  },
+
+  [ActivityActions.updateStaff.type]: (state, { payload }) => {
+    const activity = state.list.find((f) => f.id === payload.activityId);
+    if (!activity) {
+      return;
+    }
+    activity.staff = {
+      ...(activity.staff ?? {}),
+      ...payload.staff,
+    };
+  },
+
+  [ActivityActions.updateTeam.type]: (state, { payload }) => {
+    const activity = state.list.find((f) => f.id === payload.activityId);
+    if (!activity || !activity.teams) {
+      return;
+    }
+    const team = activity.teams.find((t) => t.id === payload.updates.id);
+    if (!team) {
+      return;
+    }
+    const trimmedUpdates = pickTeamProperties(payload.updates);
+    Object.assign(team, trimmedUpdates);
   },
 };

--- a/src/lib/state/activityReducers.ts
+++ b/src/lib/state/activityReducers.ts
@@ -271,6 +271,8 @@ export const BasicReducers: ActivityReducers = {
       return;
     }
     activity.comms = activity.comms ?? [];
+    // guard against sync replay applying the same entry twice
+    if (activity.comms.some((c) => c.id === payload.comm.id)) return;
     activity.comms.push(payload.comm);
   },
 

--- a/src/lib/state/activityReducers.ts
+++ b/src/lib/state/activityReducers.ts
@@ -42,17 +42,29 @@ export const BasicReducers: ActivityReducers = {
     merge(target, trimmedToProps);
   },
 
-  [ActivityActions.updatePlaces.type]: (state, { payload }) => {
+  [ActivityActions.createPlace.type]: (state, { payload }) => {
     const activity = state.list.find((a) => a.id === payload.activityId);
     if (activity) {
-      activity.places = payload.places;
+      activity.places = [...(activity.places ?? []), payload.place];
       return;
     }
 
     const newActivity = createNewActivity();
     newActivity.id = payload.activityId;
-    newActivity.places = payload.places;
+    newActivity.places = [payload.place];
     state.list.push(newActivity);
+  },
+
+  [ActivityActions.updatePlace.type]: (state, { payload }) => {
+    const activity = state.list.find((a) => a.id === payload.activityId);
+    if (!activity) return;
+    activity.places = (activity.places ?? []).map((place) => (place.id === payload.place.id ? payload.place : place));
+  },
+
+  [ActivityActions.deletePlace.type]: (state, { payload }) => {
+    const activity = state.list.find((a) => a.id === payload.activityId);
+    if (!activity) return;
+    activity.places = (activity.places ?? []).filter((place) => place.id !== payload.placeId);
   },
 
   [ActivityActions.remove.type]: (state, { payload }) => {

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -4,6 +4,7 @@ import { defaultEarlySigninWindow } from '@respond/lib/client/store/activities';
 import { pickSafely } from '@respond/lib/pickSafely';
 
 import { createNewLocation, Location } from './location';
+import { Team } from './team';
 
 export enum ParticipantStatus {
   NotResponding = 0,
@@ -117,6 +118,17 @@ export interface ParticipatingOrg {
   timeline: { time: number; status: OrganizationStatus }[];
 }
 
+export interface CommunicationsLogEntry {
+  id: string;
+  to?: string;
+  from?: string;
+  message: string;
+  timestamp: number;
+  isAutomated?: boolean;
+  isDeleted?: boolean;
+  isFavorite?: boolean;
+}
+
 export interface Activity {
   id: string;
   idNumber: string;
@@ -134,9 +146,14 @@ export interface Activity {
 
   participants: Record<string, Participant>;
   organizations: Record<string, ParticipatingOrg>;
+
+  // Operations
+  teams: Team[];
+  comms: CommunicationsLogEntry[];
+  staff: Record<string, string>;
 }
 
-export const pickActivityProperties = pickSafely<Partial<Activity>>(['id', 'idNumber', 'title', 'description', 'location', 'mapId', 'ownerOrgId', 'isMission', 'asMission', 'forceStandbyOnly', 'startTime', 'endTime', 'earlySignInWindow']);
+export const pickActivityProperties = pickSafely<Partial<Activity>>(['id', 'idNumber', 'title', 'description', 'location', 'mapId', 'ownerOrgId', 'isMission', 'asMission', 'forceStandbyOnly', 'startTime', 'endTime', 'earlySignInWindow', 'comms', 'staff']);
 
 export type ActivityType = 'missions' | 'events';
 
@@ -160,5 +177,8 @@ export function createNewActivity(): Activity {
     ownerOrgId: '',
     participants: {},
     organizations: {},
+    teams: [],
+    comms: [],
+    staff: {},
   };
 }

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -4,7 +4,7 @@ import { defaultEarlySigninWindow } from '@respond/lib/client/store/activities';
 import { pickSafely } from '@respond/lib/pickSafely';
 
 import { createNewLocation, Location } from './location';
-import { Team } from './team';
+import { CommunicationsLogEntry, Place, Team } from './operations';
 
 export enum ParticipantStatus {
   NotResponding = 0,
@@ -118,17 +118,6 @@ export interface ParticipatingOrg {
   timeline: { time: number; status: OrganizationStatus }[];
 }
 
-export interface CommunicationsLogEntry {
-  id: string;
-  to?: string;
-  from?: string;
-  message: string;
-  timestamp: number;
-  isAutomated?: boolean;
-  isDeleted?: boolean;
-  isFavorite?: boolean;
-}
-
 export interface Activity {
   id: string;
   idNumber: string;
@@ -151,9 +140,10 @@ export interface Activity {
   teams: Team[];
   comms: CommunicationsLogEntry[];
   staff: Record<string, string>;
+  places: Place[];
 }
 
-export const pickActivityProperties = pickSafely<Partial<Activity>>(['id', 'idNumber', 'title', 'description', 'location', 'mapId', 'ownerOrgId', 'isMission', 'asMission', 'forceStandbyOnly', 'startTime', 'endTime', 'earlySignInWindow', 'comms', 'staff']);
+export const pickActivityProperties = pickSafely<Partial<Activity>>(['id', 'idNumber', 'title', 'description', 'location', 'mapId', 'ownerOrgId', 'isMission', 'asMission', 'forceStandbyOnly', 'startTime', 'endTime', 'earlySignInWindow', 'comms', 'staff', 'places']);
 
 export type ActivityType = 'missions' | 'events';
 
@@ -180,5 +170,6 @@ export function createNewActivity(): Activity {
     teams: [],
     comms: [],
     staff: {},
+    places: [],
   };
 }

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -4,7 +4,7 @@ import { defaultEarlySigninWindow } from '@respond/lib/client/store/activities';
 import { pickSafely } from '@respond/lib/pickSafely';
 
 import { createNewLocation, Location } from './location';
-import { CommunicationsLogEntry, Place, Team } from './operations';
+import { CommunicationsLogEntry, getDefaultPlaces, Place, Team } from './operations';
 
 export enum ParticipantStatus {
   NotResponding = 0,
@@ -170,6 +170,6 @@ export function createNewActivity(): Activity {
     teams: [],
     comms: [],
     staff: {},
-    places: [],
+    places: getDefaultPlaces(),
   };
 }

--- a/src/types/operations.ts
+++ b/src/types/operations.ts
@@ -2,6 +2,8 @@ import { v4 as uuid } from 'uuid';
 
 import { pickSafely } from '@respond/lib/pickSafely';
 
+import { Activity } from './activity';
+
 export type TeamStatus = 'In Base' | 'In Transit' | 'On Assignment' | 'On Scene' | 'Returning To Base' | 'Disbanded';
 
 export type SarGar = 'green' | 'amber' | 'red';
@@ -38,7 +40,12 @@ export interface CommunicationsLogEntry {
 
 export interface Place {
   id: string;
+  name: string;
+  lat?: string;
+  lon?: string;
+  notes?: string;
   assignedEquipment: EquipmentItem[];
+  assignedParticipants: string[];
 }
 
 export function createNewTeam(name: string): Team {
@@ -52,5 +59,37 @@ export function createNewTeam(name: string): Team {
     teamLeaderParticipantId: null,
   };
 }
+
+export function createNewPlace(name: string): Place {
+  return {
+    id: uuid(),
+    name,
+    assignedEquipment: [],
+    assignedParticipants: [],
+  };
+}
+
+export const DEFAULT_PLACES = {
+  base: 'Command Post',
+  field: 'Field (Unassigned)',
+};
+
+export const isDefaultPlace = (place: Place) => {
+  return Object.values(DEFAULT_PLACES).includes(place.name);
+};
+
+export const getDefaultPlaces = (activity?: Activity): Place[] => {
+  return Object.values(DEFAULT_PLACES).reduce<Place[]>((places, defaultPlaceName) => {
+    const exists = activity?.places?.some((p) => p.name === defaultPlaceName);
+    if (!exists) {
+      return [...places, createNewPlace(defaultPlaceName)];
+    }
+    return places;
+  }, []);
+};
+
+export const sortEquipmentAlphabetically = (left: EquipmentItem, right: EquipmentItem) => {
+  return left.name.localeCompare(right.name);
+};
 
 export const pickTeamProperties = pickSafely<Partial<Team>>(['id', 'name', 'gar', 'status', 'assignment', 'notes', 'assignedParticipants', 'assignedEquipment', 'teamLeaderParticipantId']);

--- a/src/types/operations.ts
+++ b/src/types/operations.ts
@@ -25,6 +25,22 @@ export interface EquipmentItem {
   name: string;
 }
 
+export interface CommunicationsLogEntry {
+  id: string;
+  to?: string;
+  from?: string;
+  message: string;
+  timestamp: number;
+  isAutomated?: boolean;
+  isDeleted?: boolean;
+  isFavorite?: boolean;
+}
+
+export interface Place {
+  id: string;
+  assignedEquipment: EquipmentItem[];
+}
+
 export function createNewTeam(name: string): Team {
   return {
     id: uuid(),

--- a/src/types/operations.ts
+++ b/src/types/operations.ts
@@ -69,6 +69,20 @@ export function createNewPlace(name: string): Place {
   };
 }
 
+export function createNewCommsEntry(values: Partial<CommunicationsLogEntry>): CommunicationsLogEntry {
+  return {
+    id: uuid(),
+    from: '',
+    to: '',
+    message: '',
+    timestamp: Date.now(),
+    isAutomated: false,
+    isDeleted: false,
+    isFavorite: false,
+    ...values,
+  };
+}
+
 export const DEFAULT_PLACES = {
   base: 'Command Post',
   field: 'Field (Unassigned)',

--- a/src/types/team.ts
+++ b/src/types/team.ts
@@ -1,0 +1,39 @@
+import { v4 as uuid } from 'uuid';
+
+import { pickSafely } from '@respond/lib/pickSafely';
+
+export type TeamStatus = 'In Base' | 'In Transit' | 'On Assignment' | 'On Scene' | 'Returning To Base';
+
+export type SarGar = 'green' | 'amber' | 'red';
+
+export interface Team {
+  id: string;
+  name: string;
+  gar: SarGar;
+  status: TeamStatus;
+  assignment?: string;
+  notes?: string;
+  assignedParticipants: string[];
+  assignedEquipment: EquipmentItem[];
+  teamLeaderParticipantId: string | null;
+}
+
+export interface EquipmentItem {
+  id: string;
+  uuid?: string;
+  name: string;
+}
+
+export function createNewTeam(name: string): Team {
+  return {
+    id: uuid(),
+    name,
+    gar: 'green',
+    status: 'In Base',
+    assignedParticipants: [],
+    assignedEquipment: [],
+    teamLeaderParticipantId: null,
+  };
+}
+
+export const pickTeamProperties = pickSafely<Partial<Team>>(['id', 'name', 'gar', 'status', 'assignment', 'notes', 'assignedParticipants', 'assignedEquipment', 'teamLeaderParticipantId']);

--- a/src/types/team.ts
+++ b/src/types/team.ts
@@ -2,7 +2,7 @@ import { v4 as uuid } from 'uuid';
 
 import { pickSafely } from '@respond/lib/pickSafely';
 
-export type TeamStatus = 'In Base' | 'In Transit' | 'On Assignment' | 'On Scene' | 'Returning To Base';
+export type TeamStatus = 'In Base' | 'In Transit' | 'On Assignment' | 'On Scene' | 'Returning To Base' | 'Disbanded';
 
 export type SarGar = 'green' | 'amber' | 'red';
 

--- a/src/types/team.ts
+++ b/src/types/team.ts
@@ -20,6 +20,7 @@ export interface Team {
 
 export interface EquipmentItem {
   id: string;
+  type: string;
   uuid?: string;
   name: string;
 }


### PR DESCRIPTION
# Operations Dashboard

<img width="2554" height="1299" alt="image" src="https://github.com/user-attachments/assets/41a510e3-35db-417f-93a8-a13d6bafb8fc" />

This pull request introduces the main Operations Dashboard view with core features for resource tracking, automated communications logging, and situational awareness.

* Create Teams, assign Resources and track status, assignments and GAR.
* Track Resources assigned to key locations such as the Command Post and Staging Areas.
* Build the communications log from both automated and manual entries.
* Quicky identify how many resources are enroute, assigned, and in the field.
* Track assignment of key leadership roles.

The dashboard implements drag and drop, including touch screen support, enabling resources to be intuitively assigned by directly moving them between Teams, Places and Roles.

Other features include:
* A default list of the the most common equipment and the ability to create ad-hoc items.
* Automated logging of key events like team status changes, role assignments, and more.
* Collapsible panels, sorting and filter options enabling customization by role.