### PR TITLE
Operations Dashboard Enhancements

### DIFF
--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -5,7 +5,7 @@ import GroupsIcon from '@mui/icons-material/Groups';
 import Inventory2Icon from '@mui/icons-material/Inventory2';
 import PeopleAltIcon from '@mui/icons-material/PeopleAlt';
 import { Badge, Box, Stack, Tab, Tabs, useMediaQuery } from '@mui/material';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useActivityContext } from '../activities/ActivityProvider';
 import { DnDProvider } from '../DragAndDrop/DnDProvider';
@@ -86,6 +86,10 @@ function CombinedTeamCommsPanel() {
 function DashboardContent() {
   const activity = useActivityContext();
   const hasLocation = activity.location?.lat && activity.location?.lon;
+
+  useEffect(() => {
+    document.title = `${activity.idNumber} ${activity.title} - Dashboard`;
+  }, [activity.idNumber, activity.title]);
 
   // Mobile View: narrower than 1280px
   const isSmallScreen = useMediaQuery('(max-width:1279.95px)');

--- a/src/components/dashboard/DashboardActivityDetails.tsx
+++ b/src/components/dashboard/DashboardActivityDetails.tsx
@@ -1,4 +1,5 @@
 import { Box, Typography } from '@mui/material';
+import Link from 'next/link';
 
 import { useActivityContext } from '../activities/ActivityProvider';
 
@@ -6,7 +7,7 @@ export function DashboardActivityDetails() {
   const activity = useActivityContext();
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', minWidth: 0 }}>
-      <Typography variant="h5" sx={{ fontWeight: 700, lineHeight: 1.2 }}>
+      <Typography variant="h5" component={Link} href={`/${activity.isMission ? 'mission' : 'event'}/${activity.id}`} sx={{ fontWeight: 700, lineHeight: 1.2, color: 'inherit', textDecoration: 'none', '&:hover': { textDecoration: 'underline' } }}>
         {activity.title}
       </Typography>
       <Typography variant="subtitle1" sx={{ color: 'text.secondary', mt: 0.5 }}>

--- a/src/components/dashboard/DashboardAutoScrollContainer.tsx
+++ b/src/components/dashboard/DashboardAutoScrollContainer.tsx
@@ -1,0 +1,132 @@
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import { Box, Fab, SxProps, Theme } from '@mui/material';
+import { ReactNode, useEffect, useRef, useState } from 'react';
+
+const DEFAULT_SCROLL_BOTTOM_THRESHOLD = 16;
+const PROGRAMMATIC_SCROLL_TIMEOUT_MS = 500;
+
+type DashboardAutoScrollContainerProps<T> = {
+  items: T[];
+  getItemKey: (item: T) => string;
+  /** Suspend auto-scrolling to new items without affecting the current scroll position, e.g. while a form is open. */
+  paused?: boolean;
+  scrollBottomThreshold?: number;
+  children: ReactNode;
+  sx?: SxProps<Theme>;
+  contentSx?: SxProps<Theme>;
+};
+
+/**
+ * Scrollable container that stays pinned to the bottom as new items arrive, auto-scrolling to the
+ * bottom on mount and whenever new items are appended. Auto-scroll is disabled when the user scrolls
+ * away from the bottom, and a floating button appears to jump back down and re-enable it.
+ */
+export function DashboardAutoScrollContainer<T>({ items, getItemKey, paused = false, scrollBottomThreshold = DEFAULT_SCROLL_BOTTOM_THRESHOLD, children, sx, contentSx }: DashboardAutoScrollContainerProps<T>) {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const previousItemKeysRef = useRef<string[] | null>(null);
+  const pendingNewItemScrollRef = useRef(false);
+  const hasInitializedScrollRef = useRef(false);
+  const isProgrammaticScrollRef = useRef(false);
+  const programmaticScrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const [autoScroll, setAutoScroll] = useState(true);
+
+  function beginProgrammaticScroll() {
+    isProgrammaticScrollRef.current = true;
+    if (programmaticScrollTimeoutRef.current) {
+      clearTimeout(programmaticScrollTimeoutRef.current);
+    }
+    // Fallback in case the animation never reports a scroll event that lands exactly at the bottom.
+    programmaticScrollTimeoutRef.current = setTimeout(() => {
+      isProgrammaticScrollRef.current = false;
+    }, PROGRAMMATIC_SCROLL_TIMEOUT_MS);
+  }
+
+  useEffect(() => {
+    const currentItemKeys = items.map(getItemKey);
+    const previousItemKeys = previousItemKeysRef.current;
+    previousItemKeysRef.current = currentItemKeys;
+
+    const target = scrollContainerRef.current;
+
+    if (!hasInitializedScrollRef.current) {
+      // Wait until the list has actually laid out (non-zero height) before snapping to bottom.
+      if (target && currentItemKeys.length > 0 && target.clientHeight > 0) {
+        beginProgrammaticScroll();
+        requestAnimationFrame(() => {
+          if (target) {
+            target.scrollTop = target.scrollHeight;
+          }
+          setAutoScroll(true);
+        });
+        hasInitializedScrollRef.current = true;
+      }
+      return;
+    }
+
+    if (!previousItemKeys) {
+      return;
+    }
+
+    const hasNewItem = currentItemKeys.some((key) => previousItemKeys.indexOf(key) === -1);
+    if (hasNewItem) {
+      pendingNewItemScrollRef.current = autoScroll;
+    }
+
+    if (!autoScroll || paused || !pendingNewItemScrollRef.current) {
+      return;
+    }
+
+    if (target) {
+      beginProgrammaticScroll();
+      target.scrollTo({ top: target.scrollHeight, behavior: 'smooth' });
+      pendingNewItemScrollRef.current = false;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [items, autoScroll, paused]);
+
+  const handleScroll = () => {
+    const target = scrollContainerRef.current;
+    if (!target) {
+      return;
+    }
+    const distanceFromBottom = target.scrollHeight - target.scrollTop - target.clientHeight;
+    const atBottom = distanceFromBottom <= scrollBottomThreshold;
+
+    if (isProgrammaticScrollRef.current) {
+      // Ignore intermediate scroll events from an in-flight auto-scroll to avoid flickering the button.
+      if (atBottom) {
+        isProgrammaticScrollRef.current = false;
+        if (programmaticScrollTimeoutRef.current) {
+          clearTimeout(programmaticScrollTimeoutRef.current);
+          programmaticScrollTimeoutRef.current = null;
+        }
+      }
+      return;
+    }
+
+    setAutoScroll(atBottom);
+  };
+
+  const scrollToBottom = () => {
+    const target = scrollContainerRef.current;
+    if (target) {
+      beginProgrammaticScroll();
+      target.scrollTo({ top: target.scrollHeight, behavior: 'smooth' });
+    }
+    setAutoScroll(true);
+  };
+
+  return (
+    <Box sx={{ position: 'relative', flex: 1, minHeight: 0, width: '100%', ...sx }}>
+      <Box ref={scrollContainerRef} onScroll={handleScroll} sx={{ height: '100%', overflow: 'auto', width: '100%', ...contentSx }}>
+        {children}
+      </Box>
+      {!autoScroll && (
+        <Fab size="small" color="primary" onClick={scrollToBottom} aria-label="scroll to newest" sx={{ position: 'absolute', bottom: 8, right: 8 }}>
+          <KeyboardArrowDownIcon />
+        </Fab>
+      )}
+    </Box>
+  );
+}

--- a/src/components/dashboard/DashboardCommsComposer.tsx
+++ b/src/components/dashboard/DashboardCommsComposer.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, FormControlLabel, Stack, Switch, TextField } from '@mui/material';
+import { Box, Button, Stack, TextField } from '@mui/material';
 import { DateTimePicker } from '@mui/x-date-pickers';
 import { useEffect, useRef } from 'react';
 import { Controller, SubmitHandler, useForm } from 'react-hook-form';
@@ -20,11 +20,9 @@ type DashboardCommsComposerProps = {
   entry?: CommunicationsLogEntry | null;
   onSave?: () => void;
   onCancel?: () => void;
-  autoScroll?: boolean;
-  onAutoScrollChange?: (enabled: boolean) => void;
 };
 
-export function DashboardCommsComposer({ entry, onSave, onCancel, autoScroll, onAutoScrollChange }: DashboardCommsComposerProps) {
+export function DashboardCommsComposer({ entry, onSave, onCancel }: DashboardCommsComposerProps) {
   const dispatch = useAppDispatch();
   const activity = useActivityContext();
   const fromRef = useRef<HTMLInputElement | null>(null);
@@ -114,9 +112,8 @@ export function DashboardCommsComposer({ entry, onSave, onCancel, autoScroll, on
               }
             }}
           />
-          <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between">
-            {!entry && onAutoScrollChange && <FormControlLabel control={<Switch size="small" checked={autoScroll ?? true} onChange={(event) => onAutoScrollChange(event.target.checked)} sx={{ ml: 0.5 }} />} label="Auto-scroll" />}
-            <Stack direction="row" spacing={1} alignItems="center" sx={{ ml: 'auto' }}>
+          <Stack direction="row" spacing={1} alignItems="center" justifyContent="flex-end">
+            <Stack direction="row" spacing={1} alignItems="center">
               {entry && (
                 <Button
                   onClick={() => {

--- a/src/components/dashboard/DashboardCommsComposer.tsx
+++ b/src/components/dashboard/DashboardCommsComposer.tsx
@@ -1,6 +1,6 @@
-import { Box, Button, Stack, TextField } from '@mui/material';
+import { Autocomplete, Box, Button, Stack, TextField } from '@mui/material';
 import { DateTimePicker } from '@mui/x-date-pickers';
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { Controller, SubmitHandler, useForm } from 'react-hook-form';
 
 import { useAppDispatch } from '@respond/lib/client/store';
@@ -8,6 +8,8 @@ import { ActivityActions } from '@respond/lib/state';
 import { CommunicationsLogEntry, createNewCommsEntry } from '@respond/types/operations';
 
 import { useActivityContext } from '../activities/ActivityProvider';
+
+const PREDEFINED_COMMS_CONTACTS = ['All Teams', 'Incident Commander'];
 
 type FormValues = {
   from: string;
@@ -26,6 +28,24 @@ export function DashboardCommsComposer({ entry, onSave, onCancel }: DashboardCom
   const dispatch = useAppDispatch();
   const activity = useActivityContext();
   const fromRef = useRef<HTMLInputElement | null>(null);
+
+  // Split by source so adding a comms entry only re-scans comms, not teams/staff/places.
+  const teamContacts = useMemo(() => (activity.teams ?? []).filter((team) => team.status !== 'Disbanded').map((team) => team.name), [activity.teams]);
+  const staffContacts = useMemo(() => Object.keys(activity.staff ?? {}), [activity.staff]);
+  const placeContacts = useMemo(() => (activity.places ?? []).map((place) => place.name), [activity.places]);
+  const commsContacts = useMemo(() => {
+    const seen = new Set<string>();
+    (activity.comms ?? []).forEach((comm) => {
+      if (comm.from) seen.add(comm.from);
+      if (comm.to) seen.add(comm.to);
+    });
+    return Array.from(seen);
+  }, [activity.comms]);
+
+  const contactOptions = useMemo(() => {
+    const options = new Set<string>([...PREDEFINED_COMMS_CONTACTS, ...teamContacts, ...staffContacts, ...placeContacts, ...commsContacts]);
+    return Array.from(options).sort((left, right) => left.localeCompare(right));
+  }, [teamContacts, staffContacts, placeContacts, commsContacts]);
 
   const { register, handleSubmit, reset, formState, control } = useForm<FormValues>({
     defaultValues: {
@@ -75,8 +95,8 @@ export function DashboardCommsComposer({ entry, onSave, onCancel }: DashboardCom
       <form onSubmit={handleSubmit(submit)}>
         <Stack spacing={1}>
           <Stack direction={{ xl: 'row' }} alignItems={{ xs: 'stretch', xl: 'center' }} gap={2}>
-            <TextField label="From" size="small" inputRef={fromRef} {...register('from')} />
-            <TextField label="To" size="small" {...register('to')} />
+            <Controller name="from" control={control} render={({ field }) => <Autocomplete freeSolo fullWidth options={contactOptions} inputValue={field.value} onInputChange={(_, newInputValue) => field.onChange(newInputValue)} renderInput={(params) => <TextField {...params} label="From" size="small" inputRef={fromRef} />} />} />
+            <Controller name="to" control={control} render={({ field }) => <Autocomplete freeSolo fullWidth options={contactOptions} inputValue={field.value} onInputChange={(_, newInputValue) => field.onChange(newInputValue)} renderInput={(params) => <TextField {...params} label="To" size="small" />} />} />
             {entry && (
               <Controller
                 name="timestamp"

--- a/src/components/dashboard/DashboardCommsManager.tsx
+++ b/src/components/dashboard/DashboardCommsManager.tsx
@@ -4,7 +4,7 @@ import StarIcon from '@mui/icons-material/Star';
 import StarBorderIcon from '@mui/icons-material/StarBorder';
 import { Box, IconButton, Paper, Typography } from '@mui/material';
 import { alpha } from '@mui/material/styles';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { useAppDispatch } from '@respond/lib/client/store';
 import { ActivityActions } from '@respond/lib/state';
@@ -14,6 +14,7 @@ import { useActivityContext } from '../activities/ActivityProvider';
 import ConfirmDialog from '../ConfirmDialog';
 import { Stack } from '../Material';
 
+import { DashboardAutoScrollContainer } from './DashboardAutoScrollContainer';
 import { CommsAutomatedToggleButton } from './DashboardCommsAutomatedToggleButton';
 import { DashboardCommsComposer } from './DashboardCommsComposer';
 import { CommsFavoriteToggleButton } from './DashboardCommsFavoriteToggleButton';
@@ -45,13 +46,9 @@ const parseValues = (value: string): string[] => {
 export function DashboardCommsManager() {
   const dispatch = useAppDispatch();
   const activity = useActivityContext();
-  const commsListRef = useRef<HTMLDivElement>(null);
-  const previousCommunicationIdsRef = useRef<string[] | null>(null);
-  const pendingNewEntryScrollRef = useRef(false);
 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [entryPendingDelete, setEntryPendingDelete] = useState<CommunicationsLogEntry | null>(null);
-  const [autoScroll, setAutoScroll] = useState(true);
 
   const [searchQuery, setSearchQuery] = useState('');
   const [showFavorites, setShowFavorites] = useState(false);
@@ -106,31 +103,6 @@ export function DashboardCommsManager() {
     dispatch(ActivityActions.updateComm(activity.id, id, updates));
   };
 
-  useEffect(() => {
-    const currentCommunicationIds = (activity.comms ?? []).map((entry) => entry.id);
-    const previousCommunicationIds = previousCommunicationIdsRef.current;
-    previousCommunicationIdsRef.current = currentCommunicationIds;
-
-    if (!previousCommunicationIds) {
-      return;
-    }
-
-    const hasNewEntry = currentCommunicationIds.some((id) => previousCommunicationIds.indexOf(id) === -1);
-    if (hasNewEntry) {
-      pendingNewEntryScrollRef.current = autoScroll;
-    }
-
-    if (!autoScroll || editingId || !pendingNewEntryScrollRef.current) {
-      return;
-    }
-
-    const target = commsListRef.current;
-    if (target) {
-      target.scrollTo({ top: target.scrollHeight, behavior: 'smooth' });
-      pendingNewEntryScrollRef.current = false;
-    }
-  }, [activity.comms, autoScroll, editingId]);
-
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, width: '100%' }}>
       <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
@@ -139,7 +111,7 @@ export function DashboardCommsManager() {
         <CommsFavoriteToggleButton onChange={(isSelected) => setShowFavorites(isSelected)} />
         <DashboardCommsPrintButton activity={activity} communications={filteredCommunications} />
       </Stack>
-      <Box ref={commsListRef} sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2, p: 0.5, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 1, minHeight: 0, width: '100%' }}>
+      <DashboardAutoScrollContainer items={filteredCommunications} getItemKey={(entry) => entry.id} paused={Boolean(editingId)} contentSx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2, p: 0.5, display: 'flex', flexDirection: 'column', gap: 1 }}>
         {filteredCommunications.length === 0 ? (
           <Box sx={{ flex: 1, minHeight: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <Typography variant="body2" color="text.secondary" textAlign="center">
@@ -153,8 +125,8 @@ export function DashboardCommsManager() {
             </DashboardCommsItemWrapper>
           ))
         )}
-      </Box>
-      <DashboardCommsComposer autoScroll={autoScroll} onAutoScrollChange={setAutoScroll} />
+      </DashboardAutoScrollContainer>
+      <DashboardCommsComposer />
       <ConfirmDialog open={Boolean(entryPendingDelete)} prompt={entryPendingDelete ? `Delete communication from ${entryPendingDelete.from} to ${entryPendingDelete.to} at ${format24HourTime(entryPendingDelete.timestamp)}?` : 'Delete this communication?'} destructive={true} label="Delete" onConfirm={confirmDeleteEntry} onClose={() => setEntryPendingDelete(null)} />
     </Box>
   );

--- a/src/components/dashboard/DashboardPlaceManager.tsx
+++ b/src/components/dashboard/DashboardPlaceManager.tsx
@@ -31,7 +31,7 @@ export function DashboardAddPlaceButton() {
 
   const addPlace = (placeToCreate: Place) => {
     dispatch(ActivityActions.createPlace(activity.id, placeToCreate));
-    const parts = [placeToCreate.name, 'established: '];
+    const parts = [placeToCreate.name, 'established '];
     if (placeToCreate.lat?.trim() && placeToCreate.lon?.trim()) parts.push(`${placeToCreate.lat.trim()}, ${placeToCreate.lon.trim()}`);
     if (placeToCreate.notes?.trim()) parts.push(placeToCreate.notes.trim());
     const comm: CommunicationsLogEntry = createNewCommsEntry({
@@ -114,14 +114,8 @@ function PlaceTile({ place }: { place: Place }) {
     dispatch(ActivityActions.updatePlace(activity.id, placeToUpsert));
   };
 
-  const deletePlace = (id: string) => {
-    const hasResources = place.assignedParticipants.length > 0 || place.assignedEquipment.length > 0;
-    if (hasResources) {
-      setConfirmDeleteOpen(true);
-      return;
-    }
-    dispatch(ActivityActions.deletePlace(activity.id, id));
-    logDeleteComm();
+  const deletePlace = () => {
+    setConfirmDeleteOpen(true);
   };
 
   const logDeleteComm = () => {
@@ -144,6 +138,17 @@ function PlaceTile({ place }: { place: Place }) {
     logDeleteComm();
   };
 
+  const confirmDelete = () => {
+    const hasResources = place.assignedParticipants.length > 0 || place.assignedEquipment.length > 0;
+    if (hasResources) {
+      deleteAndReassign();
+    } else {
+      dispatch(ActivityActions.deletePlace(activity.id, place.id));
+      logDeleteComm();
+    }
+    setConfirmDeleteOpen(false);
+  };
+
   const editAction = {
     id: 'edit',
     icon: <EditIcon sx={{ fontSize: 16 }} />,
@@ -153,7 +158,7 @@ function PlaceTile({ place }: { place: Place }) {
   const deleteAction = {
     id: 'delete',
     icon: <DeleteOutlineIcon sx={{ fontSize: 16, color: 'darkred' }} />,
-    onClick: () => deletePlace(place.id),
+    onClick: () => deletePlace(),
   };
 
   const actions = isDefaultPlace(place) ? [editAction] : [editAction, deleteAction];
@@ -269,15 +274,7 @@ function PlaceTile({ place }: { place: Place }) {
         }}
         onClose={() => setEditingPlace(null)}
       />
-      <ConfirmDialog
-        open={confirmDeleteOpen}
-        prompt={`"${place.name}" still has assigned members or equipment. They will be moved to ${DEFAULT_PLACES.field}. Delete anyway?`}
-        onConfirm={() => {
-          deleteAndReassign();
-          setConfirmDeleteOpen(false);
-        }}
-        onClose={() => setConfirmDeleteOpen(false)}
-      />
+      <ConfirmDialog open={confirmDeleteOpen} prompt={place.assignedParticipants.length > 0 || place.assignedEquipment.length > 0 ? `"${place.name}" still has assigned members or equipment. They will be moved to ${DEFAULT_PLACES.field}. Delete anyway?` : `Delete "${place.name}"?`} destructive={true} label="Delete" onConfirm={confirmDelete} onClose={() => setConfirmDeleteOpen(false)} />
     </Droppable>
   );
 }

--- a/src/components/dashboard/DashboardRoleTile.tsx
+++ b/src/components/dashboard/DashboardRoleTile.tsx
@@ -1,5 +1,6 @@
 import ClearIcon from '@mui/icons-material/Clear';
 import { Box, IconButton, Paper, Stack, Typography } from '@mui/material';
+import { useState } from 'react';
 
 import { useAppDispatch } from '@respond/lib/client/store';
 import { ActivityActions } from '@respond/lib/state';
@@ -7,11 +8,13 @@ import { Participant } from '@respond/types/activity';
 import { CommunicationsLogEntry, createNewCommsEntry } from '@respond/types/operations';
 
 import { useActivityContext } from '../activities/ActivityProvider';
+import ConfirmDialog from '../ConfirmDialog';
 import { Droppable } from '../DragAndDrop/DnDComponents';
 
 export function DashboardRoleTile({ title, id }: { title: string; id?: string }) {
   const dispatch = useAppDispatch();
   const activity = useActivityContext();
+  const [confirmClearOpen, setConfirmClearOpen] = useState(false);
 
   const selectedId = activity.staff?.[title] ?? id;
   const participant = selectedId ? activity.participants[selectedId] : undefined;
@@ -26,6 +29,10 @@ export function DashboardRoleTile({ title, id }: { title: string; id?: string })
   };
 
   const handleDelete = (): void => {
+    setConfirmClearOpen(true);
+  };
+
+  const confirmDelete = (): void => {
     if (activity && activity.id) {
       dispatch(ActivityActions.updateStaff(activity.id, { [title]: '' }));
       autoLog(`${title} unassigned`);
@@ -42,22 +49,25 @@ export function DashboardRoleTile({ title, id }: { title: string; id?: string })
   };
 
   return (
-    <Droppable accepts="participant" onDrop={handleDrop}>
-      <Paper variant="outlined" sx={{ p: 1, borderRadius: 2 }}>
-        <Box sx={{ '&:hover .action': { opacity: 1, visibility: 'visible' } }}>
-          <Typography component="div" variant="subtitle1" sx={{ fontWeight: 700 }}>
-            {title}
-          </Typography>
-          <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={1}>
-            <Typography component="div" sx={{ color: 'text.secondary' }}>
-              {name}
+    <>
+      <Droppable accepts="participant" onDrop={handleDrop}>
+        <Paper variant="outlined" sx={{ p: 1, borderRadius: 2 }}>
+          <Box sx={{ '&:hover .action': { opacity: 1, visibility: 'visible' } }}>
+            <Typography component="div" variant="subtitle1" sx={{ fontWeight: 700 }}>
+              {title}
             </Typography>
-            <IconButton className="action" onClick={handleDelete} size="small" aria-label="delete communication" sx={{ opacity: 0, visibility: 'hidden', transition: 'opacity 180ms ease' }}>
-              <ClearIcon sx={{ fontSize: 16, color: 'darkred' }} />
-            </IconButton>
-          </Stack>
-        </Box>
-      </Paper>
-    </Droppable>
+            <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={1}>
+              <Typography component="div" sx={{ color: 'text.secondary' }}>
+                {name}
+              </Typography>
+              <IconButton className="action" onClick={handleDelete} size="small" aria-label="delete communication" sx={{ opacity: 0, visibility: 'hidden', transition: 'opacity 180ms ease' }}>
+                <ClearIcon sx={{ fontSize: 16, color: 'darkred' }} />
+              </IconButton>
+            </Stack>
+          </Box>
+        </Paper>
+      </Droppable>
+      <ConfirmDialog open={confirmClearOpen} prompt={`Unassign ${name} from ${title}?`} destructive={true} label="Unassign" onConfirm={confirmDelete} onClose={() => setConfirmClearOpen(false)} />
+    </>
   );
 }

--- a/src/components/dashboard/DashboardTeamCard.tsx
+++ b/src/components/dashboard/DashboardTeamCard.tsx
@@ -26,20 +26,26 @@ const sortEquipmentAlphabetically = (left: EquipmentItem, right: EquipmentItem) 
   return left.name.localeCompare(right.name);
 };
 
-export default function DashboardTeamCard({ team, defaultExpanded }: { team: Team; defaultExpanded?: boolean }) {
+export default function DashboardTeamCard({ team, expandCommand, onExpandedChange }: { team: Team; expandCommand?: { expanded: boolean; nonce: number }; onExpandedChange?: (expanded: boolean) => void }) {
   const dispatch = useAppDispatch();
 
   const activity = useActivityContext();
 
   const [openTeamEditor, setOpenTeamEditor] = useState<Team | null>(null);
-  const [localExpanded, setLocalExpanded] = useState<boolean>(defaultExpanded ?? false);
+  const [localExpanded, setLocalExpanded] = useState<boolean>(false);
   const isExpanded = localExpanded;
 
   useEffect(() => {
-    if (defaultExpanded !== undefined) {
-      setLocalExpanded(defaultExpanded);
+    if (expandCommand !== undefined) {
+      setLocalExpanded(expandCommand.expanded);
     }
-  }, [defaultExpanded]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expandCommand]);
+
+  useEffect(() => {
+    onExpandedChange?.(isExpanded);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isExpanded]);
 
   const teamParticipants: Participant[] = Object.values(activity.participants).filter((participant) => team.assignedParticipants.includes(participant.id));
   const teamLeader: Participant | undefined = teamParticipants.find((participant) => participant.id === team.teamLeaderParticipantId);

--- a/src/components/dashboard/DashboardTeamCard.tsx
+++ b/src/components/dashboard/DashboardTeamCard.tsx
@@ -33,7 +33,9 @@ export default function DashboardTeamCard({ team, expandCommand, onExpandedChang
 
   const [openTeamEditor, setOpenTeamEditor] = useState<Team | null>(null);
   const [localExpanded, setLocalExpanded] = useState<boolean>(false);
-  const isExpanded = localExpanded;
+  const isDisbanded = team.status === 'Disbanded';
+  // Disbanded teams are read-only: never expandable, regardless of local state or expand-all commands.
+  const isExpanded = !isDisbanded && localExpanded;
 
   useEffect(() => {
     if (expandCommand !== undefined) {
@@ -131,6 +133,7 @@ export default function DashboardTeamCard({ team, expandCommand, onExpandedChang
 
   const handleExpandClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
+    if (isDisbanded) return;
     setLocalExpanded((current) => !current);
   };
 
@@ -142,16 +145,16 @@ export default function DashboardTeamCard({ team, expandCommand, onExpandedChang
 
   return (
     <>
-      <Droppable accepts={['participant', 'equipment']} onDrop={handleDrop}>
+      <Droppable accepts={isDisbanded ? [] : ['participant', 'equipment']} onDrop={handleDrop}>
         <StatusContainer color={team.status === 'Disbanded' ? 'grey' : statusColor} sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2 }}>
           <Box sx={{ display: 'flex', flexDirection: 'column', borderRadius: 2, p: 1, pl: 0.5, bgcolor: 'background.paper', height: '100%' }}>
             <Stack direction="row" alignItems="center" justifyContent="space-between">
               <Stack direction="row" alignItems="center">
-                <IconButton onClick={handleExpandClick} size="small" sx={{ width: 32, height: 32 }}>
+                <IconButton onClick={handleExpandClick} disabled={isDisbanded} size="small" sx={{ width: 32, height: 32 }}>
                   {isExpanded ? <ExpandMoreIcon /> : <ChevronRightIcon />}
                 </IconButton>
                 <Stack direction="row" spacing={2} alignItems="center">
-                  <Typography variant="subtitle1" sx={{ fontWeight: 700, cursor: 'pointer' }} onClick={() => setOpenTeamEditor(team)}>
+                  <Typography variant="subtitle1" sx={{ fontWeight: 700, cursor: 'pointer', color: isDisbanded ? 'text.disabled' : undefined }} onClick={() => setOpenTeamEditor(team)}>
                     {team.name}
                   </Typography>
                   <DashboardErrorIndicator message={hasTeamMemberError ? 'One or more team members are not assigned to the activity.' : undefined} size={16} />

--- a/src/components/dashboard/DashboardTeamEditDialog.tsx
+++ b/src/components/dashboard/DashboardTeamEditDialog.tsx
@@ -1,8 +1,13 @@
 import { Button, DialogActions, DialogContent, DialogTitle, MenuItem, TextField } from '@mui/material';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
-import { SarGar, Team } from '../../types/operations';
+import { useAppDispatch } from '@respond/lib/client/store';
+import { ActivityActions } from '@respond/lib/state';
+
+import { createNewPlace, DEFAULT_PLACES, SarGar, Team } from '../../types/operations';
+import { useActivityContext } from '../activities/ActivityProvider';
+import ConfirmDialog from '../ConfirmDialog';
 import DialogWithHistory from '../DialogWithHistory';
 import { Stack } from '../Material';
 
@@ -37,6 +42,10 @@ export function validateTeamName(teams: Team[], currentTeamId: string, name: str
 }
 
 export function DashboardTeamEditDialog({ team, teams, onSave, onClose }: DashboardTeamEditDialogProps) {
+  const dispatch = useAppDispatch();
+  const activity = useActivityContext();
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+
   const {
     register,
     control,
@@ -89,38 +98,74 @@ export function DashboardTeamEditDialog({ team, teams, onSave, onClose }: Dashbo
   // Prevent rendering dialog contents if team is null/undefined
   if (!team) return null;
 
+  const hasAssignedResources = team.assignedParticipants.length > 0 || team.assignedEquipment.length > 0;
+
+  const deleteTeam = () => {
+    dispatch(ActivityActions.deleteTeam(activity.id, team.id));
+    onClose();
+  };
+
+  const deleteTeamWithReassign = () => {
+    const fieldPlace = activity.places?.find((place) => place.name === DEFAULT_PLACES.field);
+    const mergedParticipants = Array.from(new Set([...(fieldPlace?.assignedParticipants ?? []), ...team.assignedParticipants]));
+    const existingEquipmentIds = new Set((fieldPlace?.assignedEquipment ?? []).map((item) => item.uuid));
+    const mergedEquipment = [...(fieldPlace?.assignedEquipment ?? []), ...team.assignedEquipment.filter((item) => !existingEquipmentIds.has(item.uuid))];
+
+    const updatedFieldPlace = fieldPlace ? { ...fieldPlace, assignedParticipants: mergedParticipants, assignedEquipment: mergedEquipment } : { ...createNewPlace(DEFAULT_PLACES.field), assignedParticipants: mergedParticipants, assignedEquipment: mergedEquipment };
+
+    if (fieldPlace) {
+      dispatch(ActivityActions.updatePlace(activity.id, updatedFieldPlace));
+    } else {
+      dispatch(ActivityActions.createPlace(activity.id, updatedFieldPlace));
+    }
+
+    deleteTeam();
+  };
+
+  const handleDeleteClick = () => {
+    setConfirmDeleteOpen(true);
+  };
+
   return (
-    <DialogWithHistory fullWidth={true} open={Boolean(team)} onClose={onClose}>
-      <DialogTitle>Edit Team</DialogTitle>
+    <>
+      <DialogWithHistory fullWidth={true} open={Boolean(team)} onClose={onClose}>
+        <DialogTitle>Edit Team</DialogTitle>
 
-      <form onSubmit={handleSubmit(handleSave)}>
-        <DialogContent>
-          <Stack spacing={2} sx={{ pt: 1 }}>
-            <TextField autoFocus label="Team name" fullWidth {...register('name')} error={Boolean(errors.name)} helperText={errors.name?.message ?? 'Choose a unique name for this team.'} />
-            <Controller
-              name="gar"
-              control={control}
-              defaultValue={team?.gar ?? 'green'}
-              render={({ field }) => (
-                <TextField label="GAR" select fullWidth {...field}>
-                  <MenuItem value="green">Green</MenuItem>
-                  <MenuItem value="amber">Amber</MenuItem>
-                  <MenuItem value="red">Red</MenuItem>
-                </TextField>
-              )}
-            />
-            <TextField label="Assignment" fullWidth {...register('assignment')} />
-            <TextField label="Notes" fullWidth multiline minRows={3} {...register('notes')} />
-          </Stack>
-        </DialogContent>
+        <form onSubmit={handleSubmit(handleSave)}>
+          <DialogContent>
+            <Stack spacing={2} sx={{ pt: 1 }}>
+              <TextField autoFocus label="Team name" fullWidth {...register('name')} error={Boolean(errors.name)} helperText={errors.name?.message ?? 'Choose a unique name for this team.'} />
+              <Controller
+                name="gar"
+                control={control}
+                defaultValue={team?.gar ?? 'green'}
+                render={({ field }) => (
+                  <TextField label="GAR" select fullWidth {...field}>
+                    <MenuItem value="green">Green</MenuItem>
+                    <MenuItem value="amber">Amber</MenuItem>
+                    <MenuItem value="red">Red</MenuItem>
+                  </TextField>
+                )}
+              />
+              <TextField label="Assignment" fullWidth {...register('assignment')} />
+              <TextField label="Notes" fullWidth multiline minRows={3} {...register('notes')} />
+            </Stack>
+          </DialogContent>
 
-        <DialogActions>
-          <Button onClick={onClose}>Cancel</Button>
-          <Button type="submit" variant="contained">
-            Save
-          </Button>
-        </DialogActions>
-      </form>
-    </DialogWithHistory>
+          <DialogActions sx={{ justifyContent: 'space-between' }}>
+            <Button color="error" onClick={handleDeleteClick}>
+              Delete
+            </Button>
+            <Stack direction="row" spacing={1}>
+              <Button onClick={onClose}>Cancel</Button>
+              <Button type="submit" variant="contained">
+                Save
+              </Button>
+            </Stack>
+          </DialogActions>
+        </form>
+      </DialogWithHistory>
+      <ConfirmDialog open={confirmDeleteOpen} prompt={hasAssignedResources ? `Deleting ${team.name} will move remaining members and equipment to ${DEFAULT_PLACES.field}. Continue?` : `Delete ${team.name}?`} destructive={true} label="Delete" onConfirm={hasAssignedResources ? deleteTeamWithReassign : deleteTeam} onClose={() => setConfirmDeleteOpen(false)} />
+    </>
   );
 }

--- a/src/components/dashboard/DashboardTeamManager.tsx
+++ b/src/components/dashboard/DashboardTeamManager.tsx
@@ -102,23 +102,31 @@ export function DashboardTeamManager() {
   const dispatch = useAppDispatch();
 
   const activity = useActivityContext();
-  const [expandedAll, setExpandedAll] = useState(false);
+  const [expandCommand, setExpandCommand] = useState<{ expanded: boolean; nonce: number } | undefined>(undefined);
+  const [expandedTeamIds, setExpandedTeamIds] = useState<Record<string, boolean>>({});
   const teams = activity.teams ?? [];
+  const anyExpanded = teams.some((team) => expandedTeamIds[team.id]);
 
   const addTeam = () => {
     const nextTeamNumber = getNextTeamNumber(teams);
     dispatch(ActivityActions.createTeam(activity.id, createNewTeam(`Team ${nextTeamNumber}`)));
   };
 
+  // nonce forces each card's effect to rerun even if `expanded` repeats (e.g. a card was manually
+  // re-collapsed after "Expand all", so the next "Expand all" click must still re-sync it).
   const toggleAll = () => {
-    setExpandedAll((current) => !current);
+    setExpandCommand({ expanded: !anyExpanded, nonce: Date.now() });
+  };
+
+  const handleTeamExpandedChange = (teamId: string, expanded: boolean) => {
+    setExpandedTeamIds((current) => (current[teamId] === expanded ? current : { ...current, [teamId]: expanded }));
   };
 
   return (
     <>
       <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={1} sx={{ mb: 2 }}>
         <Button size="small" variant="outlined" onClick={toggleAll}>
-          {expandedAll ? 'Collapse all' : 'Expand all'}
+          {anyExpanded ? 'Collapse all' : 'Expand all'}
         </Button>
         <Button size="small" variant="contained" startIcon={<AddIcon />} onClick={addTeam}>
           Add
@@ -128,7 +136,7 @@ export function DashboardTeamManager() {
         <Stack direction="column" spacing={1} sx={{ minHeight: 0, flex: 1 }}>
           {teams.length ? (
             [...teams].sort(sortTeams).map((team) => {
-              return <DashboardTeamCard key={team.id} team={team} defaultExpanded={expandedAll} />;
+              return <DashboardTeamCard key={team.id} team={team} expandCommand={expandCommand} onExpandedChange={(expanded) => handleTeamExpandedChange(team.id, expanded)} />;
             })
           ) : (
             <Box sx={{ flex: 1, minHeight: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>

--- a/src/lib/client/store/activities.ts
+++ b/src/lib/client/store/activities.ts
@@ -36,6 +36,7 @@ const activitySliceArgs = {
       .addCase(ActivityActions.tagParticipant, BasicActivityReducers[ActivityActions.tagParticipant.type])
       .addCase(ActivityActions.createTeam, BasicActivityReducers[ActivityActions.createTeam.type])
       .addCase(ActivityActions.updateTeam, BasicActivityReducers[ActivityActions.updateTeam.type])
+      .addCase(ActivityActions.deleteTeam, BasicActivityReducers[ActivityActions.deleteTeam.type])
       .addCase(ActivityActions.addComm, BasicActivityReducers[ActivityActions.addComm.type])
       .addCase(ActivityActions.updateComm, BasicActivityReducers[ActivityActions.updateComm.type])
       .addCase(ActivityActions.updateStaff, BasicActivityReducers[ActivityActions.updateStaff.type])

--- a/src/lib/state/activityActions.ts
+++ b/src/lib/state/activityActions.ts
@@ -167,6 +167,14 @@ const updateTeam = createAction('team/update', (activityId: string, updates: Par
   meta: { sync: true },
 }));
 
+const deleteTeam = createAction('team/delete', (activityId: string, teamId: string) => ({
+  payload: {
+    activityId,
+    teamId,
+  },
+  meta: { sync: true },
+}));
+
 export const ActivityActions = {
   reload,
   update,
@@ -190,6 +198,7 @@ export const ActivityActions = {
   updateStaff,
   createTeam,
   updateTeam,
+  deleteTeam,
 };
 
 export type ActivityActionsType = typeof ActivityActions;

--- a/src/lib/state/activityReducers.ts
+++ b/src/lib/state/activityReducers.ts
@@ -311,4 +311,12 @@ export const BasicReducers: ActivityReducers = {
     const trimmedUpdates = pickTeamProperties(payload.updates);
     Object.assign(team, trimmedUpdates);
   },
+
+  [ActivityActions.deleteTeam.type]: (state, { payload }) => {
+    const activity = state.list.find((f) => f.id === payload.activityId);
+    if (!activity || !activity.teams) {
+      return;
+    }
+    activity.teams = activity.teams.filter((t) => t.id !== payload.teamId);
+  },
 };


### PR DESCRIPTION
ADD: Activity Name on Dashboard links back to the activity page.
ADD: Teams can be deleted.
ADD: Confirm when deleting places.
ADD: Confirm when clearing role assignments.
ADD: Comms Composer TO/FROM implement autocomplete; any value can be entered; existing team, place, or role names, previously used values, and certain pre-defined values will autocomplete.
CHANGE: Auto Scroll is automatically enabled/disabled based on scroll position; removed the manual toggle.
CHANGE: Expand/Collapse All on Team Manager will always be collapse if there is at least 1 team expanded.
CHANGE: Disbanded teams are disabled; not droppable, not expandable, visually greyed out.
FIX: Document title missing on dashboard view; updated to "<activity-name> - Dashboard"