### PR TITLE
Operations Dashboard Enhancements

### DIFF
--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -56,7 +56,10 @@ function CombinedResourcesPanel() {
         </Tabs>
       </Box>
 
-      {tab === 'responders' && <DashboardResponderManager availableCallback={setAvailable} />}
+      {/* Kept mounted (instead of conditionally rendered) so the available-count badge keeps updating while this tab isn't visible. */}
+      <Box sx={{ display: tab === 'responders' ? 'flex' : 'none', flex: 1, minHeight: 0, flexDirection: 'column' }}>
+        <DashboardResponderManager availableCallback={setAvailable} />
+      </Box>
       {tab === 'equipment' && <DashboardEquipmentManager />}
     </DashboardPanel>
   );

--- a/src/components/dashboard/DashboardCommsComposer.tsx
+++ b/src/components/dashboard/DashboardCommsComposer.tsx
@@ -24,6 +24,16 @@ type DashboardCommsComposerProps = {
   onCancel?: () => void;
 };
 
+// MUI's default renderOption spreads a "key" prop into <li>; pull it out and pass it directly to silence React's key-spread warning.
+function renderContactOption(props: React.HTMLAttributes<HTMLLIElement> & { key?: React.Key }, option: string) {
+  const { key, ...optionProps } = props;
+  return (
+    <li key={key} {...optionProps}>
+      {option}
+    </li>
+  );
+}
+
 export function DashboardCommsComposer({ entry, onSave, onCancel }: DashboardCommsComposerProps) {
   const dispatch = useAppDispatch();
   const activity = useActivityContext();
@@ -95,8 +105,8 @@ export function DashboardCommsComposer({ entry, onSave, onCancel }: DashboardCom
       <form onSubmit={handleSubmit(submit)}>
         <Stack spacing={1}>
           <Stack direction={{ xl: 'row' }} alignItems={{ xs: 'stretch', xl: 'center' }} gap={2}>
-            <Controller name="from" control={control} render={({ field }) => <Autocomplete freeSolo fullWidth options={contactOptions} inputValue={field.value} onInputChange={(_, newInputValue) => field.onChange(newInputValue)} renderInput={(params) => <TextField {...params} label="From" size="small" inputRef={fromRef} />} sx={{ flex: entry ? 1 : undefined, minWidth: 0 }} />} />
-            <Controller name="to" control={control} render={({ field }) => <Autocomplete freeSolo fullWidth options={contactOptions} inputValue={field.value} onInputChange={(_, newInputValue) => field.onChange(newInputValue)} renderInput={(params) => <TextField {...params} label="To" size="small" />} sx={{ flex: entry ? 1 : undefined, minWidth: 0 }} />} />
+            <Controller name="from" control={control} render={({ field }) => <Autocomplete freeSolo fullWidth options={contactOptions} inputValue={field.value} onInputChange={(_, newInputValue) => field.onChange(newInputValue)} renderOption={renderContactOption} renderInput={(params) => <TextField {...params} label="From" size="small" inputRef={fromRef} />} sx={{ flex: entry ? 1 : undefined, minWidth: 0 }} />} />
+            <Controller name="to" control={control} render={({ field }) => <Autocomplete freeSolo fullWidth options={contactOptions} inputValue={field.value} onInputChange={(_, newInputValue) => field.onChange(newInputValue)} renderOption={renderContactOption} renderInput={(params) => <TextField {...params} label="To" size="small" />} sx={{ flex: entry ? 1 : undefined, minWidth: 0 }} />} />
             {entry && (
               <Controller
                 name="timestamp"

--- a/src/components/dashboard/DashboardPlaceManager.tsx
+++ b/src/components/dashboard/DashboardPlaceManager.tsx
@@ -36,7 +36,7 @@ export function DashboardAddPlaceButton() {
     if (placeToCreate.notes?.trim()) parts.push(placeToCreate.notes.trim());
     const comm: CommunicationsLogEntry = createNewCommsEntry({
       from: placeToCreate.name,
-      to: 'CP',
+      to: DEFAULT_PLACES.base,
       message: parts.join(' '),
       isAutomated: true,
     });
@@ -121,7 +121,7 @@ function PlaceTile({ place }: { place: Place }) {
   const logDeleteComm = () => {
     const comm: CommunicationsLogEntry = createNewCommsEntry({
       from: place.name,
-      to: 'CP',
+      to: DEFAULT_PLACES.base,
       message: `${place.name} location terminated`,
       isAutomated: true,
     });

--- a/src/components/dashboard/DashboardRoleTile.tsx
+++ b/src/components/dashboard/DashboardRoleTile.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { useAppDispatch } from '@respond/lib/client/store';
 import { ActivityActions } from '@respond/lib/state';
 import { Participant } from '@respond/types/activity';
-import { CommunicationsLogEntry, createNewCommsEntry } from '@respond/types/operations';
+import { CommunicationsLogEntry, createNewCommsEntry, DEFAULT_PLACES } from '@respond/types/operations';
 
 import { useActivityContext } from '../activities/ActivityProvider';
 import ConfirmDialog from '../ConfirmDialog';
@@ -41,7 +41,7 @@ export function DashboardRoleTile({ title, id }: { title: string; id?: string })
 
   const autoLog = (message: string) => {
     const comm: CommunicationsLogEntry = createNewCommsEntry({
-      from: 'CP',
+      from: DEFAULT_PLACES.base,
       message: message,
       isAutomated: true,
     });

--- a/src/components/dashboard/DashboardRoleTile.tsx
+++ b/src/components/dashboard/DashboardRoleTile.tsx
@@ -1,4 +1,5 @@
 import ClearIcon from '@mui/icons-material/Clear';
+import GroupsIcon from '@mui/icons-material/Groups';
 import { Box, IconButton, Paper, Stack, Typography } from '@mui/material';
 import { useState } from 'react';
 
@@ -53,9 +54,12 @@ export function DashboardRoleTile({ title, id }: { title: string; id?: string })
       <Droppable accepts="participant" onDrop={handleDrop}>
         <Paper variant="outlined" sx={{ p: 1, borderRadius: 2 }}>
           <Box sx={{ '&:hover .action': { opacity: 1, visibility: 'visible' } }}>
-            <Typography component="div" variant="subtitle1" sx={{ fontWeight: 700 }}>
-              {title}
-            </Typography>
+            <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+              <GroupsIcon fontSize="small" />
+              <Typography component="div" variant="subtitle1" sx={{ fontWeight: 700 }}>
+                {title}
+              </Typography>
+            </Stack>
             <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={1}>
               <Typography component="div" sx={{ color: 'text.secondary' }}>
                 {name}

--- a/src/components/dashboard/DashboardTeamCard.tsx
+++ b/src/components/dashboard/DashboardTeamCard.tsx
@@ -32,14 +32,12 @@ export default function DashboardTeamCard({ team, expandCommand, onExpandedChang
   const activity = useActivityContext();
 
   const [openTeamEditor, setOpenTeamEditor] = useState<Team | null>(null);
-  const [localExpanded, setLocalExpanded] = useState<boolean>(false);
+  const [isExpanded, setIsExpanded] = useState<boolean>(false);
   const isDisbanded = team.status === 'Disbanded';
-  // Disbanded teams are read-only: never expandable, regardless of local state or expand-all commands.
-  const isExpanded = !isDisbanded && localExpanded;
 
   useEffect(() => {
     if (expandCommand !== undefined) {
-      setLocalExpanded(expandCommand.expanded);
+      setIsExpanded(expandCommand.expanded);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [expandCommand]);
@@ -133,8 +131,7 @@ export default function DashboardTeamCard({ team, expandCommand, onExpandedChang
 
   const handleExpandClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
-    if (isDisbanded) return;
-    setLocalExpanded((current) => !current);
+    setIsExpanded((current) => !current);
   };
 
   const statusColor = {
@@ -150,7 +147,7 @@ export default function DashboardTeamCard({ team, expandCommand, onExpandedChang
           <Box sx={{ display: 'flex', flexDirection: 'column', borderRadius: 2, p: 1, pl: 0.5, bgcolor: 'background.paper', height: '100%' }}>
             <Stack direction="row" alignItems="center" justifyContent="space-between">
               <Stack direction="row" alignItems="center">
-                <IconButton onClick={handleExpandClick} disabled={isDisbanded} size="small" sx={{ width: 32, height: 32 }}>
+                <IconButton onClick={handleExpandClick} size="small" sx={{ width: 32, height: 32 }}>
                   {isExpanded ? <ExpandMoreIcon /> : <ChevronRightIcon />}
                 </IconButton>
                 <Stack direction="row" spacing={2} alignItems="center">

--- a/src/components/dashboard/DashboardTeamCard.tsx
+++ b/src/components/dashboard/DashboardTeamCard.tsx
@@ -7,7 +7,7 @@ import { useAppDispatch } from '@respond/lib/client/store';
 import { ActivityActions } from '@respond/lib/state';
 import { Participant, ParticipantStatus } from '@respond/types/activity';
 
-import { CommunicationsLogEntry, createNewCommsEntry, EquipmentItem, Team } from '../../types/operations';
+import { CommunicationsLogEntry, createNewCommsEntry, DEFAULT_PLACES, EquipmentItem, Team } from '../../types/operations';
 import { useActivityContext } from '../activities/ActivityProvider';
 import { Draggable, Droppable } from '../DragAndDrop/DnDComponents';
 import { StatusContainer } from '../StatusContainer';
@@ -123,7 +123,7 @@ export default function DashboardTeamCard({ team, expandCommand, onExpandedChang
   const autoLog = (message: string, isFavorite = false) => {
     const comm: CommunicationsLogEntry = createNewCommsEntry({
       from: team.name,
-      to: 'CP',
+      to: DEFAULT_PLACES.base,
       message: message,
       isAutomated: true,
       isFavorite,

--- a/src/components/dashboard/DashboardTeamStatusSelect.tsx
+++ b/src/components/dashboard/DashboardTeamStatusSelect.tsx
@@ -47,7 +47,7 @@ export const TeamStatusSelect: React.FC<TeamStatusSelectProps> = ({ team }) => {
     };
     const comm: CommunicationsLogEntry = createNewCommsEntry({
       from: team.name,
-      to: 'CP',
+      to: DEFAULT_PLACES.base,
       message: messages[status] ?? status,
       isAutomated: true,
       isFavorite: status === 'Subject Located',


### PR DESCRIPTION
ADD: Group icon added to the Role Tiles.
CHANGE: Allow disbanded teams to be expanded; they may be a need to review notes.
FIX: Available responders notification not updating unless the responders tab is active.
FIX: Automated logs should use `DEFAULT_PLACES.base` for instead of a hard-coded contact value.
FIX: Error message in console related to MUI Autocomplete options.